### PR TITLE
Dblatcher/api detail path

### DIFF
--- a/apps/newsletters-api/src/app/responses.ts
+++ b/apps/newsletters-api/src/app/responses.ts
@@ -1,0 +1,15 @@
+export const makeError = (message: string, code = 500) => ({
+	ok: false,
+	message,
+	code,
+});
+
+export function makeSuccess<T extends object>(
+	content: T,
+): T & { ok: true; code: 200 } {
+	return {
+		...content,
+		ok: true,
+		code: 200,
+	};
+}

--- a/apps/newsletters-api/src/main.ts
+++ b/apps/newsletters-api/src/main.ts
@@ -19,6 +19,26 @@ app.get('/v1/newsletters', async (req, res) => {
 	return parsedLive;
 });
 
+app.get('/v1/newsletters/detail/:id', async (req, res) => {
+	//to Check Fastify docs for how best to parse req.params
+	const params = req.params as Record<string, unknown> | undefined;
+	console.log(params);
+
+	if (
+		params &&
+		'id' in params &&
+		typeof params.id === 'string' &&
+		params.id.length > 0
+	) {
+		return {
+			test: 1234,
+			id: params.id,
+		};
+	}
+
+	return res.status(400).send({ ok: false, message: 'no id!' });
+});
+
 const start = async () => {
 	try {
 		console.log('Starting newsletters-api server on http://localhost:3000');

--- a/apps/newsletters-api/src/main.ts
+++ b/apps/newsletters-api/src/main.ts
@@ -4,6 +4,7 @@ import {
 	newslettersDataClient,
 } from '@newsletters-nx/newsletters-data-client';
 import liveNewslettersData from '../static/newsletters.live.json';
+import { makeError, makeSuccess } from './app/responses';
 
 const app = Fastify();
 
@@ -25,21 +26,19 @@ app.get<{ Params: { identityName: string } }>(
 	async (req, res) => {
 		const { identityName } = req.params;
 		if (identityName.length === 0) {
-			return res.status(400).send({ ok: false, message: 'no id!' });
+			return res.status(400).send(makeError('no identity name', 400));
 		}
 
 		const parsedLive = liveNewslettersData.filter(isNewsletter);
-		const match = parsedLive.find(
+		const newsletter = parsedLive.find(
 			(newsletter) => newsletter.identityName === identityName,
 		);
 
-		if (!match) {
-			return res
-				.status(404)
-				.send({ ok: false, message: `no match for id ${identityName}` });
+		if (!newsletter) {
+			return res.status(404).send(makeError(`no match for id ${identityName}`, 404));
 		}
 
-		return match;
+		return makeSuccess({ newsletter });
 	},
 );
 

--- a/apps/newsletters-api/src/main.ts
+++ b/apps/newsletters-api/src/main.ts
@@ -30,10 +30,15 @@ app.get('/v1/newsletters/detail/:id', async (req, res) => {
 		typeof params.id === 'string' &&
 		params.id.length > 0
 	) {
-		return {
-			test: 1234,
-			id: params.id,
-		};
+
+		const parsedLive = liveNewslettersData.filter(isNewsletter);
+		const match = parsedLive.find(newsletter => newsletter.identityName === params.id)
+
+		if (!match) {
+			return res.status(404).send({ ok: false, message: `no match for id ${params.id}` })
+		}
+
+		return match;
 	}
 
 	return res.status(400).send({ ok: false, message: 'no id!' });

--- a/apps/newsletters-api/src/main.ts
+++ b/apps/newsletters-api/src/main.ts
@@ -15,34 +15,33 @@ app.get('/health', async () => {
 });
 
 app.get('/v1/newsletters', async (req, res) => {
+	// TO DO - why is eslint not happy here?
 	const parsedLive = liveNewslettersData.filter(isNewsletter);
 	return parsedLive;
 });
 
-app.get('/v1/newsletters/detail/:id', async (req, res) => {
-	//to Check Fastify docs for how best to parse req.params
-	const params = req.params as Record<string, unknown> | undefined;
-	console.log(params);
-
-	if (
-		params &&
-		'id' in params &&
-		typeof params.id === 'string' &&
-		params.id.length > 0
-	) {
+app.get<{ Params: { identityName: string } }>(
+	'/v1/newsletters/detail/:identityName',
+	async (req, res) => {
+		const { identityName } = req.params;
+		if (identityName.length === 0) {
+			return res.status(400).send({ ok: false, message: 'no id!' });
+		}
 
 		const parsedLive = liveNewslettersData.filter(isNewsletter);
-		const match = parsedLive.find(newsletter => newsletter.identityName === params.id)
+		const match = parsedLive.find(
+			(newsletter) => newsletter.identityName === identityName,
+		);
 
 		if (!match) {
-			return res.status(404).send({ ok: false, message: `no match for id ${params.id}` })
+			return res
+				.status(404)
+				.send({ ok: false, message: `no match for id ${identityName}` });
 		}
 
 		return match;
-	}
-
-	return res.status(400).send({ ok: false, message: 'no id!' });
-});
+	},
+);
 
 const start = async () => {
 	try {

--- a/apps/newsletters-api/src/main.ts
+++ b/apps/newsletters-api/src/main.ts
@@ -15,10 +15,17 @@ app.get('/health', async () => {
 	});
 });
 
+// not using the makeSuccess function on this route as
+// we are emulating the response of the legacy API
 app.get('/v1/newsletters', async (req, res) => {
 	// TO DO - why is eslint not happy here?
-	const parsedLive = liveNewslettersData.filter(isNewsletter);
-	return parsedLive;
+	const newsletters = liveNewslettersData.filter(isNewsletter);
+	return newsletters;
+});
+
+app.get('/v1/newsletters/all', async (req, res) => {
+	const newsletters = liveNewslettersData.filter(isNewsletter);
+	return makeSuccess({ newsletters });
 });
 
 app.get<{ Params: { identityName: string } }>(
@@ -35,7 +42,9 @@ app.get<{ Params: { identityName: string } }>(
 		);
 
 		if (!newsletter) {
-			return res.status(404).send(makeError(`no match for id ${identityName}`, 404));
+			return res
+				.status(404)
+				.send(makeError(`no match for id ${identityName}`, 404));
 		}
 
 		return makeSuccess({ newsletter });


### PR DESCRIPTION
## What does this change?

 - adds the `v1/newsletters/detail/:identityName` route to the api
 - defines `makeSuccess` and `makeError` helper functions for building the response body
 - adds the `v1/newsletters/all` route to the api (same as existing `v1/newsletters` except it wraps the `newsletters` in with the `makeSuccess` function

https://trello.com/c/cRJ7gOXg/233-serve-get-newsletters-newsletterid-endpoint

The idea of the makeSuccess` and `makeError` helper functions is to define a general shape/pattern for response from the API - IE every response will have an "ok" boolean and http status code in the body, making it easier for client-side consumers to parse. **Aware this is opinionated approach, so welcome comments on it - not assuming this is the right pattern**


## How to test

run the API:
 - http://localhost:3000/v1/newsletters/all : list of newsletters
 - http://localhost:3000/v1/newsletters/detail/not-a-real-identity-name : 404 error
 - http://localhost:3000/v1/newsletters/detail/ : 400 error ("no identity name")
 -  http://localhost:3000/v1/newsletters/detail/tech-scape : data for "Techscape"

## How can we measure success?

Clients can fetch data for one newsletter and use the JSON body to easily distinguish success / error responses.

## Have we considered potential risks?

We should defer merging this PR until  this after https://github.com/guardian/newsletters-nx/pull/7 is merged and this PR has updated the spec with the new routes
