### PR TITLE
Switch to Chakra UI lib

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/apps/newsletters-ui/src/app/components/ButtonContainer.tsx
+++ b/apps/newsletters-ui/src/app/components/ButtonContainer.tsx
@@ -1,78 +1,62 @@
+import { Button, Tooltip } from '@chakra-ui/react';
 import styled from '@emotion/styled';
-import { useNavigate } from 'react-router';
+import { space, until } from '@guardian/source-foundations';
+import { Link } from 'react-router-dom';
 
 const ContainerStyle = styled.div`
 	display: grid;
 	grid-template-columns: auto auto auto;
-	column-gap: 40px;
-	row-gap: 25px;
-	@media (max-width: 375px) {
+	column-gap: ${space[6]}px;
+	row-gap: ${space[2]}px;
+	${until.tablet} {
+		grid-template-columns: auto auto;
+	}
+	${until.mobileLandscape} {
 		grid-template-columns: auto;
 	}
 `;
 
-export function ButtonContainer() {
-	const navigate = useNavigate();
+type DisabledButtonProps = { children: string; tooltipLabel?: string };
+const DisabledButton = ({
+	children,
+	tooltipLabel = 'Not implemented yet',
+}: DisabledButtonProps) => (
+	<Tooltip label={tooltipLabel}>
+		<Button
+			style={{
+				cursor: 'not-allowed',
+				color: 'grey',
+				background: 'none',
+			}}
+			variant="ghost"
+		>
+			{children}
+		</Button>
+	</Tooltip>
+);
 
+export function ButtonContainer() {
 	return (
 		<ContainerStyle>
-			<button onClick={() => navigate('/newsletters/')}>
-				View current newsletters
-			</button>
-			<button
-				onClick={() =>
-					alert('Create new newsletter has not yet been implemented')
-				}
-			>
-				Create new newsletter
-			</button>
-			<button
-				onClick={() => alert('Update newsletter has not yet been implemented')}
-			>
-				Update newsletter
-			</button>
-			<button
-				onClick={() =>
-					alert('Create email template has not yet been implemented')
-				}
-			>
-				Create email template
-			</button>
-			<button
-				onClick={() =>
-					alert('Create single thrasher has not yet been implemented')
-				}
-			>
-				Create single thrasher
-			</button>
-			<button
-				onClick={() =>
-					alert('Create multi thrasher has not yet been implemented')
-				}
-			>
-				Create multi thrasher
-			</button>
-			<button
-				onClick={() =>
-					alert('Update email template has not yet been implemented')
-				}
-			>
-				Update email template
-			</button>
-			<button
-				onClick={() =>
-					alert('Update single thrasher has not yet been implemented')
-				}
-			>
-				Update single thrasher
-			</button>
-			<button
-				onClick={() =>
-					alert('Update multi thrasher has not yet been implemented')
-				}
-			>
-				Update multi thrasher
-			</button>
+			<Button>
+				<Link to="/newsletters">View current newsletters</Link>
+			</Button>
+
+			<DisabledButton>Create newsletter</DisabledButton>
+
+			<DisabledButton>Update newsletter</DisabledButton>
+
+			<DisabledButton>View email templates</DisabledButton>
+
+			<DisabledButton>Create email template</DisabledButton>
+
+			<DisabledButton>Update email template</DisabledButton>
+
+			<DisabledButton>View all thrashers</DisabledButton>
+
+			<DisabledButton>Create single thrasher</DisabledButton>
+
+			<DisabledButton>Create multi thrasher</DisabledButton>
 		</ContainerStyle>
 	);
 }

--- a/apps/newsletters-ui/src/main.tsx
+++ b/apps/newsletters-ui/src/main.tsx
@@ -1,3 +1,4 @@
+import { ChakraProvider } from '@chakra-ui/react';
 import { StrictMode } from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
@@ -11,6 +12,8 @@ const root = ReactDOM.createRoot(
 );
 root.render(
 	<StrictMode>
-		<RouterProvider router={router} />
+		<ChakraProvider>
+			<RouterProvider router={router} />
+		</ChakraProvider>
 	</StrictMode>,
 );

--- a/apps/newsletters-ui/tsconfig.app.json
+++ b/apps/newsletters-ui/tsconfig.app.json
@@ -1,22 +1,22 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
-    "types": ["node", "vitest/importMeta"]
-  },
-  "files": [
-    "../../node_modules/@nrwl/react/typings/cssmodule.d.ts",
-    "../../node_modules/@nrwl/react/typings/image.d.ts"
-  ],
-  "exclude": [
-    "src/**/*.spec.ts",
-    "src/**/*.test.ts",
-    "src/**/*.spec.tsx",
-    "src/**/*.test.tsx",
-    "src/**/*.spec.js",
-    "src/**/*.test.js",
-    "src/**/*.spec.jsx",
-    "src/**/*.test.jsx"
-  ],
-  "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"]
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../dist/out-tsc",
+		"types": ["node", "vitest/importMeta"]
+	},
+	"files": [
+		"../../node_modules/@nrwl/react/typings/cssmodule.d.ts",
+		"../../node_modules/@nrwl/react/typings/image.d.ts"
+	],
+	"exclude": [
+		"src/**/*.spec.ts",
+		"src/**/*.test.ts",
+		"src/**/*.spec.tsx",
+		"src/**/*.test.tsx",
+		"src/**/*.spec.js",
+		"src/**/*.test.js",
+		"src/**/*.spec.jsx",
+		"src/**/*.test.jsx"
+	],
+	"include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,13 @@
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
+				"@chakra-ui/react": "^2.4.9",
 				"@emotion/css": "^11.10.5",
 				"@emotion/react": "11.10.5",
 				"@emotion/styled": "11.10.5",
 				"@guardian/source-foundations": "^8.0.0",
 				"@types/react-table": "^7.7.14",
+				"framer-motion": "^8.5.3",
 				"react": "18.2.0",
 				"react-dom": "18.2.0",
 				"react-router-dom": "6.4.3",
@@ -613,6 +615,1139 @@
 			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
