### PR TITLE
Display View Current Newsletters data in react-table

### DIFF
--- a/apps/newsletters-ui/src/app/components/Cell.tsx
+++ b/apps/newsletters-ui/src/app/components/Cell.tsx
@@ -1,0 +1,5 @@
+export type Cell<T> = { cell: { value: T } };
+
+export const formatCellBoolean = ({ cell: { value } }: Cell<boolean>) => (
+	<span>{value ? '✅ Yes' : '❌ No'}</span>
+);

--- a/apps/newsletters-ui/src/app/components/NewslettersListView.tsx
+++ b/apps/newsletters-ui/src/app/components/NewslettersListView.tsx
@@ -23,6 +23,5 @@ export const NewsletterListView = () => {
 	// 		</ul>
 	// 	</nav>
 	// );
-	// return <NewslettersTable newsletters={newsLetters} />
-	return <NewslettersTable />
+	return <NewslettersTable newsletters={newsLetters} />
 };

--- a/apps/newsletters-ui/src/app/components/NewslettersListView.tsx
+++ b/apps/newsletters-ui/src/app/components/NewslettersListView.tsx
@@ -1,4 +1,4 @@
-import { Link, useLoaderData } from 'react-router-dom';
+import { useLoaderData } from 'react-router-dom';
 import type { Newsletter } from '@newsletters-nx/newsletters-data-client';
 import { NewslettersTable } from './NewslettersTable';
 
@@ -9,19 +9,5 @@ export const NewsletterListView = () => {
 	}
 
 	const newsLetters = list as Newsletter[];
-
-	// return (
-	// 	<nav>
-	// 		<ul>
-	// 			{newsLetters.map((newsletter, index) => (
-	// 				<li key={index}>
-	// 					<Link to={`/newsletters/${newsletter.identityName}`}>
-	// 						{newsletter.name}
-	// 					</Link>
-	// 				</li>
-	// 			))}
-	// 		</ul>
-	// 	</nav>
-	// );
 	return <NewslettersTable newsletters={newsLetters} />
 };

--- a/apps/newsletters-ui/src/app/components/NewslettersListView.tsx
+++ b/apps/newsletters-ui/src/app/components/NewslettersListView.tsx
@@ -9,5 +9,5 @@ export const NewsletterListView = () => {
 	}
 
 	const newsLetters = list as Newsletter[];
-	return <NewslettersTable newsletters={newsLetters} />
+	return <NewslettersTable newsletters={newsLetters} />;
 };

--- a/apps/newsletters-ui/src/app/components/NewslettersListView.tsx
+++ b/apps/newsletters-ui/src/app/components/NewslettersListView.tsx
@@ -1,5 +1,6 @@
 import { Link, useLoaderData } from 'react-router-dom';
 import type { Newsletter } from '@newsletters-nx/newsletters-data-client';
