### PR TITLE
Dblatcher/nicer details page

### DIFF
--- a/apps/newsletters-ui/src/app/Layout.tsx
+++ b/apps/newsletters-ui/src/app/Layout.tsx
@@ -1,37 +1,45 @@
 import { css } from '@emotion/react';
-import { space } from '@guardian/source-foundations';
-import type { ReactNode } from 'react';
-import { Link, Outlet } from 'react-router-dom';
-
-interface Props {
-	children?: ReactNode;
-}
+import {
+	brand,
+	space,
+	textSansObjectStyles,
+} from '@guardian/source-foundations';
+import { Outlet, useLocation } from 'react-router-dom';
+import { MainNav } from './components/MainNav';
 
 const headerStyle = css`
-	nav a {
-		margin-right: ${space[2]}px;
+	margin-bottom: ${space[6]}px;
+	padding: ${space[1]}px;
+	border-bottom: 2px solid ${brand[300]};
+	background-color: ${brand[800]};
+
+	h1 {
+		${textSansObjectStyles.xlarge({ fontStyle: 'italic' })};
+		margin: 0;
+		color: ${brand[300]};
 	}
 `;
 
-export function Layout({ children }: Props) {
+const footerStyle = css`
+	margin-top: ${space[3]}px;
+	padding: ${space[1]}px;
+	border-top: 2px solid ${brand[300]};
+	background-color: ${brand[800]};
+`;
+
+export function Layout() {
+	const location = useLocation();
+
 	return (
 		<>
 			<header css={headerStyle}>
 				<h1>Newsletters UI</h1>
-
-				<nav>
-					<Link to={`/`}>home</Link>
-					<Link to={`/api`}>api test page</Link>
-					<Link to={`/newsletters/`}>View Current Newsletters</Link>
-				</nav>
-				{children && <nav>{children}</nav>}
-				<hr></hr>
+				<MainNav pathname={location.pathname} />
 			</header>
 			<main>
 				<Outlet />
 			</main>
-			<footer>
-				<hr></hr>
+			<footer css={footerStyle}>
 				<b>Footer</b>
 			</footer>
 		</>

--- a/apps/newsletters-ui/src/app/components/Cell.tsx
+++ b/apps/newsletters-ui/src/app/components/Cell.tsx
@@ -1,5 +1,7 @@
+import { renderYesNo } from '../util';
+
 export type Cell<T> = { cell: { value: T } };
 
 export const formatCellBoolean = ({ cell: { value } }: Cell<boolean>) => (
-	<span>{value ? '✅ Yes' : '❌ No'}</span>
+	<span>{renderYesNo(value)}</span>
 );

--- a/apps/newsletters-ui/src/app/components/Illustration.tsx
+++ b/apps/newsletters-ui/src/app/components/Illustration.tsx
@@ -1,0 +1,43 @@
+import { css } from '@emotion/react';
+import { brand, space } from '@guardian/source-foundations';
+import type { Newsletter } from '@newsletters-nx/newsletters-data-client';
+
+interface Props {
+	newsletter: Newsletter;
+}
+
+const figureStyles = css`
+	display: inline-flex;
+	margin: 0;
+	border: 2px dashed ${brand[400]};
+	border-radius: ${space[2]}px;
+	padding: ${space[1]}px;
+	flex-direction: column;
+	align-items: center;
+
+	span {
+		font-size: 100px;
+	}
+`;
+
+export const Illustration = ({ newsletter }: Props) => {
+	const { illustration, name } = newsletter;
+
+	if (!illustration) {
+		return (
+			<figure css={figureStyles}>
+				<span role="img" aria-label="no illustration">
+					🚫
+				</span>
+				<figcaption>{name} has no illustration</figcaption>
+			</figure>
+		);
+	}
+
+	return (
+		<figure css={figureStyles}>
+			<img src={illustration.circle} alt="" height={100} />
+			<figcaption>illustration for {name}</figcaption>
+		</figure>
+	);
+};

--- a/apps/newsletters-ui/src/app/components/MainNav.tsx
+++ b/apps/newsletters-ui/src/app/components/MainNav.tsx
@@ -1,0 +1,63 @@
+import { css } from '@emotion/react';
+import {
+	neutral,
+	space,
+	textSansObjectStyles,
+} from '@guardian/source-foundations';
+import { Link } from 'react-router-dom';
+
+interface Props {
+	pathname: string;
+}
+
+interface NavLink {
+	path: string;
+	label: string;
+}
+
+const navLinks: NavLink[] = [
+	{ path: '/', label: 'home' },
+	{ path: '/api', label: 'api test page' },
+	{ path: '/newsletters/', label: 'View Current Newsletters' },
+];
+
+const navStyle = css`
+	display: flex;
+	padding: ${space[2]}px 0;
+	flex-wrap: wrap;
+
+	a {
+		${textSansObjectStyles.medium({ fontWeight: 'light' })};
+		min-width: 200px;
+		margin-right: ${space[2]}px;
+		padding: ${space[1]}px;
+		background-color: ${neutral[97]};
+		color: ${neutral[7]};
+		text-decoration: none;
+
+		&.current {
+			${textSansObjectStyles.medium({ fontWeight: 'bold' })};
+			background-color: ${neutral[7]};
+			color: ${neutral[97]};
+		}
+	}
+`;
+
+export function MainNav({ pathname }: Props) {
+	const getLinkClass = (linkPath: string): string | undefined => {
+		if (linkPath === pathname) {
+			return 'current';
+		}
+		return undefined;
+	};
+
+	return (
+		<nav css={navStyle}>
+			{navLinks.map((link) => (
+				<Link to={link.path} className={getLinkClass(link.path)}>
+					{link.label}
+				</Link>
+			))}
+		</nav>
+	);
+}

--- a/apps/newsletters-ui/src/app/components/NewsletterDetails.tsx
+++ b/apps/newsletters-ui/src/app/components/NewsletterDetails.tsx
@@ -8,20 +8,20 @@ import {
 import type { Newsletter } from '@newsletters-nx/newsletters-data-client';
 import {
 	getPropertyDescription,
+	isPropertyOptional,
 } from '@newsletters-nx/newsletters-data-client';
-import { getPalette } from '../util';
+import { getGuardianUrl, getPalette } from '../util';
 import type { SourcePalette } from '../util';
 
 interface Props {
 	newsletter: Newsletter;
 }
 
-const detailStyles = (palette: SourcePalette) => css`
-	h2 {
-		${headlineObjectStyles.medium()};
-		color: ${palette[100]};
-		border-bottom: 2px solid ${palette[400]};
-		margin: 0 0 ${space[3]}px 0;
+const tableStyles = (palette: SourcePalette) => css`
+
+	caption {
+		${textSansObjectStyles.large()};
+		padding-top: ${space[4]}px;
 	}
 
 	th,
@@ -34,6 +34,7 @@ const detailStyles = (palette: SourcePalette) => css`
 	th {
 		background-color: ${palette[400]};
 		color: ${neutral[97]};
+		min-width: 10rem;
 	}
 	td {
 		background-color: ${palette[800]};
@@ -41,14 +42,26 @@ const detailStyles = (palette: SourcePalette) => css`
 	}
 `;
 
-const flagStyles = (palette: SourcePalette) => css`
-	display: 'inline-block';
-	margin-right: ${space[3]}px;
-	margin-bottom: ${space[3]}px;
-	border-radius: ${space[3]}px;
-	padding: ${space[2]}px ${space[4]}px;
-	background-color: ${palette[600]};
-	color: ${palette[100]};
+const headingRowStyles = (palette: SourcePalette) => css`
+	display: flex;
+	align-items: flex-end;
+
+	h2 {
+		${headlineObjectStyles.medium()};
+		color: ${palette[100]};
+		border-bottom: 2px solid ${palette[400]};
+		margin: 0 ${space[6]}px ${space[3]}px 0;
+	}
+
+	div {
+		display: 'inline-block';
+		margin-right: ${space[3]}px;
+		margin-bottom: ${space[3]}px;
+		border-radius: ${space[3]}px;
+		padding: ${space[2]}px ${space[4]}px;
+		background-color: ${palette[600]};
+		color: ${neutral[100]};
+	}
 `;
 
 export const NewsletterDetail = ({ newsletter }: Props) => {
@@ -56,36 +69,99 @@ export const NewsletterDetail = ({ newsletter }: Props) => {
 
 	const palette = getPalette(theme);
 
-	const FieldRow = (
-		property: keyof Newsletter,
-		defaultDisplayValue?: string,
-	) => (
-		<tr>
-			<th>{property}</th>
-			<td>{newsletter[property]?.toString() ?? defaultDisplayValue}</td>
-			<td>{getPropertyDescription(property)}</td>
-		</tr>
-	);
+	const FieldRow = ({
+		property,
+		defaultDisplayValue,
+		displayValueAs = 'text',
+	}: {
+		property: keyof Newsletter;
+		defaultDisplayValue?: string;
+		displayValueAs?: 'guardianLink' | 'text';
+	}) => {
+		const valueString =
+			newsletter[property]?.toString() ?? defaultDisplayValue ?? '';
+
+		const getValueCellContents = () => {
+			if (typeof newsletter[property] === 'boolean') {
+				return <span>{newsletter[property] ? '✅ Yes' : '❌ No'}</span>;
+			}
+
+			if (displayValueAs === 'guardianLink') {
+				return (
+					<a
+						href={getGuardianUrl(valueString)}
+						rel="noreferrer"
+						target="_blank"
+					>
+						{valueString}
+					</a>
+				);
+			}
+
+			return <span>{valueString}</span>;
+		};
+
+		return (
+			<tr>
+				<th>
+					{property} {isPropertyOptional(property) && <b>[OPTIONAL]</b>}
+				</th>
+				<td>{getValueCellContents()}</td>
+				<td>{getPropertyDescription(property)}</td>
+			</tr>
+		);
+	};
 
 	return (
 		<div>
-			<div css={detailStyles(palette)}>
+			<div css={tableStyles(palette)}>
+				<div css={headingRowStyles(palette)}>
 				<h2>{name}</h2>
-				<div>
-					{cancelled && <div css={flagStyles(palette)}>CANCELLED</div>}
-					{paused && <div css={flagStyles(palette)}>PAUSED</div>}
-					{restricted && <div css={flagStyles(palette)}>restricted</div>}
-					{!paused && !cancelled && <div css={flagStyles(palette)}>LIVE</div>}
+					{cancelled && <div>CANCELLED</div>}
+					{paused && <div>PAUSED</div>}
+					{restricted && <div>restricted</div>}
+					{!paused && !cancelled && <div>LIVE</div>}
 				</div>
 				<table>
+					<caption>Reference Properties</caption>
 					<tbody>
-						{FieldRow('name')}
-						{FieldRow('identityName')}
-						{FieldRow('listId')}
-						{FieldRow('theme')}
-						{FieldRow('description')}
-						{FieldRow('frequency')}
-						{FieldRow('regionFocus', '[NONE]')}
+						<FieldRow property="identityName" />
+						<FieldRow property="listId" />
+						<FieldRow property="listIdV1" />
+					</tbody>
+				</table>
+				<table>
+					<caption>Status flags and settings</caption>
+					<tbody>
+						<FieldRow property="cancelled" />
+						<FieldRow property="paused" />
+						<FieldRow property="restricted" />
+						<FieldRow property="emailConfirmation" />
+					</tbody>
+				</table>
+				<table>
+					<caption>Display and information Properties</caption>
+					<tbody>
+						<FieldRow property="name" />
+						<FieldRow property="theme" />
+						<FieldRow property="description" />
+						<FieldRow property="frequency" />
+						<FieldRow property="regionFocus" defaultDisplayValue="[NONE]" />
+						<FieldRow property="group" />
+						<FieldRow property="signupPage" displayValueAs="guardianLink" />
+						<FieldRow property="exampleUrl" displayValueAs="guardianLink" />
+					</tbody>
+				</table>
+
+				<table>
+					<caption>tracking values</caption>
+					<tbody>
+						<FieldRow property="brazeNewsletterName" />
+						<FieldRow property="brazeSubscribeAttributeName" />
+						<FieldRow property="brazeSubscribeEventNamePrefix" />
+						<FieldRow property="campaignName" />
+						<FieldRow property="campaignCode" />
+						<FieldRow property="brazeSubscribeAttributeNameAlternate" />
 					</tbody>
 				</table>
 			</div>

--- a/apps/newsletters-ui/src/app/components/NewsletterDetails.tsx
+++ b/apps/newsletters-ui/src/app/components/NewsletterDetails.tsx
@@ -65,8 +65,8 @@ export const NewsletterDetail = ({ newsletter }: Props) => {
 				newsletter={newsletter}
 				caption="Status Flags and Settings"
 				fields={[
+					{ property: 'emailConfirmation' },
 					{ property: 'cancelled' },
-					{ property: 'paused' },
 					{ property: 'paused' },
 					{ property: 'restricted' },
 				]}

--- a/apps/newsletters-ui/src/app/components/NewsletterDetails.tsx
+++ b/apps/newsletters-ui/src/app/components/NewsletterDetails.tsx
@@ -3,44 +3,16 @@ import {
 	headlineObjectStyles,
 	neutral,
 	space,
-	textSansObjectStyles,
 } from '@guardian/source-foundations';
 import type { Newsletter } from '@newsletters-nx/newsletters-data-client';
-import {
-	getPropertyDescription,
-	isPropertyOptional,
-} from '@newsletters-nx/newsletters-data-client';
-import { getGuardianUrl, getPalette, renderYesNo } from '../util';
+import { getPalette } from '../util';
 import type { SourcePalette } from '../util';
 import { Illustration } from './Illustration';
+import { NewsletterPropertyTable } from './NewsletterPropertyTable';
 
 interface Props {
 	newsletter: Newsletter;
 }
-
-const tableStyles = (palette: SourcePalette) => css`
-	caption {
-		${textSansObjectStyles.large()};
-		padding-top: ${space[4]}px;
-	}
-
-	th,
-	td {
-		text-align: left;
-		padding: ${space[1]}px;
-		${textSansObjectStyles.medium()};
-	}
-
-	th {
-		background-color: ${palette[400]};
-		color: ${neutral[97]};
-		min-width: 10rem;
-	}
-	td {
-		background-color: ${palette[800]};
-		color: ${neutral[7]};
-	}
-`;
 
 const headingRowStyles = (palette: SourcePalette) => css`
 	display: flex;
@@ -69,49 +41,6 @@ export const NewsletterDetail = ({ newsletter }: Props) => {
 
 	const palette = getPalette(theme);
 
-	const FieldRow = ({
-		property,
-		defaultDisplayValue,
-		displayValueAs = 'text',
-	}: {
-		property: keyof Newsletter;
-		defaultDisplayValue?: string;
-		displayValueAs?: 'guardianLink' | 'text';
-	}) => {
-		const value = newsletter[property];
-		const valueString = value?.toString() ?? defaultDisplayValue ?? '';
-
-		const getValueCellContents = () => {
-			if (typeof value === 'boolean') {
-				return <span>{renderYesNo(value)}</span>;
-			}
-
-			if (displayValueAs === 'guardianLink') {
-				return (
-					<a
-						href={getGuardianUrl(valueString)}
-						rel="noreferrer"
-						target="_blank"
-					>
-						{valueString}
-					</a>
-				);
-			}
-
-			return <span>{valueString}</span>;
-		};
-
-		return (
-			<tr>
-				<th>
-					{property} {isPropertyOptional(property) && <b>[OPTIONAL]</b>}
-				</th>
-				<td>{getValueCellContents()}</td>
-				<td>{getPropertyDescription(property)}</td>
-			</tr>
-		);
-	};
-
 	return (
 		<div>
 			<div css={headingRowStyles(palette)}>
@@ -122,50 +51,52 @@ export const NewsletterDetail = ({ newsletter }: Props) => {
 				{!paused && !cancelled && <div>LIVE</div>}
 			</div>
 			<Illustration newsletter={newsletter} />
-			<div css={tableStyles(palette)}>
-				<table>
-					<caption>Reference Properties</caption>
-					<tbody>
-						<FieldRow property="identityName" />
-						<FieldRow property="listId" />
-						<FieldRow property="listIdV1" />
-					</tbody>
-				</table>
-				<table>
-					<caption>Status Flags and Settings</caption>
-					<tbody>
-						<FieldRow property="cancelled" />
-						<FieldRow property="paused" />
-						<FieldRow property="restricted" />
-						<FieldRow property="emailConfirmation" />
-					</tbody>
-				</table>
-				<table>
-					<caption>Display and Information Properties</caption>
-					<tbody>
-						<FieldRow property="name" />
-						<FieldRow property="theme" />
-						<FieldRow property="description" />
-						<FieldRow property="frequency" />
-						<FieldRow property="regionFocus" defaultDisplayValue="[NONE]" />
-						<FieldRow property="group" />
-						<FieldRow property="signupPage" displayValueAs="guardianLink" />
-						<FieldRow property="exampleUrl" displayValueAs="guardianLink" />
-					</tbody>
-				</table>
 
-				<table>
-					<caption>Tracking Values</caption>
-					<tbody>
-						<FieldRow property="brazeNewsletterName" />
-						<FieldRow property="brazeSubscribeAttributeName" />
-						<FieldRow property="brazeSubscribeEventNamePrefix" />
-						<FieldRow property="campaignName" />
-						<FieldRow property="campaignCode" />
-						<FieldRow property="brazeSubscribeAttributeNameAlternate" />
-					</tbody>
-				</table>
-			</div>
+			<NewsletterPropertyTable
+				newsletter={newsletter}
+				caption="Reference Properties"
+				fields={[
+					{ property: 'identityName' },
+					{ property: 'listId' },
+					{ property: 'listIdV1' },
+				]}
+			/>
+			<NewsletterPropertyTable
+				newsletter={newsletter}
+				caption="Status Flags and Settings"
+				fields={[
+					{ property: 'cancelled' },
+					{ property: 'paused' },
+					{ property: 'paused' },
+					{ property: 'restricted' },
+				]}
+			/>
+			<NewsletterPropertyTable
+				newsletter={newsletter}
+				caption="Display and Information Properties"
+				fields={[
+					{ property: 'name' },
+					{ property: 'theme' },
+					{ property: 'description' },
+					{ property: 'frequency' },
+					{ property: 'regionFocus', defaultDisplayValue: '[NONE]' },
+					{ property: 'group' },
+					{ property: 'signupPage', displayValueAs: 'guardianLink' },
+					{ property: 'exampleUrl', displayValueAs: 'guardianLink' },
+				]}
+			/>
+			<NewsletterPropertyTable
+				newsletter={newsletter}
+				caption="Tracking Values"
+				fields={[
+					{ property: 'brazeNewsletterName' },
+					{ property: 'brazeSubscribeAttributeName' },
+					{ property: 'brazeSubscribeEventNamePrefix' },
+					{ property: 'campaignName' },
+					{ property: 'campaignCode' },
+					{ property: 'brazeSubscribeAttributeNameAlternate' },
+				]}
+			/>
 		</div>
 	);
 };

--- a/apps/newsletters-ui/src/app/components/NewsletterDetails.tsx
+++ b/apps/newsletters-ui/src/app/components/NewsletterDetails.tsx
@@ -12,13 +12,13 @@ import {
 } from '@newsletters-nx/newsletters-data-client';
 import { getGuardianUrl, getPalette } from '../util';
 import type { SourcePalette } from '../util';
+import { Illustration } from './Illustration';
 
 interface Props {
 	newsletter: Newsletter;
 }
 
 const tableStyles = (palette: SourcePalette) => css`
-
 	caption {
 		${textSansObjectStyles.large()};
 		padding-top: ${space[4]}px;
@@ -114,14 +114,15 @@ export const NewsletterDetail = ({ newsletter }: Props) => {
 
 	return (
 		<div>
-			<div css={tableStyles(palette)}>
-				<div css={headingRowStyles(palette)}>
+			<div css={headingRowStyles(palette)}>
 				<h2>{name}</h2>
-					{cancelled && <div>CANCELLED</div>}
-					{paused && <div>PAUSED</div>}
-					{restricted && <div>restricted</div>}
-					{!paused && !cancelled && <div>LIVE</div>}
-				</div>
+				{cancelled && <div>CANCELLED</div>}
+				{paused && <div>PAUSED</div>}
+				{restricted && <div>restricted</div>}
+				{!paused && !cancelled && <div>LIVE</div>}
+			</div>
+			<Illustration newsletter={newsletter} />
+			<div css={tableStyles(palette)}>
 				<table>
 					<caption>Reference Properties</caption>
 					<tbody>

--- a/apps/newsletters-ui/src/app/components/NewsletterDetails.tsx
+++ b/apps/newsletters-ui/src/app/components/NewsletterDetails.tsx
@@ -6,7 +6,9 @@ import {
 	textSansObjectStyles,
 } from '@guardian/source-foundations';
 import type { Newsletter } from '@newsletters-nx/newsletters-data-client';
-import { newsletterSchema } from '@newsletters-nx/newsletters-data-client';
+import {
+	getPropertyDescription,
+} from '@newsletters-nx/newsletters-data-client';
 import { getPalette } from '../util';
 import type { SourcePalette } from '../util';
 
@@ -50,21 +52,18 @@ const flagStyles = (palette: SourcePalette) => css`
 `;
 
 export const NewsletterDetail = ({ newsletter }: Props) => {
-	const {
-		name,
-		theme,
-		cancelled,
-		paused,
-		restricted,
-	} = newsletter;
+	const { name, theme, cancelled, paused, restricted } = newsletter;
 
 	const palette = getPalette(theme);
 
-	const FieldRow = (property: keyof Newsletter, defaultDisplayValue?:string) => (
+	const FieldRow = (
+		property: keyof Newsletter,
+		defaultDisplayValue?: string,
+	) => (
 		<tr>
 			<th>{property}</th>
 			<td>{newsletter[property]?.toString() ?? defaultDisplayValue}</td>
-			<td>{newsletterSchema.shape[property].description}</td>
+			<td>{getPropertyDescription(property)}</td>
 		</tr>
 	);
 
@@ -87,8 +86,6 @@ export const NewsletterDetail = ({ newsletter }: Props) => {
 						{FieldRow('description')}
 						{FieldRow('frequency')}
 						{FieldRow('regionFocus', '[NONE]')}
-
-
 					</tbody>
 				</table>
 			</div>

--- a/apps/newsletters-ui/src/app/components/NewsletterDetails.tsx
+++ b/apps/newsletters-ui/src/app/components/NewsletterDetails.tsx
@@ -10,7 +10,7 @@ import {
 	getPropertyDescription,
 	isPropertyOptional,
 } from '@newsletters-nx/newsletters-data-client';
-import { getGuardianUrl, getPalette } from '../util';
+import { getGuardianUrl, getPalette, renderYesNo } from '../util';
 import type { SourcePalette } from '../util';
 import { Illustration } from './Illustration';
 
@@ -78,12 +78,12 @@ export const NewsletterDetail = ({ newsletter }: Props) => {
 		defaultDisplayValue?: string;
 		displayValueAs?: 'guardianLink' | 'text';
 	}) => {
-		const valueString =
-			newsletter[property]?.toString() ?? defaultDisplayValue ?? '';
+		const value = newsletter[property];
+		const valueString = value?.toString() ?? defaultDisplayValue ?? '';
 
 		const getValueCellContents = () => {
-			if (typeof newsletter[property] === 'boolean') {
-				return <span>{newsletter[property] ? '✅ Yes' : '❌ No'}</span>;
+			if (typeof value === 'boolean') {
+				return <span>{renderYesNo(value)}</span>;
 			}
 
 			if (displayValueAs === 'guardianLink') {
@@ -132,7 +132,7 @@ export const NewsletterDetail = ({ newsletter }: Props) => {
 					</tbody>
 				</table>
 				<table>
-					<caption>Status flags and settings</caption>
+					<caption>Status Flags and Settings</caption>
 					<tbody>
 						<FieldRow property="cancelled" />
 						<FieldRow property="paused" />
@@ -141,7 +141,7 @@ export const NewsletterDetail = ({ newsletter }: Props) => {
 					</tbody>
 				</table>
 				<table>
-					<caption>Display and information Properties</caption>
+					<caption>Display and Information Properties</caption>
 					<tbody>
 						<FieldRow property="name" />
 						<FieldRow property="theme" />
@@ -155,7 +155,7 @@ export const NewsletterDetail = ({ newsletter }: Props) => {
 				</table>
 
 				<table>
-					<caption>tracking values</caption>
+					<caption>Tracking Values</caption>
 					<tbody>
 						<FieldRow property="brazeNewsletterName" />
 						<FieldRow property="brazeSubscribeAttributeName" />

--- a/apps/newsletters-ui/src/app/components/NewsletterDetails.tsx
+++ b/apps/newsletters-ui/src/app/components/NewsletterDetails.tsx
@@ -6,6 +6,7 @@ import {
 	textSansObjectStyles,
 } from '@guardian/source-foundations';
 import type { Newsletter } from '@newsletters-nx/newsletters-data-client';
+import { newsletterSchema } from '@newsletters-nx/newsletters-data-client';
 import { getPalette } from '../util';
 import type { SourcePalette } from '../util';
 
@@ -51,18 +52,21 @@ const flagStyles = (palette: SourcePalette) => css`
 export const NewsletterDetail = ({ newsletter }: Props) => {
 	const {
 		name,
-		identityName,
-		description,
 		theme,
-		frequency,
-		regionFocus,
 		cancelled,
 		paused,
 		restricted,
-		listId,
 	} = newsletter;
 
 	const palette = getPalette(theme);
+
+	const FieldRow = (property: keyof Newsletter, defaultDisplayValue?:string) => (
+		<tr>
+			<th>{property}</th>
+			<td>{newsletter[property]?.toString() ?? defaultDisplayValue}</td>
+			<td>{newsletterSchema.shape[property].description}</td>
+		</tr>
+	);
 
 	return (
 		<div>
@@ -76,30 +80,15 @@ export const NewsletterDetail = ({ newsletter }: Props) => {
 				</div>
 				<table>
 					<tbody>
-						<tr>
-							<th>identityName</th>
-							<td>{identityName}</td>
-						</tr>
-						<tr>
-							<th>listId</th>
-							<td>{listId}</td>
-						</tr>
-						<tr>
-							<th>theme</th>
-							<td>{theme}</td>
-						</tr>
-						<tr>
-							<th>description</th>
-							<td>{description}</td>
-						</tr>
-						<tr>
-							<th>frequency</th>
-							<td>{frequency}</td>
-						</tr>
-						<tr>
-							<th>regionFocus</th>
-							<td>{regionFocus ?? '[UNDEFINED]'}</td>
-						</tr>
+						{FieldRow('name')}
+						{FieldRow('identityName')}
+						{FieldRow('listId')}
+						{FieldRow('theme')}
+						{FieldRow('description')}
+						{FieldRow('frequency')}
+						{FieldRow('regionFocus', '[NONE]')}
+
+
 					</tbody>
 				</table>
 			</div>

--- a/apps/newsletters-ui/src/app/components/NewsletterPropertyTable.tsx
+++ b/apps/newsletters-ui/src/app/components/NewsletterPropertyTable.tsx
@@ -1,0 +1,111 @@
+import { css } from '@emotion/react';
+import {
+	neutral,
+	space,
+	textSansObjectStyles,
+} from '@guardian/source-foundations';
+import type { Newsletter } from '@newsletters-nx/newsletters-data-client';
+import {
+	getPropertyDescription,
+	isPropertyOptional,
+} from '@newsletters-nx/newsletters-data-client';
+import { getGuardianUrl, getPalette, renderYesNo } from '../util';
+import type { SourcePalette } from '../util';
+
+interface Props {
+	newsletter: Newsletter;
+	fields: FieldRowProps[];
+	caption: string;
+}
+
+interface FieldRowProps {
+	property: keyof Newsletter;
+	defaultDisplayValue?: string;
+	displayValueAs?: 'guardianLink' | 'text';
+}
+
+const tableStyles = (palette: SourcePalette) => css`
+	caption {
+		${textSansObjectStyles.large()};
+		padding-top: ${space[4]}px;
+	}
+
+	th,
+	td {
+		text-align: left;
+		padding: ${space[1]}px;
+		${textSansObjectStyles.medium()};
+	}
+
+	th {
+		background-color: ${palette[400]};
+		color: ${neutral[97]};
+		min-width: 10rem;
+	}
+	td {
+		background-color: ${palette[800]};
+		color: ${neutral[7]};
+	}
+`;
+
+export const NewsletterPropertyTable = ({
+	newsletter,
+	fields,
+	caption,
+}: Props) => {
+	const { theme } = newsletter;
+
+	const palette = getPalette(theme);
+
+	const FieldRow = ({
+		property,
+		defaultDisplayValue,
+		displayValueAs = 'text',
+	}: FieldRowProps) => {
+		const value = newsletter[property];
+		const valueString = value?.toString() ?? defaultDisplayValue ?? '';
+
+		const getValueCellContents = () => {
+			if (typeof value === 'boolean') {
+				return <span>{renderYesNo(value)}</span>;
+			}
+
+			if (displayValueAs === 'guardianLink') {
+				return (
+					<a
+						href={getGuardianUrl(valueString)}
+						rel="noreferrer"
+						target="_blank"
+					>
+						{valueString}
+					</a>
+				);
+			}
+
+			return <span>{valueString}</span>;
+		};
+
+		return (
+			<tr>
+				<th>
+					{property} {isPropertyOptional(property) && <b>[OPTIONAL]</b>}
+				</th>
+				<td>{getValueCellContents()}</td>
+				<td>{getPropertyDescription(property)}</td>
+			</tr>
+		);
+	};
+
+	return (
+		<div css={tableStyles(palette)}>
+			<table>
+				<caption>{caption}</caption>
+				<tbody>
+					{fields.map((field) => (
+						<FieldRow {...field} />
+					))}
+				</tbody>
+			</table>
+		</div>
+	);
+};

--- a/apps/newsletters-ui/src/app/util.ts
+++ b/apps/newsletters-ui/src/app/util.ts
@@ -37,3 +37,6 @@ export const getGuardianUrl = (relativeUrl: string): string =>
 	`https://www.theguardian.com${
 		relativeUrl.startsWith('/') ? '' : '/'
 	}${relativeUrl}`;
+
+export const renderYesNo = (value: boolean): string =>
+	value ? '✅ Yes' : '❌ No';

--- a/apps/newsletters-ui/src/app/util.ts
+++ b/apps/newsletters-ui/src/app/util.ts
@@ -32,3 +32,8 @@ export const getPalette = (theme: string): SourcePalette => {
 			return brand;
 	}
 };
+
+export const getGuardianUrl = (relativeUrl: string): string =>
+	`https://www.theguardian.com${
+		relativeUrl.startsWith('/') ? '' : '/'
+	}${relativeUrl}`;

--- a/libs/newsletters-data-client/src/lib/newsletter-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-type.ts
@@ -54,7 +54,7 @@ const baseNewsletterSchema = z.object({
 	regionFocus: z
 		.string()
 		.optional()
-		.describe('Which region (au, uk, us) the newsletter is targetted at'),
+		.describe('Which region (AU, UK, US) the newsletter is targetted at'),
 	frequency: z
 		.string()
 		.optional()

--- a/libs/newsletters-data-client/src/lib/newsletter-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-type.ts
@@ -18,8 +18,8 @@ const emailEmbedSchema = z.object({
 });
 
 const baseNewsletterSchema = z.object({
-	identityName: nonEmptyString(),
-	name: nonEmptyString(),
+	identityName: nonEmptyString().describe('The unique id for the newsletter'),
+	name: nonEmptyString().describe('The public name of the newsletter'),
 	cancelled: z.boolean(),
 	restricted: z.boolean(),
 	paused: z.boolean(),
@@ -31,8 +31,11 @@ const baseNewsletterSchema = z.object({
 	group: nonEmptyString(),
 	description: z.string().optional(),
 	regionFocus: z.string().optional(),
-	frequency: z.string().optional(),
-	listId: z.number(),
+	frequency: z
+		.string()
+		.optional()
+		.describe('How often the newsletter is sent. Value is displayed to users.'),
+	listId: z.number().describe('a unique reference number for the newsletter'),
 	listIdV1: z.number(),
 	emailEmbed: emailEmbedSchema.optional(),
 	campaignName: z.string().optional(),
@@ -43,12 +46,22 @@ const baseNewsletterSchema = z.object({
 	illustration: illustrationSchema.optional(),
 });
 
+type Base = z.infer<typeof baseNewsletterSchema>;
+const getBaseDescription = (key: keyof Base): string =>
+	baseNewsletterSchema.shape[key].description ?? '';
+
 export const newsletterSchema = baseNewsletterSchema.extend({
-	description: nonEmptyString(),
-	frequency: nonEmptyString(),
-	brazeSubscribeAttributeName: nonEmptyString(),
-	brazeSubscribeEventNamePrefix: nonEmptyString(),
-	brazeNewsletterName: nonEmptyString(),
+	description: nonEmptyString().describe(getBaseDescription('description')),
+	frequency: nonEmptyString().describe(getBaseDescription('frequency')),
+	brazeSubscribeAttributeName: nonEmptyString().describe(
+		getBaseDescription('brazeSubscribeAttributeName'),
+	),
+	brazeSubscribeEventNamePrefix: nonEmptyString().describe(
+		getBaseDescription('brazeSubscribeEventNamePrefix'),
+	),
+	brazeNewsletterName: nonEmptyString().describe(
+		getBaseDescription('brazeNewsletterName'),
+	),
 	emailEmbed: emailEmbedSchema.extend({
 		description: z.string(),
 	}),

--- a/libs/newsletters-data-client/src/lib/newsletter-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-type.ts
@@ -20,9 +20,21 @@ const emailEmbedSchema = z.object({
 const baseNewsletterSchema = z.object({
 	identityName: nonEmptyString().describe('the unique id for the newsletter'),
 	name: nonEmptyString().describe('the public name of the newsletter'),
-	cancelled: z.boolean().describe('if true, the newsletter has been permanently discontinued, but must be retained on the list for data analysis and historical reports'),
-	restricted: z.boolean().describe('🤷 not being used. We think the idea was to use this for newsletters that you have to pay for or can\'t sign up for freely.'),
-	paused: z.boolean().describe('🤔 we don\'t know what this should mean, but paused newsletters don\'t appear on the all newsletters page.'),
+	cancelled: z
+		.boolean()
+		.describe(
+			'if true, the newsletter has been permanently discontinued, but must be retained on the list for data analysis and historical reports',
+		),
+	restricted: z
+		.boolean()
+		.describe(
+			"🤷 not being used. We think the idea was to use this for newsletters that you have to pay for or can't sign up for freely.",
+		),
+	paused: z
+		.boolean()
+		.describe(
+			"🤔 we don't know what this should mean, but paused newsletters don't appear on the all newsletters page.",
+		),
 	emailConfirmation: z
 		.boolean()
 		.describe(

--- a/libs/newsletters-data-client/src/lib/newsletter-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-type.ts
@@ -28,12 +28,12 @@ const baseNewsletterSchema = z.object({
 	restricted: z
 		.boolean()
 		.describe(
-			"🤷 not being used. We think the idea was to use this for newsletters that you have to pay for or can't sign up for freely.",
+			"The exact semantic meaning is not defined - believed to indicate the newsletter required payment or otherwise cannot be freely subscribed to by all users. Restricted newsletters don't appear on the all newsletters page and in-article promotions for them will not be rendered.",
 		),
 	paused: z
 		.boolean()
 		.describe(
-			"🤔 we don't know what this should mean, but paused newsletters don't appear on the all newsletters page.",
+			"Indicates the newsletter is not being sent currently, but may be (re)started in future. Paused newsletters don't appear on the all newsletters page and in-article promotions for them will not be rendered.",
 		),
 	emailConfirmation: z
 		.boolean()

--- a/libs/newsletters-data-client/src/lib/newsletter-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-type.ts
@@ -18,31 +18,55 @@ const emailEmbedSchema = z.object({
 });
 
 const baseNewsletterSchema = z.object({
-	identityName: nonEmptyString().describe('The unique id for the newsletter'),
-	name: nonEmptyString().describe('The public name of the newsletter'),
-	cancelled: z.boolean(),
-	restricted: z.boolean(),
-	paused: z.boolean(),
-	emailConfirmation: z.boolean(),
+	identityName: nonEmptyString().describe('the unique id for the newsletter'),
+	name: nonEmptyString().describe('the public name of the newsletter'),
+	cancelled: z.boolean().describe('if true, the newsletter has been permanently discontinued, but must be retained on the list for data analysis and historical reports'),
+	restricted: z.boolean().describe('🤷 not being used. We think the idea was to use this for newsletters that you have to pay for or can\'t sign up for freely.'),
+	paused: z.boolean().describe('🤔 we don\'t know what this should mean, but paused newsletters don\'t appear on the all newsletters page.'),
+	emailConfirmation: z
+		.boolean()
+		.describe(
+			'whether a confirmation email is sent to verify the subscription after a user submits a sign-up form',
+		),
 	brazeNewsletterName: z.string().optional(),
 	brazeSubscribeAttributeName: z.string().optional(),
 	brazeSubscribeEventNamePrefix: z.string().optional(),
 	theme: nonEmptyString(),
-	group: nonEmptyString(),
-	description: z.string().optional(),
-	regionFocus: z.string().optional(),
+	group: nonEmptyString().describe(
+		'the name of the section of the newsletters page the newsletter will be listed under',
+	),
+	description: z
+		.string()
+		.optional()
+		.describe('a short description of the newsletter to display to users'),
+	regionFocus: z
+		.string()
+		.optional()
+		.describe('Which region (au, uk, us) the newsletter is targetted at'),
 	frequency: z
 		.string()
 		.optional()
-		.describe('How often the newsletter is sent. Value is displayed to users.'),
+		.describe('how often the newsletter is sent.'),
 	listId: z.number().describe('a unique reference number for the newsletter'),
-	listIdV1: z.number(),
+	listIdV1: z
+		.number()
+		.describe(
+			'a legacy reference number - no longer needed, but retained on older newsletters for reference.',
+		),
 	emailEmbed: emailEmbedSchema.optional(),
 	campaignName: z.string().optional(),
 	campaignCode: z.string().optional(),
 	brazeSubscribeAttributeNameAlternate: z.array(z.string()).optional(),
-	signupPage: z.string().optional(),
-	exampleUrl: z.string().optional(),
+	signupPage: z
+		.string()
+		.optional()
+		.describe('the relative link to the sign-up page on theguardian.com'),
+	exampleUrl: z
+		.string()
+		.optional()
+		.describe(
+			'a relative link to a page on theguardian.com rendering an example chapter of the newsletter',
+		),
 	illustration: illustrationSchema.optional(),
 });
 
@@ -88,3 +112,6 @@ export function isCancelledNewsletter(
 	return cancelledNewsletterSchema.safeParse(subject).success;
 }
 
+export function isPropertyOptional(property: keyof Newsletter): boolean {
+	return newsletterSchema.shape[property].isOptional();
+}

--- a/libs/newsletters-data-client/src/lib/newsletter-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-type.ts
@@ -47,20 +47,20 @@ const baseNewsletterSchema = z.object({
 });
 
 type Base = z.infer<typeof baseNewsletterSchema>;
-const getBaseDescription = (key: keyof Base): string =>
+export const getPropertyDescription = (key: keyof Base): string =>
 	baseNewsletterSchema.shape[key].description ?? '';
 
 export const newsletterSchema = baseNewsletterSchema.extend({
-	description: nonEmptyString().describe(getBaseDescription('description')),
-	frequency: nonEmptyString().describe(getBaseDescription('frequency')),
+	description: nonEmptyString().describe(getPropertyDescription('description')),
+	frequency: nonEmptyString().describe(getPropertyDescription('frequency')),
 	brazeSubscribeAttributeName: nonEmptyString().describe(
-		getBaseDescription('brazeSubscribeAttributeName'),
+		getPropertyDescription('brazeSubscribeAttributeName'),
 	),
 	brazeSubscribeEventNamePrefix: nonEmptyString().describe(
-		getBaseDescription('brazeSubscribeEventNamePrefix'),
+		getPropertyDescription('brazeSubscribeEventNamePrefix'),
 	),
 	brazeNewsletterName: nonEmptyString().describe(
-		getBaseDescription('brazeNewsletterName'),
+		getPropertyDescription('brazeNewsletterName'),
 	),
 	emailEmbed: emailEmbedSchema.extend({
 		description: z.string(),
@@ -87,3 +87,4 @@ export function isCancelledNewsletter(
 ): subject is CancelledNewsletter {
 	return cancelledNewsletterSchema.safeParse(subject).success;
 }
+


### PR DESCRIPTION
## What does this change?

 - adds descriptions to the un-nested fields on the newsletter schema and exports a function to get the description for an given field
- uses the descriptions from the schema on the 'newsletter details' page
- adds some styling to the details page
- styles the `Layout` header and footer, highlighting the nav link to the current page


## How to test

run the project and take a look.

## How can we measure success?

Sets up the structure to apply some better styling on at a later stage.

## Images
### homepage with new `Layout`
<img width="1192" alt="Screenshot 2023-02-07 at 16 13 57" src="https://user-images.githubusercontent.com/30567854/217300526-ca39cf7b-cfe2-4960-af9a-f1779dc6e57e.png">

### details page
<img width="1192" alt="Screenshot 2023-02-07 at 16 13 37" src="https://user-images.githubusercontent.com/30567854/217300643-c0b6b84f-f252-4ea9-9471-1cc2c684a91d.png">


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