+		},
+		"node_modules/@chakra-ui/accordion": {
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/accordion/-/accordion-2.1.8.tgz",
+			"integrity": "sha512-RTXYhL85dUSVUEurDicxS76JaCXa/L4FYWPAxPSisbZtFvL+/gvoFMcGtT8ZRsJwFWaevmkD+57EmOYCWlLL1A==",
+			"dependencies": {
+				"@chakra-ui/descendant": "3.0.13",
+				"@chakra-ui/icon": "3.0.16",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-use-controllable-state": "2.0.8",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5",
+				"@chakra-ui/transition": "2.0.15"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"framer-motion": ">=4.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/alert": {
+			"version": "2.0.17",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/alert/-/alert-2.0.17.tgz",
+			"integrity": "sha512-0Y5vw+HkeXpwbL1roVpSSNM6luMRmUbwduUSHEA4OnX1ismvsDb1ZBfpi4Vxp6w8euJ2Uj6df3krbd5tbCP6tg==",
+			"dependencies": {
+				"@chakra-ui/icon": "3.0.16",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5",
+				"@chakra-ui/spinner": "2.0.13"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/anatomy": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.1.2.tgz",
+			"integrity": "sha512-pKfOS/mztc4sUXHNc8ypJ1gPWSolWT770jrgVRfolVbYlki8y5Y+As996zMF6k5lewTu6j9DQequ7Cc9a69IVQ=="
+		},
+		"node_modules/@chakra-ui/avatar": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/avatar/-/avatar-2.2.4.tgz",
+			"integrity": "sha512-OUuZAhabW0FgmFVt0djH3cVR8p9bKC3vYT3Ol2lrUz3hbf4LrjU5EzmMHmQvcbSs6bNDxS3k9hnswLebOFctJQ==",
+			"dependencies": {
+				"@chakra-ui/image": "2.0.15",
+				"@chakra-ui/react-children-utils": "2.0.6",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/breadcrumb": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/breadcrumb/-/breadcrumb-2.1.4.tgz",
+			"integrity": "sha512-vyBx5TAxPnHhb0b8nyRGfqyjleD//9mySFhk96c9GL+T6YDO4swHw5y/kvDv3Ngc/iRwJ9hdI49PZKwPxLqsEg==",
+			"dependencies": {
+				"@chakra-ui/react-children-utils": "2.0.6",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/breakpoint-utils": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/breakpoint-utils/-/breakpoint-utils-2.0.7.tgz",
+			"integrity": "sha512-YBwsDPMlaMRZ4fKc2WyIIaUmByzkiP4ozxMJIjJRPhedzSho7FOZuE8532q+97f2SyY8z/yZPJ41q4GdwHI/HQ==",
+			"dependencies": {
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"node_modules/@chakra-ui/button": {
+			"version": "2.0.16",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/button/-/button-2.0.16.tgz",
+			"integrity": "sha512-NjuTKa7gNhnGSUutKuTc8HoAOe9WWIigpciBG7yj3ok67kg8bXtSzPyQFZlgTY6XGdAckWTT+Do4tvhwa5LA+g==",
+			"dependencies": {
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5",
+				"@chakra-ui/spinner": "2.0.13"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/card": {
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/card/-/card-2.1.6.tgz",
+			"integrity": "sha512-fFd/WAdRNVY/WOSQv4skpy0WeVhhI0f7dTY1Sm0jVl0KLmuP/GnpsWtKtqWjNcV00K963EXDyhlk6+9oxbP4gw==",
+			"dependencies": {
+				"@chakra-ui/shared-utils": "2.0.5"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/checkbox": {
+			"version": "2.2.10",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/checkbox/-/checkbox-2.2.10.tgz",
+			"integrity": "sha512-vzxEjw99qj7loxAdP1WuHNt4EAvj/t6cc8oxyOB2mEvkAzhxI34rLR+3zWDuHWsmhyUO+XEDh4FiWdR+DK5Siw==",
+			"dependencies": {
+				"@chakra-ui/form-control": "2.0.17",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-types": "2.0.7",
+				"@chakra-ui/react-use-callback-ref": "2.0.7",
+				"@chakra-ui/react-use-controllable-state": "2.0.8",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/react-use-safe-layout-effect": "2.0.5",
+				"@chakra-ui/react-use-update-effect": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5",
+				"@chakra-ui/visually-hidden": "2.0.15",
+				"@zag-js/focus-visible": "0.2.1"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/clickable": {
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/clickable/-/clickable-2.0.14.tgz",
+			"integrity": "sha512-jfsM1qaD74ZykLHmvmsKRhDyokLUxEfL8Il1VoZMNX5RBI0xW/56vKpLTFF/v/+vLPLS+Te2cZdD4+2O+G6ulA==",
+			"dependencies": {
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			},
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/close-button": {
+			"version": "2.0.17",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/close-button/-/close-button-2.0.17.tgz",
+			"integrity": "sha512-05YPXk456t1Xa3KpqTrvm+7smx+95dmaPiwjiBN3p7LHUQVHJd8ZXSDB0V+WKi419k3cVQeJUdU/azDO2f40sw==",
+			"dependencies": {
+				"@chakra-ui/icon": "3.0.16"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/color-mode": {
+			"version": "2.1.12",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/color-mode/-/color-mode-2.1.12.tgz",
+			"integrity": "sha512-sYyfJGDoJSLYO+V2hxV9r033qhte5Nw/wAn5yRGGZnEEN1dKPEdWQ3XZvglWSDTNd0w9zkoH2w6vP4FBBYb/iw==",
+			"dependencies": {
+				"@chakra-ui/react-use-safe-layout-effect": "2.0.5"
+			},
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/control-box": {
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/control-box/-/control-box-2.0.13.tgz",
+			"integrity": "sha512-FEyrU4crxati80KUF/+1Z1CU3eZK6Sa0Yv7Z/ydtz9/tvGblXW9NFanoomXAOvcIFLbaLQPPATm9Gmpr7VG05A==",
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/counter": {
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/counter/-/counter-2.0.14.tgz",
+			"integrity": "sha512-KxcSRfUbb94dP77xTip2myoE7P2HQQN4V5fRJmNAGbzcyLciJ+aDylUU/UxgNcEjawUp6Q242NbWb1TSbKoqog==",
+			"dependencies": {
+				"@chakra-ui/number-utils": "2.0.7",
+				"@chakra-ui/react-use-callback-ref": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			},
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/css-reset": {
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/css-reset/-/css-reset-2.0.12.tgz",
+			"integrity": "sha512-Q5OYIMvqTl2vZ947kIYxcS5DhQXeStB84BzzBd6C10wOx1gFUu9pL+jLpOnHR3hhpWRMdX5o7eT+gMJWIYUZ0Q==",
+			"peerDependencies": {
+				"@emotion/react": ">=10.0.35",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/descendant": {
+			"version": "3.0.13",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/descendant/-/descendant-3.0.13.tgz",
+			"integrity": "sha512-9nzxZVxUSMc4xPL5fSaRkEOQjDQWUGjGvrZI7VzWk9eq63cojOtIxtWMSW383G9148PzWJjJYt30Eud5tdZzlg==",
+			"dependencies": {
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-use-merge-refs": "2.0.7"
+			},
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/dom-utils": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/dom-utils/-/dom-utils-2.0.6.tgz",
+			"integrity": "sha512-PVtDkPrDD5b8aoL6Atg7SLjkwhWb7BwMcLOF1L449L3nZN+DAO3nyAh6iUhZVJyunELj9d0r65CDlnMREyJZmA=="
+		},
+		"node_modules/@chakra-ui/editable": {
+			"version": "2.0.19",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/editable/-/editable-2.0.19.tgz",
+			"integrity": "sha512-YxRJsJ2JQd42zfPBgTKzIhg1HugT+gfQz1ZosmUN+IZT9YZXL2yodHTUz6Lee04Vc/CdEqgBFLuREXEUNBfGtA==",
+			"dependencies": {
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-types": "2.0.7",
+				"@chakra-ui/react-use-callback-ref": "2.0.7",
+				"@chakra-ui/react-use-controllable-state": "2.0.8",
+				"@chakra-ui/react-use-focus-on-pointer-down": "2.0.6",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/react-use-safe-layout-effect": "2.0.5",
+				"@chakra-ui/react-use-update-effect": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/event-utils": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/event-utils/-/event-utils-2.0.8.tgz",
+			"integrity": "sha512-IGM/yGUHS+8TOQrZGpAKOJl/xGBrmRYJrmbHfUE7zrG3PpQyXvbLDP1M+RggkCFVgHlJi2wpYIf0QtQlU0XZfw=="
+		},
+		"node_modules/@chakra-ui/focus-lock": {
+			"version": "2.0.16",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/focus-lock/-/focus-lock-2.0.16.tgz",
+			"integrity": "sha512-UuAdGCPVrCa1lecoAvpOQD7JFT7a9RdmhKWhFt5ioIcekSLJcerdLHuuL3w0qz//8kd1/SOt7oP0aJqdAJQrCw==",
+			"dependencies": {
+				"@chakra-ui/dom-utils": "2.0.6",
+				"react-focus-lock": "^2.9.2"
+			},
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/form-control": {
+			"version": "2.0.17",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/form-control/-/form-control-2.0.17.tgz",
+			"integrity": "sha512-34ptCaJ2LNvQNOlB6MAKsmH1AkT1xo7E+3Vw10Urr81yTOjDTM/iU6vG3JKPfRDMyXeowPjXmutlnuk72SSjRg==",
+			"dependencies": {
+				"@chakra-ui/icon": "3.0.16",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-types": "2.0.7",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/hooks": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-2.1.5.tgz",
+			"integrity": "sha512-E3bGwxjXvMUc9ev3egctrRi5fnER5xXbWUsivA3iFRdUrkfX+19JLUfP1TURzv7UQG8X1AxKSwfqIsYyeHrdmQ==",
+			"dependencies": {
+				"@chakra-ui/react-utils": "2.0.12",
+				"@chakra-ui/utils": "2.0.15",
+				"compute-scroll-into-view": "1.0.14",
+				"copy-to-clipboard": "3.3.1"
+			},
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/icon": {
+			"version": "3.0.16",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-3.0.16.tgz",
+			"integrity": "sha512-RpA1X5Ptz8Mt39HSyEIW1wxAz2AXyf9H0JJ5HVx/dBdMZaGMDJ0HyyPBVci0m4RCoJuyG1HHG/DXJaVfUTVAeg==",
+			"dependencies": {
+				"@chakra-ui/shared-utils": "2.0.5"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/image": {
+			"version": "2.0.15",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-2.0.15.tgz",
+			"integrity": "sha512-w2rElXtI3FHXuGpMCsSklus+pO1Pl2LWDwsCGdpBQUvGFbnHfl7MftQgTlaGHeD5OS95Pxva39hKrA2VklKHiQ==",
+			"dependencies": {
+				"@chakra-ui/react-use-safe-layout-effect": "2.0.5",
+				"@chakra-ui/shared-utils": "2.0.5"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/input": {
+			"version": "2.0.19",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/input/-/input-2.0.19.tgz",
+			"integrity": "sha512-wV+EG6+F9GngMPpLHBCuxXTNttHihFTT3DpbJnmID9LuAPg7YkWcTNTvpAzC0/Sz9KrcTR9RhSu9a5cvxkkXpw==",
+			"dependencies": {
+				"@chakra-ui/form-control": "2.0.17",
+				"@chakra-ui/object-utils": "2.0.8",
+				"@chakra-ui/react-children-utils": "2.0.6",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/layout": {
+			"version": "2.1.15",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/layout/-/layout-2.1.15.tgz",
+			"integrity": "sha512-dJYzBm2ywRYNmtadot/5ii+Gztsx8a9Jd+gFXiSLcfQs/QRdboqMyr/0O+6RY2sI7Mwvyo6uo9AvGJBU1djrNQ==",
+			"dependencies": {
+				"@chakra-ui/breakpoint-utils": "2.0.7",
+				"@chakra-ui/icon": "3.0.16",
+				"@chakra-ui/object-utils": "2.0.8",
+				"@chakra-ui/react-children-utils": "2.0.6",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/lazy-utils": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/lazy-utils/-/lazy-utils-2.0.5.tgz",
+			"integrity": "sha512-UULqw7FBvcckQk2n3iPO56TMJvDsNv0FKZI6PlUNJVaGsPbsYxK/8IQ60vZgaTVPtVcjY6BE+y6zg8u9HOqpyg=="
+		},
+		"node_modules/@chakra-ui/live-region": {
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/live-region/-/live-region-2.0.13.tgz",
+			"integrity": "sha512-Ja+Slk6ZkxSA5oJzU2VuGU7TpZpbMb/4P4OUhIf2D30ctmIeXkxTWw1Bs1nGJAVtAPcGS5sKA+zb89i8g+0cTQ==",
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/media-query": {
+			"version": "3.2.11",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-3.2.11.tgz",
+			"integrity": "sha512-AylT/qIpbCOvcjvURMdItLvAnaEYZynatvVJUQ8TYcQO2KHBt8BBhQ9umrmNAZFr8y7CRcg7PdvK+g+yOkq22g==",
+			"dependencies": {
+				"@chakra-ui/breakpoint-utils": "2.0.7",
+				"@chakra-ui/react-env": "3.0.0",
+				"@chakra-ui/shared-utils": "2.0.5"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/menu": {
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/menu/-/menu-2.1.8.tgz",
+			"integrity": "sha512-3Ysk1HwJTv6mzkT1dgsNObZnuZiySPJwLdmmCdv8+rpto8u0oCN+etenN0s7HQlAddvHxZ2Sm+1yKZOu6Wimrg==",
+			"dependencies": {
+				"@chakra-ui/clickable": "2.0.14",
+				"@chakra-ui/descendant": "3.0.13",
+				"@chakra-ui/lazy-utils": "2.0.5",
+				"@chakra-ui/popper": "3.0.13",
+				"@chakra-ui/react-children-utils": "2.0.6",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-use-animation-state": "2.0.8",
+				"@chakra-ui/react-use-controllable-state": "2.0.8",
+				"@chakra-ui/react-use-disclosure": "2.0.8",
+				"@chakra-ui/react-use-focus-effect": "2.0.9",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/react-use-outside-click": "2.0.7",
+				"@chakra-ui/react-use-update-effect": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5",
+				"@chakra-ui/transition": "2.0.15"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"framer-motion": ">=4.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/modal": {
+			"version": "2.2.9",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/modal/-/modal-2.2.9.tgz",
+			"integrity": "sha512-nTfNp7XsVwn5+xJOtstoFA8j0kq/9sJj7KesyYzjEDaMKvCZvIOntRYowoydho43jb4+YC7ebKhp0KOIINS0gg==",
+			"dependencies": {
+				"@chakra-ui/close-button": "2.0.17",
+				"@chakra-ui/focus-lock": "2.0.16",
+				"@chakra-ui/portal": "2.0.15",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-types": "2.0.7",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5",
+				"@chakra-ui/transition": "2.0.15",
+				"aria-hidden": "^1.2.2",
+				"react-remove-scroll": "^2.5.5"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"framer-motion": ">=4.0.0",
+				"react": ">=18",
+				"react-dom": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/number-input": {
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/number-input/-/number-input-2.0.18.tgz",
+			"integrity": "sha512-cPkyAFFHHzeFBselrT1BtjlzMkJ6TKrTDUnHFlzqXy6aqeXuhrjFhMfXucjedSpOqedsP9ZbKFTdIAhu9DdL/A==",
+			"dependencies": {
+				"@chakra-ui/counter": "2.0.14",
+				"@chakra-ui/form-control": "2.0.17",
+				"@chakra-ui/icon": "3.0.16",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-types": "2.0.7",
+				"@chakra-ui/react-use-callback-ref": "2.0.7",
+				"@chakra-ui/react-use-event-listener": "2.0.7",
+				"@chakra-ui/react-use-interval": "2.0.5",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/react-use-safe-layout-effect": "2.0.5",
+				"@chakra-ui/react-use-update-effect": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/number-utils": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/number-utils/-/number-utils-2.0.7.tgz",
+			"integrity": "sha512-yOGxBjXNvLTBvQyhMDqGU0Oj26s91mbAlqKHiuw737AXHt0aPllOthVUqQMeaYLwLCjGMg0jtI7JReRzyi94Dg=="
+		},
+		"node_modules/@chakra-ui/object-utils": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/object-utils/-/object-utils-2.0.8.tgz",
+			"integrity": "sha512-2upjT2JgRuiupdrtBWklKBS6tqeGMA77Nh6Q0JaoQuH/8yq+15CGckqn3IUWkWoGI0Fg3bK9LDlbbD+9DLw95Q=="
+		},
+		"node_modules/@chakra-ui/pin-input": {
+			"version": "2.0.19",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/pin-input/-/pin-input-2.0.19.tgz",
+			"integrity": "sha512-6O7s4vWz4cqQ6zvMov9sYj6ZqWAsTxR/MNGe3DNgu1zWQg8veNCYtj1rNGhNS3eZNUMAa8uM2dXIphGTP53Xow==",
+			"dependencies": {
+				"@chakra-ui/descendant": "3.0.13",
+				"@chakra-ui/react-children-utils": "2.0.6",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-use-controllable-state": "2.0.8",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/popover": {
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/popover/-/popover-2.1.8.tgz",
+			"integrity": "sha512-ob7fAz+WWmXIq7iGHVB3wDKzZTj+T+noYBT/U1Q+jIf+jMr2WOpJLTfb0HTZcfhvn4EBFlfBg7Wk5qbXNaOn7g==",
+			"dependencies": {
+				"@chakra-ui/close-button": "2.0.17",
+				"@chakra-ui/lazy-utils": "2.0.5",
+				"@chakra-ui/popper": "3.0.13",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-types": "2.0.7",
+				"@chakra-ui/react-use-animation-state": "2.0.8",
+				"@chakra-ui/react-use-disclosure": "2.0.8",
+				"@chakra-ui/react-use-focus-effect": "2.0.9",
+				"@chakra-ui/react-use-focus-on-pointer-down": "2.0.6",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"framer-motion": ">=4.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/popper": {
+			"version": "3.0.13",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/popper/-/popper-3.0.13.tgz",
+			"integrity": "sha512-FwtmYz80Ju8oK3Z1HQfisUE7JIMmDsCQsRBu6XuJ3TFQnBHit73yjZmxKjuRJ4JgyT4WBnZoTF3ATbRKSagBeg==",
+			"dependencies": {
+				"@chakra-ui/react-types": "2.0.7",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@popperjs/core": "^2.9.3"
+			},
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/portal": {
+			"version": "2.0.15",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/portal/-/portal-2.0.15.tgz",
+			"integrity": "sha512-z8v7K3j1/nMuBzp2+wRIIw7s/eipVtnXLdjK5yqbMxMRa44E8Mu5VNJLz3aQFLHXEUST+ifqrjImQeli9do6LQ==",
+			"dependencies": {
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-use-safe-layout-effect": "2.0.5"
+			},
+			"peerDependencies": {
+				"react": ">=18",
+				"react-dom": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/progress": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/progress/-/progress-2.1.5.tgz",
+			"integrity": "sha512-jj5Vp4lxUchuwp4RPCepM0yAyKi344bgsOd3Apd+ldxclDcewPc82fbwDu7g/Xv27LqJkT+7E/SlQy04wGrk0g==",
+			"dependencies": {
+				"@chakra-ui/react-context": "2.0.7"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/provider": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/provider/-/provider-2.1.0.tgz",
+			"integrity": "sha512-+NUBHOkqWFpi/unwqhUQh1t/S1+TMZBTz+FiTeWycSUicdFsGCcTe6eQNLu6X5C8gYx9FGXG4ESx7HCTNXQj7w==",
+			"dependencies": {
+				"@chakra-ui/css-reset": "2.0.12",
+				"@chakra-ui/portal": "2.0.15",
+				"@chakra-ui/react-env": "3.0.0",
+				"@chakra-ui/system": "2.4.0",
+				"@chakra-ui/utils": "2.0.15"
+			},
+			"peerDependencies": {
+				"@emotion/react": "^11.0.0",
+				"@emotion/styled": "^11.0.0",
+				"react": ">=18",
+				"react-dom": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/radio": {
+			"version": "2.0.19",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/radio/-/radio-2.0.19.tgz",
+			"integrity": "sha512-PlJiV59eGSmeKP4v/4+ccQUWGRd0cjPKkj/p3L+UbOf8pl9dWm8y9kIeL5TYbghQSDv0nzkrH4+yMnnDTZjdMQ==",
+			"dependencies": {
+				"@chakra-ui/form-control": "2.0.17",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-types": "2.0.7",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5",
+				"@zag-js/focus-visible": "0.2.1"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/react": {
+			"version": "2.4.9",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-2.4.9.tgz",
+			"integrity": "sha512-lY++xW+zhLp0zQr2Sf5phjYMIphOmjGV/o5A1oDQPrqwLJFm4mL2+eXvpAFrLnZoh00qa4iBqarxJCW7qpHeiA==",
+			"dependencies": {
+				"@chakra-ui/accordion": "2.1.8",
+				"@chakra-ui/alert": "2.0.17",
+				"@chakra-ui/avatar": "2.2.4",
+				"@chakra-ui/breadcrumb": "2.1.4",
+				"@chakra-ui/button": "2.0.16",
+				"@chakra-ui/card": "2.1.6",
+				"@chakra-ui/checkbox": "2.2.10",
+				"@chakra-ui/close-button": "2.0.17",
+				"@chakra-ui/control-box": "2.0.13",
+				"@chakra-ui/counter": "2.0.14",
+				"@chakra-ui/css-reset": "2.0.12",
+				"@chakra-ui/editable": "2.0.19",
+				"@chakra-ui/form-control": "2.0.17",
+				"@chakra-ui/hooks": "2.1.5",
+				"@chakra-ui/icon": "3.0.16",
+				"@chakra-ui/image": "2.0.15",
+				"@chakra-ui/input": "2.0.19",
+				"@chakra-ui/layout": "2.1.15",
+				"@chakra-ui/live-region": "2.0.13",
+				"@chakra-ui/media-query": "3.2.11",
+				"@chakra-ui/menu": "2.1.8",
+				"@chakra-ui/modal": "2.2.9",
+				"@chakra-ui/number-input": "2.0.18",
+				"@chakra-ui/pin-input": "2.0.19",
+				"@chakra-ui/popover": "2.1.8",
+				"@chakra-ui/popper": "3.0.13",
+				"@chakra-ui/portal": "2.0.15",
+				"@chakra-ui/progress": "2.1.5",
+				"@chakra-ui/provider": "2.1.0",
+				"@chakra-ui/radio": "2.0.19",
+				"@chakra-ui/react-env": "3.0.0",
+				"@chakra-ui/select": "2.0.18",
+				"@chakra-ui/skeleton": "2.0.23",
+				"@chakra-ui/slider": "2.0.20",
+				"@chakra-ui/spinner": "2.0.13",
+				"@chakra-ui/stat": "2.0.17",
+				"@chakra-ui/styled-system": "2.5.2",
+				"@chakra-ui/switch": "2.0.22",
+				"@chakra-ui/system": "2.4.0",
+				"@chakra-ui/table": "2.0.16",
+				"@chakra-ui/tabs": "2.1.8",
+				"@chakra-ui/tag": "2.0.17",
+				"@chakra-ui/textarea": "2.0.18",
+				"@chakra-ui/theme": "2.2.5",
+				"@chakra-ui/theme-utils": "2.0.9",
+				"@chakra-ui/toast": "5.0.1",
+				"@chakra-ui/tooltip": "2.2.6",
+				"@chakra-ui/transition": "2.0.15",
+				"@chakra-ui/utils": "2.0.15",
+				"@chakra-ui/visually-hidden": "2.0.15"
+			},
+			"peerDependencies": {
+				"@emotion/react": "^11.0.0",
+				"@emotion/styled": "^11.0.0",
+				"framer-motion": ">=4.0.0",
+				"react": ">=18",
+				"react-dom": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/react-children-utils": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-children-utils/-/react-children-utils-2.0.6.tgz",
+			"integrity": "sha512-QVR2RC7QsOsbWwEnq9YduhpqSFnZGvjjGREV8ygKi8ADhXh93C8azLECCUVgRJF2Wc+So1fgxmjLcbZfY2VmBA==",
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/react-context": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-context/-/react-context-2.0.7.tgz",
+			"integrity": "sha512-i7EGmSU+h2GB30cwrKB4t1R5BMHyGoJM5L2Zz7b+ZUX4aAqyPcfe97wPiQB6Rgr1ImGXrUeov4CDVrRZ2FPgLQ==",
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/react-env": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-env/-/react-env-3.0.0.tgz",
+			"integrity": "sha512-tfMRO2v508HQWAqSADFrwZgR9oU10qC97oV6zGbjHh9ALP0/IcFR+Bi71KRTveDTm85fMeAzZYGj57P3Dsipkw==",
+			"dependencies": {
+				"@chakra-ui/react-use-safe-layout-effect": "2.0.5"
+			},
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/react-types": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-types/-/react-types-2.0.7.tgz",
+			"integrity": "sha512-12zv2qIZ8EHwiytggtGvo4iLT0APris7T0qaAWqzpUGS0cdUtR8W+V1BJ5Ocq+7tA6dzQ/7+w5hmXih61TuhWQ==",
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/react-use-animation-state": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-animation-state/-/react-use-animation-state-2.0.8.tgz",
+			"integrity": "sha512-xv9zSF2Rd1mHWQ+m5DLBWeh4atF8qrNvsOs3MNrvxKYBS3f79N3pqcQGrWAEvirXWXfiCeje2VAkEggqFRIo+Q==",
+			"dependencies": {
+				"@chakra-ui/dom-utils": "2.0.6",
+				"@chakra-ui/react-use-event-listener": "2.0.7"
+			},
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/react-use-callback-ref": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-callback-ref/-/react-use-callback-ref-2.0.7.tgz",
+			"integrity": "sha512-YjT76nTpfHAK5NxplAlZsQwNju5KmQExnqsWNPFeOR6vvbC34+iPSTr+r91i1Hdy7gBSbevsOsd5Wm6RN3GuMw==",
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/react-use-controllable-state": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-controllable-state/-/react-use-controllable-state-2.0.8.tgz",
+			"integrity": "sha512-F7rdCbLEmRjwwODqWZ3y+mKgSSHPcLQxeUygwk1BkZPXbKkJJKymOIjIynil2cbH7ku3hcSIWRvuhpCcfQWJ7Q==",
+			"dependencies": {
+				"@chakra-ui/react-use-callback-ref": "2.0.7"
+			},
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/react-use-disclosure": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-disclosure/-/react-use-disclosure-2.0.8.tgz",
+			"integrity": "sha512-2ir/mHe1YND40e+FyLHnDsnDsBQPwzKDLzfe9GZri7y31oU83JSbHdlAXAhp3bpjohslwavtRCp+S/zRxfO9aQ==",
+			"dependencies": {
+				"@chakra-ui/react-use-callback-ref": "2.0.7"
+			},
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/react-use-event-listener": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-event-listener/-/react-use-event-listener-2.0.7.tgz",
+			"integrity": "sha512-4wvpx4yudIO3B31pOrXuTHDErawmwiXnvAN7gLEOVREi16+YGNcFnRJ5X5nRrmB7j2MDUtsEDpRBFfw5Z9xQ5g==",
+			"dependencies": {
+				"@chakra-ui/react-use-callback-ref": "2.0.7"
+			},
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/react-use-focus-effect": {
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-focus-effect/-/react-use-focus-effect-2.0.9.tgz",
+			"integrity": "sha512-20nfNkpbVwyb41q9wxp8c4jmVp6TUGAPE3uFTDpiGcIOyPW5aecQtPmTXPMJH+2aa8Nu1wyoT1btxO+UYiQM3g==",
+			"dependencies": {
+				"@chakra-ui/dom-utils": "2.0.6",
+				"@chakra-ui/react-use-event-listener": "2.0.7",
+				"@chakra-ui/react-use-safe-layout-effect": "2.0.5",
+				"@chakra-ui/react-use-update-effect": "2.0.7"
+			},
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/react-use-focus-on-pointer-down": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-focus-on-pointer-down/-/react-use-focus-on-pointer-down-2.0.6.tgz",
+			"integrity": "sha512-OigXiLRVySn3tyVqJ/rn57WGuukW8TQe8fJYiLwXbcNyAMuYYounvRxvCy2b53sQ7QIZamza0N0jhirbH5FNoQ==",
+			"dependencies": {
+				"@chakra-ui/react-use-event-listener": "2.0.7"
+			},
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/react-use-interval": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-interval/-/react-use-interval-2.0.5.tgz",
+			"integrity": "sha512-1nbdwMi2K87V6p5f5AseOKif2CkldLaJlq1TOqaPRwb7v3aU9rltBtYdf+fIyuHSToNJUV6wd9budCFdLCl3Fg==",
+			"dependencies": {
+				"@chakra-ui/react-use-callback-ref": "2.0.7"
+			},
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/react-use-latest-ref": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-latest-ref/-/react-use-latest-ref-2.0.5.tgz",
+			"integrity": "sha512-3mIuFzMyIo3Ok/D8uhV9voVg7KkrYVO/pwVvNPJOHsDQqCA6DpYE4WDsrIx+fVcwad3Ta7SupexR5PoI+kq6QQ==",
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/react-use-merge-refs": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-merge-refs/-/react-use-merge-refs-2.0.7.tgz",
+			"integrity": "sha512-zds4Uhsc+AMzdH8JDDkLVet9baUBgtOjPbhC5r3A0ZXjZvGhCztFAVE3aExYiVoMPoHLKbLcqvCWE6ioFKz1lw==",
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/react-use-outside-click": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-outside-click/-/react-use-outside-click-2.0.7.tgz",
+			"integrity": "sha512-MsAuGLkwYNxNJ5rb8lYNvXApXxYMnJ3MzqBpQj1kh5qP/+JSla9XMjE/P94ub4fSEttmNSqs43SmPPrmPuihsQ==",
+			"dependencies": {
+				"@chakra-ui/react-use-callback-ref": "2.0.7"
+			},
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/react-use-pan-event": {
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-pan-event/-/react-use-pan-event-2.0.9.tgz",
+			"integrity": "sha512-xu35QXkiyrgsHUOnctl+SwNcwf9Rl62uYE5y8soKOZdBm8E+FvZIt2hxUzK1EoekbJCMzEZ0Yv1ZQCssVkSLaQ==",
+			"dependencies": {
+				"@chakra-ui/event-utils": "2.0.8",
+				"@chakra-ui/react-use-latest-ref": "2.0.5",
+				"framesync": "6.1.2"
+			},
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/react-use-previous": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-previous/-/react-use-previous-2.0.5.tgz",
+			"integrity": "sha512-BIZgjycPE4Xr+MkhKe0h67uHXzQQkBX/u5rYPd65iMGdX1bCkbE0oorZNfOHLKdTmnEb4oVsNvfN6Rfr+Mnbxw==",
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/react-use-safe-layout-effect": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-safe-layout-effect/-/react-use-safe-layout-effect-2.0.5.tgz",
+			"integrity": "sha512-MwAQBz3VxoeFLaesaSEN87reVNVbjcQBDex2WGexAg6hUB6n4gc1OWYH/iXp4tzp4kuggBNhEHkk9BMYXWfhJQ==",
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/react-use-size": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-size/-/react-use-size-2.0.8.tgz",
+			"integrity": "sha512-OdCxVPm8ekPVn9R6S1OtfLVNRVZ0G1tcfA2/oY1c55aXbm/R0TFZ+twSoy+X+aRFhqydmE7DRsKyW2ysXuuVBw==",
+			"dependencies": {
+				"@zag-js/element-size": "0.3.0"
+			},
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/react-use-timeout": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-timeout/-/react-use-timeout-2.0.5.tgz",
+			"integrity": "sha512-QqmB+jVphh3h/CS60PieorpY7UqSPkrQCB7f7F+i9vwwIjtP8fxVHMmkb64K7VlzQiMPzv12nlID5dqkzlv0mw==",
+			"dependencies": {
+				"@chakra-ui/react-use-callback-ref": "2.0.7"
+			},
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/react-use-update-effect": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-update-effect/-/react-use-update-effect-2.0.7.tgz",
+			"integrity": "sha512-vBM2bmmM83ZdDtasWv3PXPznpTUd+FvqBC8J8rxoRmvdMEfrxTiQRBJhiGHLpS9BPLLPQlosN6KdFU97csB6zg==",
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/react-utils": {
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-utils/-/react-utils-2.0.12.tgz",
+			"integrity": "sha512-GbSfVb283+YA3kA8w8xWmzbjNWk14uhNpntnipHCftBibl0lxtQ9YqMFQLwuFOO0U2gYVocszqqDWX+XNKq9hw==",
+			"dependencies": {
+				"@chakra-ui/utils": "2.0.15"
+			},
+			"peerDependencies": {
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/select": {
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/select/-/select-2.0.18.tgz",
+			"integrity": "sha512-1d2lUT5LM6oOs5x4lzBh4GFDuXX62+lr+sgV7099g951/5UNbb0CS2hSZHsO7yZThLNbr7QTWZvAOAayVcGzdw==",
+			"dependencies": {
+				"@chakra-ui/form-control": "2.0.17",
+				"@chakra-ui/shared-utils": "2.0.5"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/shared-utils": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/shared-utils/-/shared-utils-2.0.5.tgz",
+			"integrity": "sha512-4/Wur0FqDov7Y0nCXl7HbHzCg4aq86h+SXdoUeuCMD3dSj7dpsVnStLYhng1vxvlbUnLpdF4oz5Myt3i/a7N3Q=="
+		},
+		"node_modules/@chakra-ui/skeleton": {
+			"version": "2.0.23",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/skeleton/-/skeleton-2.0.23.tgz",
+			"integrity": "sha512-iMK50PlC9kR52v8tZWSKnZTJsOpZrqXOXaR9r/0Ry3xhdMq5hGkcigA+zKy/ZEglbMZ2CG9Fdtvi2vQurE1VZw==",
+			"dependencies": {
+				"@chakra-ui/media-query": "3.2.11",
+				"@chakra-ui/react-use-previous": "2.0.5",
+				"@chakra-ui/shared-utils": "2.0.5"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/slider": {
+			"version": "2.0.20",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/slider/-/slider-2.0.20.tgz",
+			"integrity": "sha512-5Q+9s6bIjI8GIp7YRHqt5hT678p7lCIdA/zB6c/fCp+MvOInxx4LiJZvNuaw0HX6z6bC7R/skIhmIjsgSI3MNw==",
+			"dependencies": {
+				"@chakra-ui/number-utils": "2.0.7",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-types": "2.0.7",
+				"@chakra-ui/react-use-callback-ref": "2.0.7",
+				"@chakra-ui/react-use-controllable-state": "2.0.8",
+				"@chakra-ui/react-use-latest-ref": "2.0.5",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/react-use-pan-event": "2.0.9",
+				"@chakra-ui/react-use-size": "2.0.8",
+				"@chakra-ui/react-use-update-effect": "2.0.7"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/spinner": {
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/spinner/-/spinner-2.0.13.tgz",
+			"integrity": "sha512-T1/aSkVpUIuiYyrjfn1+LsQEG7Onbi1UE9ccS/evgf61Dzy4GgTXQUnDuWFSgpV58owqirqOu6jn/9eCwDlzlg==",
+			"dependencies": {
+				"@chakra-ui/shared-utils": "2.0.5"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/stat": {
+			"version": "2.0.17",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/stat/-/stat-2.0.17.tgz",
+			"integrity": "sha512-PhD+5oVLWjQmGLfeZSmexp3AtLcaggWBwoMZ4z8QMZIQzf/fJJWMk0bMqxlpTv8ORDkfY/4ImuFB/RJHvcqlcA==",
+			"dependencies": {
+				"@chakra-ui/icon": "3.0.16",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/styled-system": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.5.2.tgz",
+			"integrity": "sha512-FVnSWcj28F2t0R6slslYnhdWL8L3+elzoNt9oXBosS9PS6u6Yh56Dqq2GH2yasOWSmuuXGCPbzOYuc0U+MlCqg==",
+			"dependencies": {
+				"@chakra-ui/shared-utils": "2.0.5",
+				"csstype": "^3.0.11",
+				"lodash.mergewith": "4.6.2"
+			}
+		},
+		"node_modules/@chakra-ui/switch": {
+			"version": "2.0.22",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/switch/-/switch-2.0.22.tgz",
+			"integrity": "sha512-+/Yy6y7VFD91uSPruF8ZvePi3tl5D8UNVATtWEQ+QBI92DLSM+PtgJ2F0Y9GMZ9NzMxpZ80DqwY7/kqcPCfLvw==",
+			"dependencies": {
+				"@chakra-ui/checkbox": "2.2.10",
+				"@chakra-ui/shared-utils": "2.0.5"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"framer-motion": ">=4.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/system": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-2.4.0.tgz",
+			"integrity": "sha512-gUX6OZVvFDMV92NtKLuawIWqvjhYc0u1LCAMeb1k3ktVBjWEYjIM4DBIirEhHjcADa8ownrTEHeW0aGxN7uxjQ==",
+			"dependencies": {
+				"@chakra-ui/color-mode": "2.1.12",
+				"@chakra-ui/object-utils": "2.0.8",
+				"@chakra-ui/react-utils": "2.0.12",
+				"@chakra-ui/styled-system": "2.5.2",
+				"@chakra-ui/theme-utils": "2.0.9",
+				"@chakra-ui/utils": "2.0.15",
+				"react-fast-compare": "3.2.0"
+			},
+			"peerDependencies": {
+				"@emotion/react": "^11.0.0",
+				"@emotion/styled": "^11.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/table": {
+			"version": "2.0.16",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/table/-/table-2.0.16.tgz",
+			"integrity": "sha512-vWDXZ6Ad3Aj66curp1tZBHvCfQHX2FJ4ijLiqGgQszWFIchfhJ5vMgEBJaFMZ+BN1draAjuRTZqaQefOApzvRg==",
+			"dependencies": {
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/tabs": {
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/tabs/-/tabs-2.1.8.tgz",
+			"integrity": "sha512-B7LeFN04Ny2jsSy5TFOQxnbZ6ITxGxLxsB2PE0vvQjMSblBrUryOxdjw80HZhfiw6od0ikK9CeKQOIt9QCguSw==",
+			"dependencies": {
+				"@chakra-ui/clickable": "2.0.14",
+				"@chakra-ui/descendant": "3.0.13",
+				"@chakra-ui/lazy-utils": "2.0.5",
+				"@chakra-ui/react-children-utils": "2.0.6",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-use-controllable-state": "2.0.8",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/react-use-safe-layout-effect": "2.0.5",
+				"@chakra-ui/shared-utils": "2.0.5"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/tag": {
+			"version": "2.0.17",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/tag/-/tag-2.0.17.tgz",
+			"integrity": "sha512-A47zE9Ft9qxOJ+5r1cUseKRCoEdqCRzFm0pOtZgRcckqavglk75Xjgz8HbBpUO2zqqd49MlqdOwR8o87fXS1vg==",
+			"dependencies": {
+				"@chakra-ui/icon": "3.0.16",
+				"@chakra-ui/react-context": "2.0.7"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/textarea": {
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/textarea/-/textarea-2.0.18.tgz",
+			"integrity": "sha512-aGHHb29vVifO0OtcK/k8cMykzjOKo/coDTU0NJqz7OOLAWIMNV2eGenvmO1n9tTZbmbqHiX+Sa1nPRX+pd14lg==",
+			"dependencies": {
+				"@chakra-ui/form-control": "2.0.17",
+				"@chakra-ui/shared-utils": "2.0.5"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/theme": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-2.2.5.tgz",
+			"integrity": "sha512-hYASZMwu0NqEv6PPydu+F3I+kMNd44yR4TwjR/lXBz/LEh64L6UPY6kQjebCfgdVtsGdl3HKg+eLlfa7SvfRgw==",
+			"dependencies": {
+				"@chakra-ui/anatomy": "2.1.2",
+				"@chakra-ui/shared-utils": "2.0.5",
+				"@chakra-ui/theme-tools": "2.0.17"
+			},
+			"peerDependencies": {
+				"@chakra-ui/styled-system": ">=2.0.0"
+			}
+		},
+		"node_modules/@chakra-ui/theme-tools": {
+			"version": "2.0.17",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-2.0.17.tgz",
+			"integrity": "sha512-Auu38hnihlJZQcPok6itRDBbwof3TpXGYtDPnOvrq4Xp7jnab36HLt7KEXSDPXbtOk3ZqU99pvI1en5LbDrdjg==",
+			"dependencies": {
+				"@chakra-ui/anatomy": "2.1.2",
+				"@chakra-ui/shared-utils": "2.0.5",
+				"color2k": "^2.0.0"
+			},
+			"peerDependencies": {
+				"@chakra-ui/styled-system": ">=2.0.0"
+			}
+		},
+		"node_modules/@chakra-ui/theme-utils": {
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/theme-utils/-/theme-utils-2.0.9.tgz",
+			"integrity": "sha512-+Nn1NooFeAr4d/OVU1NjXEMKCKCIfesYw27BoYzFYCWt/+cS/qcVdPJj+uXgK8L8xExhkREipt2r9kGlE+WpTw==",
+			"dependencies": {
+				"@chakra-ui/shared-utils": "2.0.5",
+				"@chakra-ui/styled-system": "2.5.2",
+				"@chakra-ui/theme": "2.2.5",
+				"lodash.mergewith": "4.6.2"
+			}
+		},
+		"node_modules/@chakra-ui/toast": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/toast/-/toast-5.0.1.tgz",
+			"integrity": "sha512-R66broJXhe4cd+o5/r7raF4Jg4J3W3QBHrykV7AV/W0Wiav8tL8jwSq8pMmXVnO3oGwKWZ+VHuSWmjcL65BHmg==",
+			"dependencies": {
+				"@chakra-ui/alert": "2.0.17",
+				"@chakra-ui/close-button": "2.0.17",
+				"@chakra-ui/portal": "2.0.15",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-use-timeout": "2.0.5",
+				"@chakra-ui/react-use-update-effect": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5",
+				"@chakra-ui/styled-system": "2.5.2",
+				"@chakra-ui/theme": "2.2.5"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": "2.4.0",
+				"framer-motion": ">=4.0.0",
+				"react": ">=18",
+				"react-dom": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/tooltip": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/tooltip/-/tooltip-2.2.6.tgz",
+			"integrity": "sha512-4cbneidZ5+HCWge3OZzewRQieIvhDjSsl+scrl4Scx7E0z3OmqlTIESU5nGIZDBLYqKn/UirEZhqaQ33FOS2fw==",
+			"dependencies": {
+				"@chakra-ui/popper": "3.0.13",
+				"@chakra-ui/portal": "2.0.15",
+				"@chakra-ui/react-types": "2.0.7",
+				"@chakra-ui/react-use-disclosure": "2.0.8",
+				"@chakra-ui/react-use-event-listener": "2.0.7",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			},
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"framer-motion": ">=4.0.0",
+				"react": ">=18",
+				"react-dom": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/transition": {
+			"version": "2.0.15",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/transition/-/transition-2.0.15.tgz",
+			"integrity": "sha512-o9LBK/llQfUDHF/Ty3cQ6nShpekKTqHUoJlUOzNKhoTsNpoRerr9v0jwojrX1YI02KtVjfhFU6PiqXlDfREoNw==",
+			"dependencies": {
+				"@chakra-ui/shared-utils": "2.0.5"
+			},
+			"peerDependencies": {
+				"framer-motion": ">=4.0.0",
+				"react": ">=18"
+			}
+		},
+		"node_modules/@chakra-ui/utils": {
+			"version": "2.0.15",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-2.0.15.tgz",
+			"integrity": "sha512-El4+jL0WSaYYs+rJbuYFDbjmfCcfGDmRY95GO4xwzit6YAPZBLcR65rOEwLps+XWluZTy1xdMrusg/hW0c1aAA==",
+			"dependencies": {
+				"@types/lodash.mergewith": "4.6.7",
+				"css-box-model": "1.2.1",
+				"framesync": "6.1.2",
+				"lodash.mergewith": "4.6.2"
+			}
+		},
+		"node_modules/@chakra-ui/visually-hidden": {
+			"version": "2.0.15",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/visually-hidden/-/visually-hidden-2.0.15.tgz",
+			"integrity": "sha512-WWULIiucYRBIewHKFA7BssQ2ABLHLVd9lrUo3N3SZgR0u4ZRDDVEUNOy+r+9ruDze8+36dGbN9wsN1IdELtdOw==",
+			"peerDependencies": {
+				"@chakra-ui/system": ">=2.0.0",
+				"react": ">=18"
+			}
 		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",
@@ -3246,6 +4381,64 @@
 			"integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
 			"dev": true
 		},
+		"node_modules/@motionone/animation": {
+			"version": "10.15.1",
+			"resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.15.1.tgz",
+			"integrity": "sha512-mZcJxLjHor+bhcPuIFErMDNyrdb2vJur8lSfMCsuCB4UyV8ILZLvK+t+pg56erv8ud9xQGK/1OGPt10agPrCyQ==",
+			"dependencies": {
+				"@motionone/easing": "^10.15.1",
+				"@motionone/types": "^10.15.1",
+				"@motionone/utils": "^10.15.1",
+				"tslib": "^2.3.1"
+			}
+		},
+		"node_modules/@motionone/dom": {
+			"version": "10.15.5",
+			"resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.15.5.tgz",
+			"integrity": "sha512-Xc5avlgyh3xukU9tydh9+8mB8+2zAq+WlLsC3eEIp7Ax7DnXgY7Bj/iv0a4X2R9z9ZFZiaXK3BO0xMYHKbAAdA==",
+			"dependencies": {
+				"@motionone/animation": "^10.15.1",
+				"@motionone/generators": "^10.15.1",
+				"@motionone/types": "^10.15.1",
+				"@motionone/utils": "^10.15.1",
+				"hey-listen": "^1.0.8",
+				"tslib": "^2.3.1"
+			}
+		},
+		"node_modules/@motionone/easing": {
+			"version": "10.15.1",
+			"resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.15.1.tgz",
+			"integrity": "sha512-6hIHBSV+ZVehf9dcKZLT7p5PEKHGhDwky2k8RKkmOvUoYP3S+dXsKupyZpqx5apjd9f+php4vXk4LuS+ADsrWw==",
+			"dependencies": {
+				"@motionone/utils": "^10.15.1",
+				"tslib": "^2.3.1"
+			}
+		},
+		"node_modules/@motionone/generators": {
+			"version": "10.15.1",
+			"resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.15.1.tgz",
+			"integrity": "sha512-67HLsvHJbw6cIbLA/o+gsm7h+6D4Sn7AUrB/GPxvujse1cGZ38F5H7DzoH7PhX+sjvtDnt2IhFYF2Zp1QTMKWQ==",
+			"dependencies": {
+				"@motionone/types": "^10.15.1",
+				"@motionone/utils": "^10.15.1",
+				"tslib": "^2.3.1"
+			}
+		},
+		"node_modules/@motionone/types": {
+			"version": "10.15.1",
+			"resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.15.1.tgz",
+			"integrity": "sha512-iIUd/EgUsRZGrvW0jqdst8st7zKTzS9EsKkP+6c6n4MPZoQHwiHuVtTQLD6Kp0bsBLhNzKIBlHXponn/SDT4hA=="
+		},
+		"node_modules/@motionone/utils": {
+			"version": "10.15.1",
+			"resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.15.1.tgz",
+			"integrity": "sha512-p0YncgU+iklvYr/Dq4NobTRdAPv9PveRDUXabPEeOjBLSO/1FNB2phNTZxOxpi1/GZwYpAoECEa0Wam+nsmhSw==",
+			"dependencies": {
+				"@motionone/types": "^10.15.1",
+				"hey-listen": "^1.0.8",
+				"tslib": "^2.3.1"
+			}
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4365,6 +5558,15 @@
 			"integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
 			"dev": true
 		},
+		"node_modules/@popperjs/core": {
+			"version": "2.11.6",
+			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+			"integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/popperjs"
+			}
+		},
 		"node_modules/@remix-run/router": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.0.3.tgz",
@@ -4797,6 +5999,19 @@
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
+		},
+		"node_modules/@types/lodash": {
+			"version": "4.14.191",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+			"integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ=="
+		},
+		"node_modules/@types/lodash.mergewith": {
+			"version": "4.6.7",
+			"resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.7.tgz",
+			"integrity": "sha512-3m+lkO5CLRRYU0fhGRp7zbsGi6+BZj0uTVSwvcKU+nSlhjA9/QRNfuSGnD2mX6hQA7ZbmcCkzk5h4ZYGOtk14A==",
+			"dependencies": {
+				"@types/lodash": "*"
+			}
 		},
 		"node_modules/@types/mime": {
 			"version": "3.0.1",
@@ -5477,6 +6692,16 @@
 				"node": ">=14.15.0"
 			}
 		},
+		"node_modules/@zag-js/element-size": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@zag-js/element-size/-/element-size-0.3.0.tgz",
+			"integrity": "sha512-5/hEI+0c6ZNCx6KHlOS5/WeHsd6+I7gk7Y/b/zATp4Rp3tHirs/tu1frq+iy5BmfaG9hbQtfHfUJTjOcI5jnoQ=="
+		},
+		"node_modules/@zag-js/focus-visible": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-0.2.1.tgz",
+			"integrity": "sha512-19uTjoZGP4/Ax7kSNhhay9JA83BirKzpqLkeEAilrpdI1hE5xuq6q+tzJOsrMOOqJrm7LkmZp5lbsTQzvK2pYg=="
+		},
 		"node_modules/@zkochan/js-yaml": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz",
@@ -5745,6 +6970,26 @@
 			"dev": true,
 			"dependencies": {
 				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/aria-hidden": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.2.tgz",
+			"integrity": "sha512-6y/ogyDTk/7YAe91T3E2PR1ALVKyM2QbTio5HwM+N1Q6CMlCKhvClyIjkckBswa0f2xJhjsfzIGa1yVSe1UMVA==",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
+				"react": "^16.9.0 || ^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/aria-query": {
@@ -6595,9 +7840,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001448",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001448.tgz",
-			"integrity": "sha512-tq2YI+MJnooG96XpbTRYkBxLxklZPOdLmNIOdIhvf7SNJan6u5vCKum8iT7ZfCt70m1GPkuC7P3TtX6UuhupuA==",
+			"version": "1.0.30001449",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001449.tgz",
+			"integrity": "sha512-CPB+UL9XMT/Av+pJxCKGhdx+yg1hzplvFJQlJ2n68PyQGMz9L/E2zCyLdOL8uasbouTUgnPl+y0tccI/se+BEw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -6810,6 +8055,11 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
 		},
+		"node_modules/color2k": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.1.tgz",
+			"integrity": "sha512-iCg+xrEqtYISsSJZN1z44fyhv4EfX8lSkcDhodt6VnMf1+iMwZxAtmGXchTCeMUnTbXunGvUVK6E3skkApPnZw=="
+		},
 		"node_modules/colord": {
 			"version": "2.9.3",
 			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
@@ -6900,6 +8150,11 @@
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"dev": true
 		},
+		"node_modules/compute-scroll-into-view": {
+			"version": "1.0.14",
+			"resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.14.tgz",
+			"integrity": "sha512-mKDjINe3tc6hGelUMNDzuhorIUZ7kS7BwyY0r2wQd2HOH2tRuJykiC06iSEX8y1TuhNzvz4GcJnK16mM2J1NMQ=="
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6961,6 +8216,14 @@
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
 			"integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
 			"dev": true
+		},
+		"node_modules/copy-to-clipboard": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+			"integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+			"dependencies": {
+				"toggle-selection": "^1.0.6"
+			}
 		},
 		"node_modules/copy-webpack-plugin": {
 			"version": "10.2.4",
@@ -7156,6 +8419,14 @@
 				"inherits": "^2.0.4",
 				"source-map": "^0.6.1",
 				"source-map-resolve": "^0.6.0"
+			}
+		},
+		"node_modules/css-box-model": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+			"integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+			"dependencies": {
+				"tiny-invariant": "^1.0.6"
 			}
 		},
 		"node_modules/css-declaration-sorter": {
@@ -7746,6 +9017,11 @@
 			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
 			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
 			"dev": true
+		},
+		"node_modules/detect-node-es": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+			"integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
 		},
 		"node_modules/diff": {
 			"version": "4.0.2",
@@ -10080,6 +11356,17 @@
 			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
 			"dev": true
 		},
+		"node_modules/focus-lock": {
+			"version": "0.11.4",
+			"resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.4.tgz",
+			"integrity": "sha512-LzZWJcOBIcHslQ46N3SUu/760iLPSrUtp8omM4gh9du438V2CQdks8TcOu1yvmu2C68nVOBnl1WFiKGPbQ8L6g==",
+			"dependencies": {
+				"tslib": "^2.0.3"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/follow-redirects": {
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
@@ -10327,6 +11614,51 @@
 				"url": "https://www.patreon.com/infusion"
 			}
 		},
+		"node_modules/framer-motion": {
+			"version": "8.5.3",
+			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-8.5.3.tgz",
+			"integrity": "sha512-CkQHhGlldJptI0SGjmjUzseXCzi0lljDkToE7cANHRCs12F5I84ymdWvCi6HfIKkt6Ykq2RiDd3dGuYV0oMn2w==",
+			"dependencies": {
+				"@motionone/dom": "^10.15.3",
+				"hey-listen": "^1.0.8",
+				"tslib": "^2.4.0"
+			},
+			"optionalDependencies": {
+				"@emotion/is-prop-valid": "^0.8.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/framer-motion/node_modules/@emotion/is-prop-valid": {
+			"version": "0.8.8",
+			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+			"integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+			"optional": true,
+			"dependencies": {
+				"@emotion/memoize": "0.7.4"
+			}
+		},
+		"node_modules/framer-motion/node_modules/@emotion/memoize": {
+			"version": "0.7.4",
+			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+			"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+			"optional": true
+		},
+		"node_modules/framesync": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/framesync/-/framesync-6.1.2.tgz",
+			"integrity": "sha512-jBTqhX6KaQVDyus8muwZbBeGGP0XgujBRbQ7gM7BRdS3CadCZIHiawyzYLnafYcvZIh5j8WE7cxZKFn7dXhu9g==",
+			"dependencies": {
+				"tslib": "2.4.0"
+			}
+		},
+		"node_modules/framesync/node_modules/tslib": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+		},
 		"node_modules/fresh": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -10470,6 +11802,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-nonce": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+			"integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/get-package-type": {
@@ -10747,6 +12087,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/hey-listen": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
+			"integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
 		},
 		"node_modules/hoist-non-react-statics": {
 			"version": "3.3.2",
@@ -11108,6 +12453,14 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/invariant": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"dependencies": {
+				"loose-envify": "^1.0.0"
 			}
 		},
 		"node_modules/ipaddr.js": {
@@ -15486,6 +16839,11 @@
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
 		},
+		"node_modules/lodash.mergewith": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+			"integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
+		},
 		"node_modules/lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -16233,7 +17591,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -17398,7 +18755,6 @@
 			"version": "15.8.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
 			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
@@ -17558,6 +18914,17 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/react-clientside-effect": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz",
+			"integrity": "sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==",
+			"dependencies": {
+				"@babel/runtime": "^7.12.13"
+			},
+			"peerDependencies": {
+				"react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
 		"node_modules/react-dom": {
 			"version": "18.2.0",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -17568,6 +18935,33 @@
 			},
 			"peerDependencies": {
 				"react": "^18.2.0"
+			}
+		},
+		"node_modules/react-fast-compare": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+			"integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+		},
+		"node_modules/react-focus-lock": {
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.2.tgz",
+			"integrity": "sha512-5JfrsOKyA5Zn3h958mk7bAcfphr24jPoMoznJ8vaJF6fUrPQ8zrtEd3ILLOK8P5jvGxdMd96OxWNjDzATfR2qw==",
+			"dependencies": {
+				"@babel/runtime": "^7.0.0",
+				"focus-lock": "^0.11.2",
+				"prop-types": "^15.6.2",
+				"react-clientside-effect": "^1.2.6",
+				"use-callback-ref": "^1.3.0",
+				"use-sidecar": "^1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/react-is": {
@@ -17582,6 +18976,51 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-remove-scroll": {
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
+			"integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
+			"dependencies": {
+				"react-remove-scroll-bar": "^2.3.3",
+				"react-style-singleton": "^2.2.1",
+				"tslib": "^2.1.0",
+				"use-callback-ref": "^1.3.0",
+				"use-sidecar": "^1.1.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/react-remove-scroll-bar": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz",
+			"integrity": "sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==",
+			"dependencies": {
+				"react-style-singleton": "^2.2.1",
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/react-router": {
@@ -17625,6 +19064,28 @@
 			},
 			"peerDependencies": {
 				"react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/react-style-singleton": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+			"integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+			"dependencies": {
+				"get-nonce": "^1.0.0",
+				"invariant": "^2.2.4",
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/react-table": {
@@ -19195,6 +20656,11 @@
 				"globrex": "^0.1.2"
 			}
 		},
+		"node_modules/tiny-invariant": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+			"integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
+		},
 		"node_modules/tiny-lru": {
 			"version": "10.0.1",
 			"resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-10.0.1.tgz",
@@ -19211,9 +20677,9 @@
 			"dev": true
 		},
 		"node_modules/tinypool": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.3.0.tgz",
-			"integrity": "sha512-NX5KeqHOBZU6Bc0xj9Vr5Szbb1j8tUHIeD18s41aDJaPeC5QTdEhK0SpdpUrZlj2nv5cctNcSjaKNanXlfcVEQ==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.3.1.tgz",
+			"integrity": "sha512-zLA1ZXlstbU2rlpA4CIeVaqvWq41MTWqLY3FfsAXgC8+f7Pk7zroaJQxDgxn1xNudKW6Kmj4808rPFShUlIRmQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=14.0.0"
@@ -19265,6 +20731,11 @@
 			"engines": {
 				"node": ">=8.0"
 			}
+		},
+		"node_modules/toggle-selection": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+			"integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
 		},
 		"node_modules/toidentifier": {
 			"version": "1.0.1",
@@ -19695,9 +21166,9 @@
 			}
 		},
 		"node_modules/tslib": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
 		},
 		"node_modules/tsutils": {
 			"version": "3.21.0",
@@ -19874,6 +21345,47 @@
 			"dependencies": {
 				"querystringify": "^2.1.1",
 				"requires-port": "^1.0.0"
+			}
+		},
+		"node_modules/use-callback-ref": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
+			"integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/use-sidecar": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+			"integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+			"dependencies": {
+				"detect-node-es": "^1.1.0",
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -21260,6 +22772,872 @@
 			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
+		},
+		"@chakra-ui/accordion": {
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/accordion/-/accordion-2.1.8.tgz",
+			"integrity": "sha512-RTXYhL85dUSVUEurDicxS76JaCXa/L4FYWPAxPSisbZtFvL+/gvoFMcGtT8ZRsJwFWaevmkD+57EmOYCWlLL1A==",
+			"requires": {
+				"@chakra-ui/descendant": "3.0.13",
+				"@chakra-ui/icon": "3.0.16",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-use-controllable-state": "2.0.8",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5",
+				"@chakra-ui/transition": "2.0.15"
+			}
+		},
+		"@chakra-ui/alert": {
+			"version": "2.0.17",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/alert/-/alert-2.0.17.tgz",
+			"integrity": "sha512-0Y5vw+HkeXpwbL1roVpSSNM6luMRmUbwduUSHEA4OnX1ismvsDb1ZBfpi4Vxp6w8euJ2Uj6df3krbd5tbCP6tg==",
+			"requires": {
+				"@chakra-ui/icon": "3.0.16",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5",
+				"@chakra-ui/spinner": "2.0.13"
+			}
+		},
+		"@chakra-ui/anatomy": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.1.2.tgz",
+			"integrity": "sha512-pKfOS/mztc4sUXHNc8ypJ1gPWSolWT770jrgVRfolVbYlki8y5Y+As996zMF6k5lewTu6j9DQequ7Cc9a69IVQ=="
+		},
+		"@chakra-ui/avatar": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/avatar/-/avatar-2.2.4.tgz",
+			"integrity": "sha512-OUuZAhabW0FgmFVt0djH3cVR8p9bKC3vYT3Ol2lrUz3hbf4LrjU5EzmMHmQvcbSs6bNDxS3k9hnswLebOFctJQ==",
+			"requires": {
+				"@chakra-ui/image": "2.0.15",
+				"@chakra-ui/react-children-utils": "2.0.6",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/breadcrumb": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/breadcrumb/-/breadcrumb-2.1.4.tgz",
+			"integrity": "sha512-vyBx5TAxPnHhb0b8nyRGfqyjleD//9mySFhk96c9GL+T6YDO4swHw5y/kvDv3Ngc/iRwJ9hdI49PZKwPxLqsEg==",
+			"requires": {
+				"@chakra-ui/react-children-utils": "2.0.6",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/breakpoint-utils": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/breakpoint-utils/-/breakpoint-utils-2.0.7.tgz",
+			"integrity": "sha512-YBwsDPMlaMRZ4fKc2WyIIaUmByzkiP4ozxMJIjJRPhedzSho7FOZuE8532q+97f2SyY8z/yZPJ41q4GdwHI/HQ==",
+			"requires": {
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/button": {
+			"version": "2.0.16",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/button/-/button-2.0.16.tgz",
+			"integrity": "sha512-NjuTKa7gNhnGSUutKuTc8HoAOe9WWIigpciBG7yj3ok67kg8bXtSzPyQFZlgTY6XGdAckWTT+Do4tvhwa5LA+g==",
+			"requires": {
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5",
+				"@chakra-ui/spinner": "2.0.13"
+			}
+		},
+		"@chakra-ui/card": {
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/card/-/card-2.1.6.tgz",
+			"integrity": "sha512-fFd/WAdRNVY/WOSQv4skpy0WeVhhI0f7dTY1Sm0jVl0KLmuP/GnpsWtKtqWjNcV00K963EXDyhlk6+9oxbP4gw==",
+			"requires": {
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/checkbox": {
+			"version": "2.2.10",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/checkbox/-/checkbox-2.2.10.tgz",
+			"integrity": "sha512-vzxEjw99qj7loxAdP1WuHNt4EAvj/t6cc8oxyOB2mEvkAzhxI34rLR+3zWDuHWsmhyUO+XEDh4FiWdR+DK5Siw==",
+			"requires": {
+				"@chakra-ui/form-control": "2.0.17",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-types": "2.0.7",
+				"@chakra-ui/react-use-callback-ref": "2.0.7",
+				"@chakra-ui/react-use-controllable-state": "2.0.8",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/react-use-safe-layout-effect": "2.0.5",
+				"@chakra-ui/react-use-update-effect": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5",
+				"@chakra-ui/visually-hidden": "2.0.15",
+				"@zag-js/focus-visible": "0.2.1"
+			}
+		},
+		"@chakra-ui/clickable": {
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/clickable/-/clickable-2.0.14.tgz",
+			"integrity": "sha512-jfsM1qaD74ZykLHmvmsKRhDyokLUxEfL8Il1VoZMNX5RBI0xW/56vKpLTFF/v/+vLPLS+Te2cZdD4+2O+G6ulA==",
+			"requires": {
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/close-button": {
+			"version": "2.0.17",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/close-button/-/close-button-2.0.17.tgz",
+			"integrity": "sha512-05YPXk456t1Xa3KpqTrvm+7smx+95dmaPiwjiBN3p7LHUQVHJd8ZXSDB0V+WKi419k3cVQeJUdU/azDO2f40sw==",
+			"requires": {
+				"@chakra-ui/icon": "3.0.16"
+			}
+		},
+		"@chakra-ui/color-mode": {
+			"version": "2.1.12",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/color-mode/-/color-mode-2.1.12.tgz",
+			"integrity": "sha512-sYyfJGDoJSLYO+V2hxV9r033qhte5Nw/wAn5yRGGZnEEN1dKPEdWQ3XZvglWSDTNd0w9zkoH2w6vP4FBBYb/iw==",
+			"requires": {
+				"@chakra-ui/react-use-safe-layout-effect": "2.0.5"
+			}
+		},
+		"@chakra-ui/control-box": {
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/control-box/-/control-box-2.0.13.tgz",
+			"integrity": "sha512-FEyrU4crxati80KUF/+1Z1CU3eZK6Sa0Yv7Z/ydtz9/tvGblXW9NFanoomXAOvcIFLbaLQPPATm9Gmpr7VG05A==",
+			"requires": {}
+		},
+		"@chakra-ui/counter": {
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/counter/-/counter-2.0.14.tgz",
+			"integrity": "sha512-KxcSRfUbb94dP77xTip2myoE7P2HQQN4V5fRJmNAGbzcyLciJ+aDylUU/UxgNcEjawUp6Q242NbWb1TSbKoqog==",
+			"requires": {
+				"@chakra-ui/number-utils": "2.0.7",
+				"@chakra-ui/react-use-callback-ref": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/css-reset": {
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/css-reset/-/css-reset-2.0.12.tgz",
+			"integrity": "sha512-Q5OYIMvqTl2vZ947kIYxcS5DhQXeStB84BzzBd6C10wOx1gFUu9pL+jLpOnHR3hhpWRMdX5o7eT+gMJWIYUZ0Q==",
+			"requires": {}
+		},
+		"@chakra-ui/descendant": {
+			"version": "3.0.13",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/descendant/-/descendant-3.0.13.tgz",
+			"integrity": "sha512-9nzxZVxUSMc4xPL5fSaRkEOQjDQWUGjGvrZI7VzWk9eq63cojOtIxtWMSW383G9148PzWJjJYt30Eud5tdZzlg==",
+			"requires": {
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-use-merge-refs": "2.0.7"
+			}
+		},
+		"@chakra-ui/dom-utils": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/dom-utils/-/dom-utils-2.0.6.tgz",
+			"integrity": "sha512-PVtDkPrDD5b8aoL6Atg7SLjkwhWb7BwMcLOF1L449L3nZN+DAO3nyAh6iUhZVJyunELj9d0r65CDlnMREyJZmA=="
+		},
+		"@chakra-ui/editable": {
+			"version": "2.0.19",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/editable/-/editable-2.0.19.tgz",
+			"integrity": "sha512-YxRJsJ2JQd42zfPBgTKzIhg1HugT+gfQz1ZosmUN+IZT9YZXL2yodHTUz6Lee04Vc/CdEqgBFLuREXEUNBfGtA==",
+			"requires": {
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-types": "2.0.7",
+				"@chakra-ui/react-use-callback-ref": "2.0.7",
+				"@chakra-ui/react-use-controllable-state": "2.0.8",
+				"@chakra-ui/react-use-focus-on-pointer-down": "2.0.6",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/react-use-safe-layout-effect": "2.0.5",
+				"@chakra-ui/react-use-update-effect": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/event-utils": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/event-utils/-/event-utils-2.0.8.tgz",
+			"integrity": "sha512-IGM/yGUHS+8TOQrZGpAKOJl/xGBrmRYJrmbHfUE7zrG3PpQyXvbLDP1M+RggkCFVgHlJi2wpYIf0QtQlU0XZfw=="
+		},
+		"@chakra-ui/focus-lock": {
+			"version": "2.0.16",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/focus-lock/-/focus-lock-2.0.16.tgz",
+			"integrity": "sha512-UuAdGCPVrCa1lecoAvpOQD7JFT7a9RdmhKWhFt5ioIcekSLJcerdLHuuL3w0qz//8kd1/SOt7oP0aJqdAJQrCw==",
+			"requires": {
+				"@chakra-ui/dom-utils": "2.0.6",
+				"react-focus-lock": "^2.9.2"
+			}
+		},
+		"@chakra-ui/form-control": {
+			"version": "2.0.17",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/form-control/-/form-control-2.0.17.tgz",
+			"integrity": "sha512-34ptCaJ2LNvQNOlB6MAKsmH1AkT1xo7E+3Vw10Urr81yTOjDTM/iU6vG3JKPfRDMyXeowPjXmutlnuk72SSjRg==",
+			"requires": {
+				"@chakra-ui/icon": "3.0.16",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-types": "2.0.7",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/hooks": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-2.1.5.tgz",
+			"integrity": "sha512-E3bGwxjXvMUc9ev3egctrRi5fnER5xXbWUsivA3iFRdUrkfX+19JLUfP1TURzv7UQG8X1AxKSwfqIsYyeHrdmQ==",
+			"requires": {
+				"@chakra-ui/react-utils": "2.0.12",
+				"@chakra-ui/utils": "2.0.15",
+				"compute-scroll-into-view": "1.0.14",
+				"copy-to-clipboard": "3.3.1"
+			}
+		},
+		"@chakra-ui/icon": {
+			"version": "3.0.16",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-3.0.16.tgz",
+			"integrity": "sha512-RpA1X5Ptz8Mt39HSyEIW1wxAz2AXyf9H0JJ5HVx/dBdMZaGMDJ0HyyPBVci0m4RCoJuyG1HHG/DXJaVfUTVAeg==",
+			"requires": {
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/image": {
+			"version": "2.0.15",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-2.0.15.tgz",
+			"integrity": "sha512-w2rElXtI3FHXuGpMCsSklus+pO1Pl2LWDwsCGdpBQUvGFbnHfl7MftQgTlaGHeD5OS95Pxva39hKrA2VklKHiQ==",
+			"requires": {
+				"@chakra-ui/react-use-safe-layout-effect": "2.0.5",
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/input": {
+			"version": "2.0.19",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/input/-/input-2.0.19.tgz",
+			"integrity": "sha512-wV+EG6+F9GngMPpLHBCuxXTNttHihFTT3DpbJnmID9LuAPg7YkWcTNTvpAzC0/Sz9KrcTR9RhSu9a5cvxkkXpw==",
+			"requires": {
+				"@chakra-ui/form-control": "2.0.17",
+				"@chakra-ui/object-utils": "2.0.8",
+				"@chakra-ui/react-children-utils": "2.0.6",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/layout": {
+			"version": "2.1.15",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/layout/-/layout-2.1.15.tgz",
+			"integrity": "sha512-dJYzBm2ywRYNmtadot/5ii+Gztsx8a9Jd+gFXiSLcfQs/QRdboqMyr/0O+6RY2sI7Mwvyo6uo9AvGJBU1djrNQ==",
+			"requires": {
+				"@chakra-ui/breakpoint-utils": "2.0.7",
+				"@chakra-ui/icon": "3.0.16",
+				"@chakra-ui/object-utils": "2.0.8",
+				"@chakra-ui/react-children-utils": "2.0.6",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/lazy-utils": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/lazy-utils/-/lazy-utils-2.0.5.tgz",
+			"integrity": "sha512-UULqw7FBvcckQk2n3iPO56TMJvDsNv0FKZI6PlUNJVaGsPbsYxK/8IQ60vZgaTVPtVcjY6BE+y6zg8u9HOqpyg=="
+		},
+		"@chakra-ui/live-region": {
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/live-region/-/live-region-2.0.13.tgz",
+			"integrity": "sha512-Ja+Slk6ZkxSA5oJzU2VuGU7TpZpbMb/4P4OUhIf2D30ctmIeXkxTWw1Bs1nGJAVtAPcGS5sKA+zb89i8g+0cTQ==",
+			"requires": {}
+		},
+		"@chakra-ui/media-query": {
+			"version": "3.2.11",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-3.2.11.tgz",
+			"integrity": "sha512-AylT/qIpbCOvcjvURMdItLvAnaEYZynatvVJUQ8TYcQO2KHBt8BBhQ9umrmNAZFr8y7CRcg7PdvK+g+yOkq22g==",
+			"requires": {
+				"@chakra-ui/breakpoint-utils": "2.0.7",
+				"@chakra-ui/react-env": "3.0.0",
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/menu": {
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/menu/-/menu-2.1.8.tgz",
+			"integrity": "sha512-3Ysk1HwJTv6mzkT1dgsNObZnuZiySPJwLdmmCdv8+rpto8u0oCN+etenN0s7HQlAddvHxZ2Sm+1yKZOu6Wimrg==",
+			"requires": {
+				"@chakra-ui/clickable": "2.0.14",
+				"@chakra-ui/descendant": "3.0.13",
+				"@chakra-ui/lazy-utils": "2.0.5",
+				"@chakra-ui/popper": "3.0.13",
+				"@chakra-ui/react-children-utils": "2.0.6",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-use-animation-state": "2.0.8",
+				"@chakra-ui/react-use-controllable-state": "2.0.8",
+				"@chakra-ui/react-use-disclosure": "2.0.8",
+				"@chakra-ui/react-use-focus-effect": "2.0.9",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/react-use-outside-click": "2.0.7",
+				"@chakra-ui/react-use-update-effect": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5",
+				"@chakra-ui/transition": "2.0.15"
+			}
+		},
+		"@chakra-ui/modal": {
+			"version": "2.2.9",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/modal/-/modal-2.2.9.tgz",
+			"integrity": "sha512-nTfNp7XsVwn5+xJOtstoFA8j0kq/9sJj7KesyYzjEDaMKvCZvIOntRYowoydho43jb4+YC7ebKhp0KOIINS0gg==",
+			"requires": {
+				"@chakra-ui/close-button": "2.0.17",
+				"@chakra-ui/focus-lock": "2.0.16",
+				"@chakra-ui/portal": "2.0.15",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-types": "2.0.7",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5",
+				"@chakra-ui/transition": "2.0.15",
+				"aria-hidden": "^1.2.2",
+				"react-remove-scroll": "^2.5.5"
+			}
+		},
+		"@chakra-ui/number-input": {
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/number-input/-/number-input-2.0.18.tgz",
+			"integrity": "sha512-cPkyAFFHHzeFBselrT1BtjlzMkJ6TKrTDUnHFlzqXy6aqeXuhrjFhMfXucjedSpOqedsP9ZbKFTdIAhu9DdL/A==",
+			"requires": {
+				"@chakra-ui/counter": "2.0.14",
+				"@chakra-ui/form-control": "2.0.17",
+				"@chakra-ui/icon": "3.0.16",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-types": "2.0.7",
+				"@chakra-ui/react-use-callback-ref": "2.0.7",
+				"@chakra-ui/react-use-event-listener": "2.0.7",
+				"@chakra-ui/react-use-interval": "2.0.5",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/react-use-safe-layout-effect": "2.0.5",
+				"@chakra-ui/react-use-update-effect": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/number-utils": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/number-utils/-/number-utils-2.0.7.tgz",
+			"integrity": "sha512-yOGxBjXNvLTBvQyhMDqGU0Oj26s91mbAlqKHiuw737AXHt0aPllOthVUqQMeaYLwLCjGMg0jtI7JReRzyi94Dg=="
+		},
+		"@chakra-ui/object-utils": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/object-utils/-/object-utils-2.0.8.tgz",
+			"integrity": "sha512-2upjT2JgRuiupdrtBWklKBS6tqeGMA77Nh6Q0JaoQuH/8yq+15CGckqn3IUWkWoGI0Fg3bK9LDlbbD+9DLw95Q=="
+		},
+		"@chakra-ui/pin-input": {
+			"version": "2.0.19",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/pin-input/-/pin-input-2.0.19.tgz",
+			"integrity": "sha512-6O7s4vWz4cqQ6zvMov9sYj6ZqWAsTxR/MNGe3DNgu1zWQg8veNCYtj1rNGhNS3eZNUMAa8uM2dXIphGTP53Xow==",
+			"requires": {
+				"@chakra-ui/descendant": "3.0.13",
+				"@chakra-ui/react-children-utils": "2.0.6",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-use-controllable-state": "2.0.8",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/popover": {
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/popover/-/popover-2.1.8.tgz",
+			"integrity": "sha512-ob7fAz+WWmXIq7iGHVB3wDKzZTj+T+noYBT/U1Q+jIf+jMr2WOpJLTfb0HTZcfhvn4EBFlfBg7Wk5qbXNaOn7g==",
+			"requires": {
+				"@chakra-ui/close-button": "2.0.17",
+				"@chakra-ui/lazy-utils": "2.0.5",
+				"@chakra-ui/popper": "3.0.13",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-types": "2.0.7",
+				"@chakra-ui/react-use-animation-state": "2.0.8",
+				"@chakra-ui/react-use-disclosure": "2.0.8",
+				"@chakra-ui/react-use-focus-effect": "2.0.9",
+				"@chakra-ui/react-use-focus-on-pointer-down": "2.0.6",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/popper": {
+			"version": "3.0.13",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/popper/-/popper-3.0.13.tgz",
+			"integrity": "sha512-FwtmYz80Ju8oK3Z1HQfisUE7JIMmDsCQsRBu6XuJ3TFQnBHit73yjZmxKjuRJ4JgyT4WBnZoTF3ATbRKSagBeg==",
+			"requires": {
+				"@chakra-ui/react-types": "2.0.7",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@popperjs/core": "^2.9.3"
+			}
+		},
+		"@chakra-ui/portal": {
+			"version": "2.0.15",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/portal/-/portal-2.0.15.tgz",
+			"integrity": "sha512-z8v7K3j1/nMuBzp2+wRIIw7s/eipVtnXLdjK5yqbMxMRa44E8Mu5VNJLz3aQFLHXEUST+ifqrjImQeli9do6LQ==",
+			"requires": {
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-use-safe-layout-effect": "2.0.5"
+			}
+		},
+		"@chakra-ui/progress": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/progress/-/progress-2.1.5.tgz",
+			"integrity": "sha512-jj5Vp4lxUchuwp4RPCepM0yAyKi344bgsOd3Apd+ldxclDcewPc82fbwDu7g/Xv27LqJkT+7E/SlQy04wGrk0g==",
+			"requires": {
+				"@chakra-ui/react-context": "2.0.7"
+			}
+		},
+		"@chakra-ui/provider": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/provider/-/provider-2.1.0.tgz",
+			"integrity": "sha512-+NUBHOkqWFpi/unwqhUQh1t/S1+TMZBTz+FiTeWycSUicdFsGCcTe6eQNLu6X5C8gYx9FGXG4ESx7HCTNXQj7w==",
+			"requires": {
+				"@chakra-ui/css-reset": "2.0.12",
+				"@chakra-ui/portal": "2.0.15",
+				"@chakra-ui/react-env": "3.0.0",
+				"@chakra-ui/system": "2.4.0",
+				"@chakra-ui/utils": "2.0.15"
+			}
+		},
+		"@chakra-ui/radio": {
+			"version": "2.0.19",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/radio/-/radio-2.0.19.tgz",
+			"integrity": "sha512-PlJiV59eGSmeKP4v/4+ccQUWGRd0cjPKkj/p3L+UbOf8pl9dWm8y9kIeL5TYbghQSDv0nzkrH4+yMnnDTZjdMQ==",
+			"requires": {
+				"@chakra-ui/form-control": "2.0.17",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-types": "2.0.7",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5",
+				"@zag-js/focus-visible": "0.2.1"
+			}
+		},
+		"@chakra-ui/react": {
+			"version": "2.4.9",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-2.4.9.tgz",
+			"integrity": "sha512-lY++xW+zhLp0zQr2Sf5phjYMIphOmjGV/o5A1oDQPrqwLJFm4mL2+eXvpAFrLnZoh00qa4iBqarxJCW7qpHeiA==",
+			"requires": {
+				"@chakra-ui/accordion": "2.1.8",
+				"@chakra-ui/alert": "2.0.17",
+				"@chakra-ui/avatar": "2.2.4",
+				"@chakra-ui/breadcrumb": "2.1.4",
+				"@chakra-ui/button": "2.0.16",
+				"@chakra-ui/card": "2.1.6",
+				"@chakra-ui/checkbox": "2.2.10",
+				"@chakra-ui/close-button": "2.0.17",
+				"@chakra-ui/control-box": "2.0.13",
+				"@chakra-ui/counter": "2.0.14",
+				"@chakra-ui/css-reset": "2.0.12",
+				"@chakra-ui/editable": "2.0.19",
+				"@chakra-ui/form-control": "2.0.17",
+				"@chakra-ui/hooks": "2.1.5",
+				"@chakra-ui/icon": "3.0.16",
+				"@chakra-ui/image": "2.0.15",
+				"@chakra-ui/input": "2.0.19",
+				"@chakra-ui/layout": "2.1.15",
+				"@chakra-ui/live-region": "2.0.13",
+				"@chakra-ui/media-query": "3.2.11",
+				"@chakra-ui/menu": "2.1.8",
+				"@chakra-ui/modal": "2.2.9",
+				"@chakra-ui/number-input": "2.0.18",
+				"@chakra-ui/pin-input": "2.0.19",
+				"@chakra-ui/popover": "2.1.8",
+				"@chakra-ui/popper": "3.0.13",
+				"@chakra-ui/portal": "2.0.15",
+				"@chakra-ui/progress": "2.1.5",
+				"@chakra-ui/provider": "2.1.0",
+				"@chakra-ui/radio": "2.0.19",
+				"@chakra-ui/react-env": "3.0.0",
+				"@chakra-ui/select": "2.0.18",
+				"@chakra-ui/skeleton": "2.0.23",
+				"@chakra-ui/slider": "2.0.20",
+				"@chakra-ui/spinner": "2.0.13",
+				"@chakra-ui/stat": "2.0.17",
+				"@chakra-ui/styled-system": "2.5.2",
+				"@chakra-ui/switch": "2.0.22",
+				"@chakra-ui/system": "2.4.0",
+				"@chakra-ui/table": "2.0.16",
+				"@chakra-ui/tabs": "2.1.8",
+				"@chakra-ui/tag": "2.0.17",
+				"@chakra-ui/textarea": "2.0.18",
+				"@chakra-ui/theme": "2.2.5",
+				"@chakra-ui/theme-utils": "2.0.9",
+				"@chakra-ui/toast": "5.0.1",
+				"@chakra-ui/tooltip": "2.2.6",
+				"@chakra-ui/transition": "2.0.15",
+				"@chakra-ui/utils": "2.0.15",
+				"@chakra-ui/visually-hidden": "2.0.15"
+			}
+		},
+		"@chakra-ui/react-children-utils": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-children-utils/-/react-children-utils-2.0.6.tgz",
+			"integrity": "sha512-QVR2RC7QsOsbWwEnq9YduhpqSFnZGvjjGREV8ygKi8ADhXh93C8azLECCUVgRJF2Wc+So1fgxmjLcbZfY2VmBA==",
+			"requires": {}
+		},
+		"@chakra-ui/react-context": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-context/-/react-context-2.0.7.tgz",
+			"integrity": "sha512-i7EGmSU+h2GB30cwrKB4t1R5BMHyGoJM5L2Zz7b+ZUX4aAqyPcfe97wPiQB6Rgr1ImGXrUeov4CDVrRZ2FPgLQ==",
+			"requires": {}
+		},
+		"@chakra-ui/react-env": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-env/-/react-env-3.0.0.tgz",
+			"integrity": "sha512-tfMRO2v508HQWAqSADFrwZgR9oU10qC97oV6zGbjHh9ALP0/IcFR+Bi71KRTveDTm85fMeAzZYGj57P3Dsipkw==",
+			"requires": {
+				"@chakra-ui/react-use-safe-layout-effect": "2.0.5"
+			}
+		},
+		"@chakra-ui/react-types": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-types/-/react-types-2.0.7.tgz",
+			"integrity": "sha512-12zv2qIZ8EHwiytggtGvo4iLT0APris7T0qaAWqzpUGS0cdUtR8W+V1BJ5Ocq+7tA6dzQ/7+w5hmXih61TuhWQ==",
+			"requires": {}
+		},
+		"@chakra-ui/react-use-animation-state": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-animation-state/-/react-use-animation-state-2.0.8.tgz",
+			"integrity": "sha512-xv9zSF2Rd1mHWQ+m5DLBWeh4atF8qrNvsOs3MNrvxKYBS3f79N3pqcQGrWAEvirXWXfiCeje2VAkEggqFRIo+Q==",
+			"requires": {
+				"@chakra-ui/dom-utils": "2.0.6",
+				"@chakra-ui/react-use-event-listener": "2.0.7"
+			}
+		},
+		"@chakra-ui/react-use-callback-ref": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-callback-ref/-/react-use-callback-ref-2.0.7.tgz",
+			"integrity": "sha512-YjT76nTpfHAK5NxplAlZsQwNju5KmQExnqsWNPFeOR6vvbC34+iPSTr+r91i1Hdy7gBSbevsOsd5Wm6RN3GuMw==",
+			"requires": {}
+		},
+		"@chakra-ui/react-use-controllable-state": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-controllable-state/-/react-use-controllable-state-2.0.8.tgz",
+			"integrity": "sha512-F7rdCbLEmRjwwODqWZ3y+mKgSSHPcLQxeUygwk1BkZPXbKkJJKymOIjIynil2cbH7ku3hcSIWRvuhpCcfQWJ7Q==",
+			"requires": {
+				"@chakra-ui/react-use-callback-ref": "2.0.7"
+			}
+		},
+		"@chakra-ui/react-use-disclosure": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-disclosure/-/react-use-disclosure-2.0.8.tgz",
+			"integrity": "sha512-2ir/mHe1YND40e+FyLHnDsnDsBQPwzKDLzfe9GZri7y31oU83JSbHdlAXAhp3bpjohslwavtRCp+S/zRxfO9aQ==",
+			"requires": {
+				"@chakra-ui/react-use-callback-ref": "2.0.7"
+			}
+		},
+		"@chakra-ui/react-use-event-listener": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-event-listener/-/react-use-event-listener-2.0.7.tgz",
+			"integrity": "sha512-4wvpx4yudIO3B31pOrXuTHDErawmwiXnvAN7gLEOVREi16+YGNcFnRJ5X5nRrmB7j2MDUtsEDpRBFfw5Z9xQ5g==",
+			"requires": {
+				"@chakra-ui/react-use-callback-ref": "2.0.7"
+			}
+		},
+		"@chakra-ui/react-use-focus-effect": {
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-focus-effect/-/react-use-focus-effect-2.0.9.tgz",
+			"integrity": "sha512-20nfNkpbVwyb41q9wxp8c4jmVp6TUGAPE3uFTDpiGcIOyPW5aecQtPmTXPMJH+2aa8Nu1wyoT1btxO+UYiQM3g==",
+			"requires": {
+				"@chakra-ui/dom-utils": "2.0.6",
+				"@chakra-ui/react-use-event-listener": "2.0.7",
+				"@chakra-ui/react-use-safe-layout-effect": "2.0.5",
+				"@chakra-ui/react-use-update-effect": "2.0.7"
+			}
+		},
+		"@chakra-ui/react-use-focus-on-pointer-down": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-focus-on-pointer-down/-/react-use-focus-on-pointer-down-2.0.6.tgz",
+			"integrity": "sha512-OigXiLRVySn3tyVqJ/rn57WGuukW8TQe8fJYiLwXbcNyAMuYYounvRxvCy2b53sQ7QIZamza0N0jhirbH5FNoQ==",
+			"requires": {
+				"@chakra-ui/react-use-event-listener": "2.0.7"
+			}
+		},
+		"@chakra-ui/react-use-interval": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-interval/-/react-use-interval-2.0.5.tgz",
+			"integrity": "sha512-1nbdwMi2K87V6p5f5AseOKif2CkldLaJlq1TOqaPRwb7v3aU9rltBtYdf+fIyuHSToNJUV6wd9budCFdLCl3Fg==",
+			"requires": {
+				"@chakra-ui/react-use-callback-ref": "2.0.7"
+			}
+		},
+		"@chakra-ui/react-use-latest-ref": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-latest-ref/-/react-use-latest-ref-2.0.5.tgz",
+			"integrity": "sha512-3mIuFzMyIo3Ok/D8uhV9voVg7KkrYVO/pwVvNPJOHsDQqCA6DpYE4WDsrIx+fVcwad3Ta7SupexR5PoI+kq6QQ==",
+			"requires": {}
+		},
+		"@chakra-ui/react-use-merge-refs": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-merge-refs/-/react-use-merge-refs-2.0.7.tgz",
+			"integrity": "sha512-zds4Uhsc+AMzdH8JDDkLVet9baUBgtOjPbhC5r3A0ZXjZvGhCztFAVE3aExYiVoMPoHLKbLcqvCWE6ioFKz1lw==",
+			"requires": {}
+		},
+		"@chakra-ui/react-use-outside-click": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-outside-click/-/react-use-outside-click-2.0.7.tgz",
+			"integrity": "sha512-MsAuGLkwYNxNJ5rb8lYNvXApXxYMnJ3MzqBpQj1kh5qP/+JSla9XMjE/P94ub4fSEttmNSqs43SmPPrmPuihsQ==",
+			"requires": {
+				"@chakra-ui/react-use-callback-ref": "2.0.7"
+			}
+		},
+		"@chakra-ui/react-use-pan-event": {
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-pan-event/-/react-use-pan-event-2.0.9.tgz",
+			"integrity": "sha512-xu35QXkiyrgsHUOnctl+SwNcwf9Rl62uYE5y8soKOZdBm8E+FvZIt2hxUzK1EoekbJCMzEZ0Yv1ZQCssVkSLaQ==",
+			"requires": {
+				"@chakra-ui/event-utils": "2.0.8",
+				"@chakra-ui/react-use-latest-ref": "2.0.5",
+				"framesync": "6.1.2"
+			}
+		},
+		"@chakra-ui/react-use-previous": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-previous/-/react-use-previous-2.0.5.tgz",
+			"integrity": "sha512-BIZgjycPE4Xr+MkhKe0h67uHXzQQkBX/u5rYPd65iMGdX1bCkbE0oorZNfOHLKdTmnEb4oVsNvfN6Rfr+Mnbxw==",
+			"requires": {}
+		},
+		"@chakra-ui/react-use-safe-layout-effect": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-safe-layout-effect/-/react-use-safe-layout-effect-2.0.5.tgz",
+			"integrity": "sha512-MwAQBz3VxoeFLaesaSEN87reVNVbjcQBDex2WGexAg6hUB6n4gc1OWYH/iXp4tzp4kuggBNhEHkk9BMYXWfhJQ==",
+			"requires": {}
+		},
+		"@chakra-ui/react-use-size": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-size/-/react-use-size-2.0.8.tgz",
+			"integrity": "sha512-OdCxVPm8ekPVn9R6S1OtfLVNRVZ0G1tcfA2/oY1c55aXbm/R0TFZ+twSoy+X+aRFhqydmE7DRsKyW2ysXuuVBw==",
+			"requires": {
+				"@zag-js/element-size": "0.3.0"
+			}
+		},
+		"@chakra-ui/react-use-timeout": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-timeout/-/react-use-timeout-2.0.5.tgz",
+			"integrity": "sha512-QqmB+jVphh3h/CS60PieorpY7UqSPkrQCB7f7F+i9vwwIjtP8fxVHMmkb64K7VlzQiMPzv12nlID5dqkzlv0mw==",
+			"requires": {
+				"@chakra-ui/react-use-callback-ref": "2.0.7"
+			}
+		},
+		"@chakra-ui/react-use-update-effect": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-use-update-effect/-/react-use-update-effect-2.0.7.tgz",
+			"integrity": "sha512-vBM2bmmM83ZdDtasWv3PXPznpTUd+FvqBC8J8rxoRmvdMEfrxTiQRBJhiGHLpS9BPLLPQlosN6KdFU97csB6zg==",
+			"requires": {}
+		},
+		"@chakra-ui/react-utils": {
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/react-utils/-/react-utils-2.0.12.tgz",
+			"integrity": "sha512-GbSfVb283+YA3kA8w8xWmzbjNWk14uhNpntnipHCftBibl0lxtQ9YqMFQLwuFOO0U2gYVocszqqDWX+XNKq9hw==",
+			"requires": {
+				"@chakra-ui/utils": "2.0.15"
+			}
+		},
+		"@chakra-ui/select": {
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/select/-/select-2.0.18.tgz",
+			"integrity": "sha512-1d2lUT5LM6oOs5x4lzBh4GFDuXX62+lr+sgV7099g951/5UNbb0CS2hSZHsO7yZThLNbr7QTWZvAOAayVcGzdw==",
+			"requires": {
+				"@chakra-ui/form-control": "2.0.17",
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/shared-utils": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/shared-utils/-/shared-utils-2.0.5.tgz",
+			"integrity": "sha512-4/Wur0FqDov7Y0nCXl7HbHzCg4aq86h+SXdoUeuCMD3dSj7dpsVnStLYhng1vxvlbUnLpdF4oz5Myt3i/a7N3Q=="
+		},
+		"@chakra-ui/skeleton": {
+			"version": "2.0.23",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/skeleton/-/skeleton-2.0.23.tgz",
+			"integrity": "sha512-iMK50PlC9kR52v8tZWSKnZTJsOpZrqXOXaR9r/0Ry3xhdMq5hGkcigA+zKy/ZEglbMZ2CG9Fdtvi2vQurE1VZw==",
+			"requires": {
+				"@chakra-ui/media-query": "3.2.11",
+				"@chakra-ui/react-use-previous": "2.0.5",
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/slider": {
+			"version": "2.0.20",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/slider/-/slider-2.0.20.tgz",
+			"integrity": "sha512-5Q+9s6bIjI8GIp7YRHqt5hT678p7lCIdA/zB6c/fCp+MvOInxx4LiJZvNuaw0HX6z6bC7R/skIhmIjsgSI3MNw==",
+			"requires": {
+				"@chakra-ui/number-utils": "2.0.7",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-types": "2.0.7",
+				"@chakra-ui/react-use-callback-ref": "2.0.7",
+				"@chakra-ui/react-use-controllable-state": "2.0.8",
+				"@chakra-ui/react-use-latest-ref": "2.0.5",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/react-use-pan-event": "2.0.9",
+				"@chakra-ui/react-use-size": "2.0.8",
+				"@chakra-ui/react-use-update-effect": "2.0.7"
+			}
+		},
+		"@chakra-ui/spinner": {
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/spinner/-/spinner-2.0.13.tgz",
+			"integrity": "sha512-T1/aSkVpUIuiYyrjfn1+LsQEG7Onbi1UE9ccS/evgf61Dzy4GgTXQUnDuWFSgpV58owqirqOu6jn/9eCwDlzlg==",
+			"requires": {
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/stat": {
+			"version": "2.0.17",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/stat/-/stat-2.0.17.tgz",
+			"integrity": "sha512-PhD+5oVLWjQmGLfeZSmexp3AtLcaggWBwoMZ4z8QMZIQzf/fJJWMk0bMqxlpTv8ORDkfY/4ImuFB/RJHvcqlcA==",
+			"requires": {
+				"@chakra-ui/icon": "3.0.16",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/styled-system": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.5.2.tgz",
+			"integrity": "sha512-FVnSWcj28F2t0R6slslYnhdWL8L3+elzoNt9oXBosS9PS6u6Yh56Dqq2GH2yasOWSmuuXGCPbzOYuc0U+MlCqg==",
+			"requires": {
+				"@chakra-ui/shared-utils": "2.0.5",
+				"csstype": "^3.0.11",
+				"lodash.mergewith": "4.6.2"
+			}
+		},
+		"@chakra-ui/switch": {
+			"version": "2.0.22",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/switch/-/switch-2.0.22.tgz",
+			"integrity": "sha512-+/Yy6y7VFD91uSPruF8ZvePi3tl5D8UNVATtWEQ+QBI92DLSM+PtgJ2F0Y9GMZ9NzMxpZ80DqwY7/kqcPCfLvw==",
+			"requires": {
+				"@chakra-ui/checkbox": "2.2.10",
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/system": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-2.4.0.tgz",
+			"integrity": "sha512-gUX6OZVvFDMV92NtKLuawIWqvjhYc0u1LCAMeb1k3ktVBjWEYjIM4DBIirEhHjcADa8ownrTEHeW0aGxN7uxjQ==",
+			"requires": {
+				"@chakra-ui/color-mode": "2.1.12",
+				"@chakra-ui/object-utils": "2.0.8",
+				"@chakra-ui/react-utils": "2.0.12",
+				"@chakra-ui/styled-system": "2.5.2",
+				"@chakra-ui/theme-utils": "2.0.9",
+				"@chakra-ui/utils": "2.0.15",
+				"react-fast-compare": "3.2.0"
+			}
+		},
+		"@chakra-ui/table": {
+			"version": "2.0.16",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/table/-/table-2.0.16.tgz",
+			"integrity": "sha512-vWDXZ6Ad3Aj66curp1tZBHvCfQHX2FJ4ijLiqGgQszWFIchfhJ5vMgEBJaFMZ+BN1draAjuRTZqaQefOApzvRg==",
+			"requires": {
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/tabs": {
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/tabs/-/tabs-2.1.8.tgz",
+			"integrity": "sha512-B7LeFN04Ny2jsSy5TFOQxnbZ6ITxGxLxsB2PE0vvQjMSblBrUryOxdjw80HZhfiw6od0ikK9CeKQOIt9QCguSw==",
+			"requires": {
+				"@chakra-ui/clickable": "2.0.14",
+				"@chakra-ui/descendant": "3.0.13",
+				"@chakra-ui/lazy-utils": "2.0.5",
+				"@chakra-ui/react-children-utils": "2.0.6",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-use-controllable-state": "2.0.8",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/react-use-safe-layout-effect": "2.0.5",
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/tag": {
+			"version": "2.0.17",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/tag/-/tag-2.0.17.tgz",
+			"integrity": "sha512-A47zE9Ft9qxOJ+5r1cUseKRCoEdqCRzFm0pOtZgRcckqavglk75Xjgz8HbBpUO2zqqd49MlqdOwR8o87fXS1vg==",
+			"requires": {
+				"@chakra-ui/icon": "3.0.16",
+				"@chakra-ui/react-context": "2.0.7"
+			}
+		},
+		"@chakra-ui/textarea": {
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/textarea/-/textarea-2.0.18.tgz",
+			"integrity": "sha512-aGHHb29vVifO0OtcK/k8cMykzjOKo/coDTU0NJqz7OOLAWIMNV2eGenvmO1n9tTZbmbqHiX+Sa1nPRX+pd14lg==",
+			"requires": {
+				"@chakra-ui/form-control": "2.0.17",
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/theme": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-2.2.5.tgz",
+			"integrity": "sha512-hYASZMwu0NqEv6PPydu+F3I+kMNd44yR4TwjR/lXBz/LEh64L6UPY6kQjebCfgdVtsGdl3HKg+eLlfa7SvfRgw==",
+			"requires": {
+				"@chakra-ui/anatomy": "2.1.2",
+				"@chakra-ui/shared-utils": "2.0.5",
+				"@chakra-ui/theme-tools": "2.0.17"
+			}
+		},
+		"@chakra-ui/theme-tools": {
+			"version": "2.0.17",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-2.0.17.tgz",
+			"integrity": "sha512-Auu38hnihlJZQcPok6itRDBbwof3TpXGYtDPnOvrq4Xp7jnab36HLt7KEXSDPXbtOk3ZqU99pvI1en5LbDrdjg==",
+			"requires": {
+				"@chakra-ui/anatomy": "2.1.2",
+				"@chakra-ui/shared-utils": "2.0.5",
+				"color2k": "^2.0.0"
+			}
+		},
+		"@chakra-ui/theme-utils": {
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/theme-utils/-/theme-utils-2.0.9.tgz",
+			"integrity": "sha512-+Nn1NooFeAr4d/OVU1NjXEMKCKCIfesYw27BoYzFYCWt/+cS/qcVdPJj+uXgK8L8xExhkREipt2r9kGlE+WpTw==",
+			"requires": {
+				"@chakra-ui/shared-utils": "2.0.5",
+				"@chakra-ui/styled-system": "2.5.2",
+				"@chakra-ui/theme": "2.2.5",
+				"lodash.mergewith": "4.6.2"
+			}
+		},
+		"@chakra-ui/toast": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/toast/-/toast-5.0.1.tgz",
+			"integrity": "sha512-R66broJXhe4cd+o5/r7raF4Jg4J3W3QBHrykV7AV/W0Wiav8tL8jwSq8pMmXVnO3oGwKWZ+VHuSWmjcL65BHmg==",
+			"requires": {
+				"@chakra-ui/alert": "2.0.17",
+				"@chakra-ui/close-button": "2.0.17",
+				"@chakra-ui/portal": "2.0.15",
+				"@chakra-ui/react-context": "2.0.7",
+				"@chakra-ui/react-use-timeout": "2.0.5",
+				"@chakra-ui/react-use-update-effect": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5",
+				"@chakra-ui/styled-system": "2.5.2",
+				"@chakra-ui/theme": "2.2.5"
+			}
+		},
+		"@chakra-ui/tooltip": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/tooltip/-/tooltip-2.2.6.tgz",
+			"integrity": "sha512-4cbneidZ5+HCWge3OZzewRQieIvhDjSsl+scrl4Scx7E0z3OmqlTIESU5nGIZDBLYqKn/UirEZhqaQ33FOS2fw==",
+			"requires": {
+				"@chakra-ui/popper": "3.0.13",
+				"@chakra-ui/portal": "2.0.15",
+				"@chakra-ui/react-types": "2.0.7",
+				"@chakra-ui/react-use-disclosure": "2.0.8",
+				"@chakra-ui/react-use-event-listener": "2.0.7",
+				"@chakra-ui/react-use-merge-refs": "2.0.7",
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/transition": {
+			"version": "2.0.15",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/transition/-/transition-2.0.15.tgz",
+			"integrity": "sha512-o9LBK/llQfUDHF/Ty3cQ6nShpekKTqHUoJlUOzNKhoTsNpoRerr9v0jwojrX1YI02KtVjfhFU6PiqXlDfREoNw==",
+			"requires": {
+				"@chakra-ui/shared-utils": "2.0.5"
+			}
+		},
+		"@chakra-ui/utils": {
+			"version": "2.0.15",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-2.0.15.tgz",
+			"integrity": "sha512-El4+jL0WSaYYs+rJbuYFDbjmfCcfGDmRY95GO4xwzit6YAPZBLcR65rOEwLps+XWluZTy1xdMrusg/hW0c1aAA==",
+			"requires": {
+				"@types/lodash.mergewith": "4.6.7",
+				"css-box-model": "1.2.1",
+				"framesync": "6.1.2",
+				"lodash.mergewith": "4.6.2"
+			}
+		},
+		"@chakra-ui/visually-hidden": {
+			"version": "2.0.15",
+			"resolved": "https://registry.npmjs.org/@chakra-ui/visually-hidden/-/visually-hidden-2.0.15.tgz",
+			"integrity": "sha512-WWULIiucYRBIewHKFA7BssQ2ABLHLVd9lrUo3N3SZgR0u4ZRDDVEUNOy+r+9ruDze8+36dGbN9wsN1IdELtdOw==",
+			"requires": {}
 		},
 		"@cspotcode/source-map-support": {
 			"version": "0.8.1",
@@ -23134,6 +25512,64 @@
 			"integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
 			"dev": true
 		},
+		"@motionone/animation": {
+			"version": "10.15.1",
+			"resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.15.1.tgz",
+			"integrity": "sha512-mZcJxLjHor+bhcPuIFErMDNyrdb2vJur8lSfMCsuCB4UyV8ILZLvK+t+pg56erv8ud9xQGK/1OGPt10agPrCyQ==",
+			"requires": {
+				"@motionone/easing": "^10.15.1",
+				"@motionone/types": "^10.15.1",
+				"@motionone/utils": "^10.15.1",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@motionone/dom": {
+			"version": "10.15.5",
+			"resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.15.5.tgz",
+			"integrity": "sha512-Xc5avlgyh3xukU9tydh9+8mB8+2zAq+WlLsC3eEIp7Ax7DnXgY7Bj/iv0a4X2R9z9ZFZiaXK3BO0xMYHKbAAdA==",
+			"requires": {
+				"@motionone/animation": "^10.15.1",
+				"@motionone/generators": "^10.15.1",
+				"@motionone/types": "^10.15.1",
+				"@motionone/utils": "^10.15.1",
+				"hey-listen": "^1.0.8",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@motionone/easing": {
+			"version": "10.15.1",
+			"resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.15.1.tgz",
+			"integrity": "sha512-6hIHBSV+ZVehf9dcKZLT7p5PEKHGhDwky2k8RKkmOvUoYP3S+dXsKupyZpqx5apjd9f+php4vXk4LuS+ADsrWw==",
+			"requires": {
+				"@motionone/utils": "^10.15.1",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@motionone/generators": {
+			"version": "10.15.1",
+			"resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.15.1.tgz",
+			"integrity": "sha512-67HLsvHJbw6cIbLA/o+gsm7h+6D4Sn7AUrB/GPxvujse1cGZ38F5H7DzoH7PhX+sjvtDnt2IhFYF2Zp1QTMKWQ==",
+			"requires": {
+				"@motionone/types": "^10.15.1",
+				"@motionone/utils": "^10.15.1",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@motionone/types": {
+			"version": "10.15.1",
+			"resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.15.1.tgz",
+			"integrity": "sha512-iIUd/EgUsRZGrvW0jqdst8st7zKTzS9EsKkP+6c6n4MPZoQHwiHuVtTQLD6Kp0bsBLhNzKIBlHXponn/SDT4hA=="
+		},
+		"@motionone/utils": {
+			"version": "10.15.1",
+			"resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.15.1.tgz",
+			"integrity": "sha512-p0YncgU+iklvYr/Dq4NobTRdAPv9PveRDUXabPEeOjBLSO/1FNB2phNTZxOxpi1/GZwYpAoECEa0Wam+nsmhSw==",
+			"requires": {
+				"@motionone/types": "^10.15.1",
+				"hey-listen": "^1.0.8",
+				"tslib": "^2.3.1"
+			}
+		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -23989,6 +26425,11 @@
 			"integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
 			"dev": true
 		},
+		"@popperjs/core": {
+			"version": "2.11.6",
+			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+			"integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
+		},
 		"@remix-run/router": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.0.3.tgz",
@@ -24380,6 +26821,19 @@
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
+		},
+		"@types/lodash": {
+			"version": "4.14.191",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+			"integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ=="
+		},
+		"@types/lodash.mergewith": {
+			"version": "4.6.7",
+			"resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.7.tgz",
+			"integrity": "sha512-3m+lkO5CLRRYU0fhGRp7zbsGi6+BZj0uTVSwvcKU+nSlhjA9/QRNfuSGnD2mX6hQA7ZbmcCkzk5h4ZYGOtk14A==",
+			"requires": {
+				"@types/lodash": "*"
+			}
 		},
 		"@types/mime": {
 			"version": "3.0.1",
@@ -24938,6 +27392,16 @@
 				"tslib": "^2.4.0"
 			}
 		},
+		"@zag-js/element-size": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@zag-js/element-size/-/element-size-0.3.0.tgz",
+			"integrity": "sha512-5/hEI+0c6ZNCx6KHlOS5/WeHsd6+I7gk7Y/b/zATp4Rp3tHirs/tu1frq+iy5BmfaG9hbQtfHfUJTjOcI5jnoQ=="
+		},
+		"@zag-js/focus-visible": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-0.2.1.tgz",
+			"integrity": "sha512-19uTjoZGP4/Ax7kSNhhay9JA83BirKzpqLkeEAilrpdI1hE5xuq6q+tzJOsrMOOqJrm7LkmZp5lbsTQzvK2pYg=="
+		},
 		"@zkochan/js-yaml": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz",
@@ -25143,6 +27607,14 @@
 			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
+			}
+		},
+		"aria-hidden": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.2.tgz",
+			"integrity": "sha512-6y/ogyDTk/7YAe91T3E2PR1ALVKyM2QbTio5HwM+N1Q6CMlCKhvClyIjkckBswa0f2xJhjsfzIGa1yVSe1UMVA==",
+			"requires": {
+				"tslib": "^2.0.0"
 			}
 		},
 		"aria-query": {
@@ -25762,9 +28234,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001448",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001448.tgz",
-			"integrity": "sha512-tq2YI+MJnooG96XpbTRYkBxLxklZPOdLmNIOdIhvf7SNJan6u5vCKum8iT7ZfCt70m1GPkuC7P3TtX6UuhupuA=="
+			"version": "1.0.30001449",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001449.tgz",
+			"integrity": "sha512-CPB+UL9XMT/Av+pJxCKGhdx+yg1hzplvFJQlJ2n68PyQGMz9L/E2zCyLdOL8uasbouTUgnPl+y0tccI/se+BEw=="
 		},
 		"chai": {
 			"version": "4.3.7",
@@ -25912,6 +28384,11 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
 		},
+		"color2k": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.1.tgz",
+			"integrity": "sha512-iCg+xrEqtYISsSJZN1z44fyhv4EfX8lSkcDhodt6VnMf1+iMwZxAtmGXchTCeMUnTbXunGvUVK6E3skkApPnZw=="
+		},
 		"colord": {
 			"version": "2.9.3",
 			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
@@ -25992,6 +28469,11 @@
 				}
 			}
 		},
+		"compute-scroll-into-view": {
+			"version": "1.0.14",
+			"resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.14.tgz",
+			"integrity": "sha512-mKDjINe3tc6hGelUMNDzuhorIUZ7kS7BwyY0r2wQd2HOH2tRuJykiC06iSEX8y1TuhNzvz4GcJnK16mM2J1NMQ=="
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -26041,6 +28523,14 @@
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
 			"integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
 			"dev": true
+		},
+		"copy-to-clipboard": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+			"integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+			"requires": {
+				"toggle-selection": "^1.0.6"
+			}
 		},
 		"copy-webpack-plugin": {
 			"version": "10.2.4",
@@ -26190,6 +28680,14 @@
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				}
+			}
+		},
+		"css-box-model": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+			"integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+			"requires": {
+				"tiny-invariant": "^1.0.6"
 			}
 		},
 		"css-declaration-sorter": {
@@ -26606,6 +29104,11 @@
 			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
 			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
 			"dev": true
+		},
+		"detect-node-es": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+			"integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
 		},
 		"diff": {
 			"version": "4.0.2",
@@ -28320,6 +30823,14 @@
 			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
 			"dev": true
 		},
+		"focus-lock": {
+			"version": "0.11.4",
+			"resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.4.tgz",
+			"integrity": "sha512-LzZWJcOBIcHslQ46N3SUu/760iLPSrUtp8omM4gh9du438V2CQdks8TcOu1yvmu2C68nVOBnl1WFiKGPbQ8L6g==",
+			"requires": {
+				"tslib": "^2.0.3"
+			}
+		},
 		"follow-redirects": {
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
@@ -28485,6 +30996,49 @@
 			"integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
 			"dev": true
 		},
+		"framer-motion": {
+			"version": "8.5.3",
+			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-8.5.3.tgz",
+			"integrity": "sha512-CkQHhGlldJptI0SGjmjUzseXCzi0lljDkToE7cANHRCs12F5I84ymdWvCi6HfIKkt6Ykq2RiDd3dGuYV0oMn2w==",
+			"requires": {
+				"@emotion/is-prop-valid": "^0.8.2",
+				"@motionone/dom": "^10.15.3",
+				"hey-listen": "^1.0.8",
+				"tslib": "^2.4.0"
+			},
+			"dependencies": {
+				"@emotion/is-prop-valid": {
+					"version": "0.8.8",
+					"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+					"integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+					"optional": true,
+					"requires": {
+						"@emotion/memoize": "0.7.4"
+					}
+				},
+				"@emotion/memoize": {
+					"version": "0.7.4",
+					"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+					"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+					"optional": true
+				}
+			}
+		},
+		"framesync": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/framesync/-/framesync-6.1.2.tgz",
+			"integrity": "sha512-jBTqhX6KaQVDyus8muwZbBeGGP0XgujBRbQ7gM7BRdS3CadCZIHiawyzYLnafYcvZIh5j8WE7cxZKFn7dXhu9g==",
+			"requires": {
+				"tslib": "2.4.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+				}
+			}
+		},
 		"fresh": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -28592,6 +31146,11 @@
 				"has": "^1.0.3",
 				"has-symbols": "^1.0.3"
 			}
+		},
+		"get-nonce": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+			"integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="
 		},
 		"get-package-type": {
 			"version": "0.1.0",
@@ -28791,6 +31350,11 @@
 			"requires": {
 				"has-symbols": "^1.0.2"
 			}
+		},
+		"hey-listen": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
+			"integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
 		},
 		"hoist-non-react-statics": {
 			"version": "3.3.2",
@@ -29060,6 +31624,14 @@
 				"get-intrinsic": "^1.1.3",
 				"has": "^1.0.3",
 				"side-channel": "^1.0.4"
+			}
+		},
+		"invariant": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"requires": {
+				"loose-envify": "^1.0.0"
 			}
 		},
 		"ipaddr.js": {
@@ -32362,6 +34934,11 @@
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
 		},
+		"lodash.mergewith": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+			"integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
+		},
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -32933,8 +35510,7 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-			"dev": true
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
 		},
 		"object-inspect": {
 			"version": "1.12.3",
@@ -33739,7 +36315,6 @@
 			"version": "15.8.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
 			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
@@ -33860,6 +36435,14 @@
 				"loose-envify": "^1.1.0"
 			}
 		},
+		"react-clientside-effect": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz",
+			"integrity": "sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==",
+			"requires": {
+				"@babel/runtime": "^7.12.13"
+			}
+		},
 		"react-dom": {
 			"version": "18.2.0",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -33867,6 +36450,24 @@
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.0"
+			}
+		},
+		"react-fast-compare": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+			"integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+		},
+		"react-focus-lock": {
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.2.tgz",
+			"integrity": "sha512-5JfrsOKyA5Zn3h958mk7bAcfphr24jPoMoznJ8vaJF6fUrPQ8zrtEd3ILLOK8P5jvGxdMd96OxWNjDzATfR2qw==",
+			"requires": {
+				"@babel/runtime": "^7.0.0",
+				"focus-lock": "^0.11.2",
+				"prop-types": "^15.6.2",
+				"react-clientside-effect": "^1.2.6",
+				"use-callback-ref": "^1.3.0",
+				"use-sidecar": "^1.1.2"
 			}
 		},
 		"react-is": {
@@ -33879,6 +36480,27 @@
 			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
 			"integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
 			"dev": true
+		},
+		"react-remove-scroll": {
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
+			"integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
+			"requires": {
+				"react-remove-scroll-bar": "^2.3.3",
+				"react-style-singleton": "^2.2.1",
+				"tslib": "^2.1.0",
+				"use-callback-ref": "^1.3.0",
+				"use-sidecar": "^1.1.2"
+			}
+		},
+		"react-remove-scroll-bar": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz",
+			"integrity": "sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==",
+			"requires": {
+				"react-style-singleton": "^2.2.1",
+				"tslib": "^2.0.0"
+			}
 		},
 		"react-router": {
 			"version": "6.4.3",
@@ -33905,6 +36527,16 @@
 			"requires": {
 				"object-assign": "^4.1.1",
 				"react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"react-style-singleton": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+			"integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+			"requires": {
+				"get-nonce": "^1.0.0",
+				"invariant": "^2.2.4",
+				"tslib": "^2.0.0"
 			}
 		},
 		"react-table": {
@@ -35088,6 +37720,11 @@
 				"globrex": "^0.1.2"
 			}
 		},