+import { NewslettersTable } from './NewslettersTable';
 
 export const NewsletterListView = () => {
 	const list = useLoaderData();
@@ -9,17 +10,19 @@ export const NewsletterListView = () => {
 
 	const newsLetters = list as Newsletter[];
 
-	return (
-		<nav>
-			<ul>
-				{newsLetters.map((newsletter, index) => (
-					<li key={index}>
-						<Link to={`/newsletters/${newsletter.identityName}`}>
-							{newsletter.name}
-						</Link>
-					</li>
-				))}
-			</ul>
-		</nav>
-	);
+	// return (
+	// 	<nav>
+	// 		<ul>
+	// 			{newsLetters.map((newsletter, index) => (
+	// 				<li key={index}>
+	// 					<Link to={`/newsletters/${newsletter.identityName}`}>
+	// 						{newsletter.name}
+	// 					</Link>
+	// 				</li>
+	// 			))}
+	// 		</ul>
+	// 	</nav>
+	// );
+	// return <NewslettersTable newsletters={newsLetters} />
+	return <NewslettersTable />
 };

--- a/apps/newsletters-ui/src/app/components/NewslettersTable.tsx
+++ b/apps/newsletters-ui/src/app/components/NewslettersTable.tsx
@@ -1,8 +1,13 @@
 import { useMemo } from 'react';
 import type { Column } from 'react-table';
+import type { Newsletter } from '@newsletters-nx/newsletters-data-client';
 import { Table } from './Table';
 
-export const NewslettersTable = () => {
+interface Props {
+	newsletters: Newsletter[];
+}
+
+export const NewslettersTable = ({newsletters}: Props) => {
   const data = useMemo<object[]>(
     () => [
       {

--- a/apps/newsletters-ui/src/app/components/NewslettersTable.tsx
+++ b/apps/newsletters-ui/src/app/components/NewslettersTable.tsx
@@ -9,31 +9,14 @@ interface Props {
 
 export const NewslettersTable = ({newsletters}: Props) => {
   const data = useMemo<object[]>(
-    () => [
-      {
-        col1: 'Hello',
-        col2: 'World',
-      },
-      {
-        col1: 'react-table',
-        col2: 'rocks',
-      },
-      {
-        col1: 'whatever',
-        col2: 'you want',
-      },
-    ],
-    [],
+    () => newsletters,
+    [newsletters],
   );
   const columns = useMemo<Column[]>(
     () => [
       {
-        Header: 'Column 1',
-        accessor: 'col1',
-      },
-      {
-        Header: 'Column 2',
-        accessor: 'col2',
+        Header: 'Identity Name',
+        accessor: 'identityName',
       },
     ],
     [],

--- a/apps/newsletters-ui/src/app/components/NewslettersTable.tsx
+++ b/apps/newsletters-ui/src/app/components/NewslettersTable.tsx
@@ -1,0 +1,37 @@
+import { useMemo } from 'react';
+import type { Column } from 'react-table';
+import { Table } from './Table';
+
+export const NewslettersTable = () => {
+  const data = useMemo<object[]>(
+    () => [
+      {
+        col1: 'Hello',
+        col2: 'World',
+      },
+      {
+        col1: 'react-table',
+        col2: 'rocks',
+      },
+      {
+        col1: 'whatever',
+        col2: 'you want',
+      },
+    ],
+    [],
+  );
+  const columns = useMemo<Column[]>(
+    () => [
+      {
+        Header: 'Column 1',
+        accessor: 'col1',
+      },
+      {
+        Header: 'Column 2',
+        accessor: 'col2',
+      },
+    ],
+    [],
+  );
+	return <Table data={data} columns={columns}/>
+}

--- a/apps/newsletters-ui/src/app/components/NewslettersTable.tsx
+++ b/apps/newsletters-ui/src/app/components/NewslettersTable.tsx
@@ -24,6 +24,11 @@ export const NewslettersTable = ({newsletters}: Props) => {
         Header: 'Newsletter Name',
         accessor: 'name',
       },
+      {
+        Header: 'Paused',
+        accessor: 'paused',
+				Cell: ({ cell: { value } }) => <>{value ? '✅ Yes' : '❌ No'}</>
+      },
     ],
     [],
   );

--- a/apps/newsletters-ui/src/app/components/NewslettersTable.tsx
+++ b/apps/newsletters-ui/src/app/components/NewslettersTable.tsx
@@ -2,17 +2,12 @@ import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import type { Column } from 'react-table';
 import type { Newsletter } from '@newsletters-nx/newsletters-data-client';
+import { formatCellBoolean } from './Cell';
 import { Table } from './Table';
 
 interface Props {
 	newsletters: Newsletter[];
 }
-
-type Cell<T> = { cell: { value: T } };
-
-const formatCellBoolean = ({ cell: { value } }: Cell<boolean>) => (
-	<span>{value ? '✅ Yes' : '❌ No'}</span>
-);
 
 export const NewslettersTable = ({ newsletters }: Props) => {
 	const data = useMemo<object[]>(() => newsletters, [newsletters]);

--- a/apps/newsletters-ui/src/app/components/NewslettersTable.tsx
+++ b/apps/newsletters-ui/src/app/components/NewslettersTable.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { Link } from 'react-router-dom';
 import type { Column } from 'react-table';
 import type { Newsletter } from '@newsletters-nx/newsletters-data-client';
 import { Table } from './Table';
@@ -17,7 +18,7 @@ export const NewslettersTable = ({newsletters}: Props) => {
       {
         Header: 'Newsletter ID',
         accessor: 'identityName',
-				
+				Cell: ({ cell: { value } }) => <Link to={`/newsletters/${value as string}`}>{value}</Link>
       },
       {
         Header: 'Newsletter Name',

--- a/apps/newsletters-ui/src/app/components/NewslettersTable.tsx
+++ b/apps/newsletters-ui/src/app/components/NewslettersTable.tsx
@@ -15,8 +15,13 @@ export const NewslettersTable = ({newsletters}: Props) => {
   const columns = useMemo<Column[]>(
     () => [
       {
-        Header: 'Identity Name',
+        Header: 'Newsletter ID',
         accessor: 'identityName',
+				
+      },
+      {
+        Header: 'Newsletter Name',
+        accessor: 'name',
       },
     ],
     [],

--- a/apps/newsletters-ui/src/app/components/NewslettersTable.tsx
+++ b/apps/newsletters-ui/src/app/components/NewslettersTable.tsx
@@ -8,29 +8,34 @@ interface Props {
 	newsletters: Newsletter[];
 }
 
-export const NewslettersTable = ({newsletters}: Props) => {
-  const data = useMemo<object[]>(
-    () => newsletters,
-    [newsletters],
-  );
-  const columns = useMemo<Column[]>(
-    () => [
-      {
-        Header: 'Newsletter ID',
-        accessor: 'identityName',
-				Cell: ({ cell: { value } }) => <Link to={`/newsletters/${value as string}`}>{value}</Link>
-      },
-      {
-        Header: 'Newsletter Name',
-        accessor: 'name',
-      },
-      {
-        Header: 'Paused',
-        accessor: 'paused',
-				Cell: ({ cell: { value } }) => <>{value ? '✅ Yes' : '❌ No'}</>
-      },
-    ],
-    [],
-  );
-	return <Table data={data} columns={columns}/>
-}
+type Cell<T> = { cell: { value: T } };
+
+const formatCellBoolean = ({ cell: { value } }: Cell<boolean>) => (
+	<span>{value ? '✅ Yes' : '❌ No'}</span>
+);
+
+export const NewslettersTable = ({ newsletters }: Props) => {
+	const data = useMemo<object[]>(() => newsletters, [newsletters]);
+	const columns = useMemo<Column[]>(
+		() => [
+			{
+				Header: 'Newsletter ID',
+				accessor: 'identityName',
+				Cell: ({ cell: { value } }) => (
+					<Link to={`/newsletters/${value as string}`}>{value}</Link>
+				),
+			},
+			{
+				Header: 'Newsletter Name',
+				accessor: 'name',
+			},
+			{
+				Header: 'Paused',
+				accessor: 'paused',
+				Cell: formatCellBoolean,
+			},
+		],
+		[],
+	);
+	return <Table data={data} columns={columns} />;
+};

--- a/apps/newsletters-ui/src/app/components/Table.tsx
+++ b/apps/newsletters-ui/src/app/components/Table.tsx
@@ -1,38 +1,49 @@
 import { useTable } from 'react-table';
-import type { Column } from 'react-table';
+import type { Cell, Column } from 'react-table';
+import { Link } from 'react-router-dom';
 
 interface Props {
 	data: object[];
 	columns: Column[];
 }
 
-export const Table = ({data, columns}: Props) => {
-  const tableInstance = useTable({ columns, data });
-  const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
-    tableInstance;
-  return (
-    <table {...getTableProps()}>
-      <thead>
-        {headerGroups.map(headerGroup => (
-          <tr {...headerGroup.getFooterGroupProps()}>
-            {headerGroup.headers.map(column => (
-              <th {...column.getHeaderProps()}>{column.render('Header')}</th>
-            ))}
-          </tr>
-        ))}
-      </thead>
-      <tbody {...getTableBodyProps()}>
-        {rows.map(row => {
-          prepareRow(row)
-          return (
-            <tr {...row.getRowProps()}>
-              {row.cells.map(cell => {
-                return (<td {...cell.getCellProps()}>{cell.render('Cell')}</td>)
-              })}
-            </tr>
-          )
-        })}
-      </tbody>
-    </table>
-  );
-}
+export const Table = ({ data, columns }: Props) => {
+	const tableInstance = useTable({ columns, data });
+	const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
+		tableInstance;
+	return (
+		<table {...getTableProps()}>
+			<thead>
+				{headerGroups.map((headerGroup) => (
+					<tr {...headerGroup.getFooterGroupProps()}>
+						{headerGroup.headers.map((column) => (
+							<th {...column.getHeaderProps()}>{column.render('Header')}</th>
+						))}
+					</tr>
+				))}
+			</thead>
+			<tbody {...getTableBodyProps()}>
+				{rows.map((row) => {
+					prepareRow(row);
+					return (
+						<tr {...row.getRowProps()}>
+							{row.cells.map((cell: Cell, index) => {
+								return (
+									<td {...cell.getCellProps()}>
+										{index === 0 ? (
+											<Link to={`/newsletters/${cell.value as string}`}>
+												{cell.render('Cell')}
+											</Link>
+										) : (
+											cell.render('Cell')
+										)}
+									</td>
+								);
+							})}
+						</tr>
+					);
+				})}
+			</tbody>
+		</table>
+	);
+};

--- a/apps/newsletters-ui/src/app/components/Table.tsx
+++ b/apps/newsletters-ui/src/app/components/Table.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { css } from '@emotion/react';
 import { useTable } from 'react-table';
 import type { Cell, Column } from 'react-table';
 
@@ -11,8 +11,17 @@ export const Table = ({ data, columns }: Props) => {
 	const tableInstance = useTable({ columns, data });
 	const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
 		tableInstance;
+	const tableStyle = css`
+		border-collapse: collapse;
+		th,
+		td {
+			border: 1px solid #dddddd;
+			padding: 8px;
+			text-align: left;
+		}
+	`;
 	return (
-		<table {...getTableProps()}>
+		<table {...getTableProps()} css={tableStyle}>
 			<thead>
 				{headerGroups.map((headerGroup) => (
 					<tr {...headerGroup.getFooterGroupProps()}>
@@ -28,17 +37,7 @@ export const Table = ({ data, columns }: Props) => {
 					return (
 						<tr {...row.getRowProps()}>
 							{row.cells.map((cell: Cell, index) => {
-								return (
-									<td {...cell.getCellProps()}>
-										{index === 0 ? (
-											<Link to={`/newsletters/${cell.value as string}`}>
-												{cell.render('Cell')}
-											</Link>
-										) : (
-											cell.render('Cell')
-										)}
-									</td>
-								);
+								return <td {...cell.getCellProps()}>{cell.render('Cell')}</td>;
 							})}
 						</tr>
 					);

--- a/apps/newsletters-ui/src/app/components/Table.tsx
+++ b/apps/newsletters-ui/src/app/components/Table.tsx
@@ -1,6 +1,6 @@
+import { Link } from 'react-router-dom';
 import { useTable } from 'react-table';
 import type { Cell, Column } from 'react-table';
-import { Link } from 'react-router-dom';
 
 interface Props {
 	data: object[];

--- a/apps/newsletters-ui/src/app/components/Table.tsx
+++ b/apps/newsletters-ui/src/app/components/Table.tsx
@@ -1,0 +1,38 @@
+import { useTable } from 'react-table';
+import type { Column } from 'react-table';
+
+interface Props {
+	data: object[];
+	columns: Column[];
+}
+
+export const Table = ({data, columns}: Props) => {
+  const tableInstance = useTable({ columns, data });
+  const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
+    tableInstance;
+  return (
+    <table {...getTableProps()}>
+      <thead>
+        {headerGroups.map(headerGroup => (
+          <tr {...headerGroup.getFooterGroupProps()}>
+            {headerGroup.headers.map(column => (
+              <th {...column.getHeaderProps()}>{column.render('Header')}</th>
+            ))}
+          </tr>
+        ))}
+      </thead>
+      <tbody {...getTableBodyProps()}>
+        {rows.map(row => {
+          prepareRow(row)
+          return (
+            <tr {...row.getRowProps()}>
+              {row.cells.map(cell => {
+                return (<td {...cell.getCellProps()}>{cell.render('Cell')}</td>)
+              })}
+            </tr>
+          )
+        })}
+      </tbody>
+    </table>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
 		"@emotion/styled": "11.10.5",
 		"@guardian/source-foundations": "^8.0.0",
 		"@guardian/source-react-components": "^10.0.2",
+		"@types/react-table": "^7.7.14",
 		"react": "18.2.0",
 		"react-dom": "18.2.0",
 		"react-router-dom": "6.4.3",
+		"react-table": "^7.8.0",
 		"tslib": "^2.3.0",
 		"zod": "^3.20.2"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -1643,6 +1643,13 @@
     "@types/history" "^4.7.11"
     "@types/react" "*"
 
+"@types/react-table@^7.7.14":
+  version "7.7.14"
+  resolved "https://registry.yarnpkg.com/@types/react-table/-/react-table-7.7.14.tgz#b880f1ae140ed065bca2e21b3008ca1ebe71595a"
+  integrity sha512-TYrv7onCiakaG1uAu/UpQ9FojNEt/4/ht87EgJQaEGFoWV606ZLWUZAcUHzMxgc3v1mywP1cDyz3qB4ho3hWOw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*":
   version "18.0.27"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.27.tgz#d9425abe187a00f8a5ec182b010d4fd9da703b71"
@@ -7046,6 +7053,11 @@ react-shallow-renderer@^16.15.0:
   dependencies:
     object-assign "^4.1.1"
     react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
+
+react-table@^7.8.0:
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.8.0.tgz#07858c01c1718c09f7f1aed7034fcfd7bda907d2"
+  integrity sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==
 
 react-test-renderer@18.2.0:
   version "18.2.0"


### PR DESCRIPTION
## What does this change?

As part of https://github.com/guardian/newsletters-nx/pull/9, the newsletters were displayed in a list

This PR uses a react-table to display the list of all newsletters.  The columns included in this initial version are not intended to be definitive but were selected in the short term to demonstrate:
- displaying text as a Link
- displaying normal text
- rendering a boolean

Changes to the columns can easily be made via the `columns` const in `NewslettersTable.tsx`

Styling and other functionality (such as sort and filter) will be addressed in separate PRs

## How to test

Run `yarn dev` in your IDE
View http://localhost:4200/newsletters/ in your browser

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

The choice of emojis for the boolean display are generally logical (Yes being portrayed as a positive thing, and No being portrayed as a negative thing), but aren't particularly intuitive in the context of a Paused newsletter.  This is something to consider when deciding how to structure our data, and what data to display (ultimately) on this page.  Possibly other emojis should be chosen in place of the tick and cross.

## Images

![Screenshot 2023-01-26 at 15 33 36](https://user-images.githubusercontent.com/74301289/214878169-4254e15d-c917-4727-97ab-7bb974cac4e5.png)


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