+		"tiny-invariant": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+			"integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
+		},
 		"tiny-lru": {
 			"version": "10.0.1",
 			"resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-10.0.1.tgz",
@@ -35101,9 +37738,9 @@
 			"dev": true
 		},
 		"tinypool": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.3.0.tgz",
-			"integrity": "sha512-NX5KeqHOBZU6Bc0xj9Vr5Szbb1j8tUHIeD18s41aDJaPeC5QTdEhK0SpdpUrZlj2nv5cctNcSjaKNanXlfcVEQ==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.3.1.tgz",
+			"integrity": "sha512-zLA1ZXlstbU2rlpA4CIeVaqvWq41MTWqLY3FfsAXgC8+f7Pk7zroaJQxDgxn1xNudKW6Kmj4808rPFShUlIRmQ==",
 			"dev": true
 		},
 		"tinyspy": {
@@ -35140,6 +37777,11 @@
 			"requires": {
 				"is-number": "^7.0.0"
 			}
+		},
+		"toggle-selection": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+			"integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
 		},
 		"toidentifier": {
 			"version": "1.0.1",
@@ -35427,9 +38069,9 @@
 			}
 		},
 		"tslib": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
 		},
 		"tsutils": {
 			"version": "3.21.0",
@@ -35552,6 +38194,23 @@
 			"requires": {
 				"querystringify": "^2.1.1",
 				"requires-port": "^1.0.0"
+			}
+		},
+		"use-callback-ref": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
+			"integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+			"requires": {
+				"tslib": "^2.0.0"
+			}
+		},
+		"use-sidecar": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+			"integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+			"requires": {
+				"detect-node-es": "^1.1.0",
+				"tslib": "^2.0.0"
 			}
 		},
 		"util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -16,11 +16,13 @@
 	},
 	"private": true,
 	"dependencies": {
+		"@chakra-ui/react": "^2.4.9",
 		"@emotion/css": "^11.10.5",
 		"@emotion/react": "11.10.5",
 		"@emotion/styled": "11.10.5",
 		"@guardian/source-foundations": "^8.0.0",
 		"@types/react-table": "^7.7.14",
+		"framer-motion": "^8.5.3",
 		"react": "18.2.0",
 		"react-dom": "18.2.0",
 		"react-router-dom": "6.4.3",


### PR DESCRIPTION
## Main change

Adds UI library `@chakra-ui/react` to get quick components up and running.

In https://github.com/guardian/newsletters-nx/pull/11 we removed `@guardian/source-react-components` since it relied on react@17 but we're using v18. 

It was suggested to fork the Source React Components library instead but I felt this would be the faster solution. Given that most of our code doesn't rely on a specific library yet, this keeps us moving and still enables us to switch out for a different one if need be. We're just using the `Button` component at the moment and we can bear in mind that if Chakra doesn't suit our needs, we can move to a different one.

### Other changes (mainly related to eslint & TS errors/warnings)

- Adds `.vscode/settings.json` as my VS code kept using a different TS version and was giving me evils. A quick google sorted this out and imagine it could be quite common
- Changes the React Router `navigate` to a `Link` component instead
- Adds a very basic `DisabledButton` component to reduce the size of the button grid, as well as adjusting the breakpoints (source foundations) for grid. Also uses source foundation spacing now.