### PR TITLE
chore: separate cdk checks from general checks for git hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+# Check CDK setup before committing
+if [[ $(git diff --name-status --staged | xargs echo | grep cdk/ ) ]];
+	then echo "Detected changes in CDK dir. Checking status..."
+	npm --prefix cdk run lint && npm --prefix cdk run test
+fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,7 +4,3 @@
 # Check workspace before pushing
 npx nx affected --target=format:check,lint,test,build --parallel=3
 
-# Check CDK setup before pushing
-alias cdk="npm --prefix cdk"
-cdk run lint
-cdk run test


### PR DESCRIPTION
## What does this change?

This change results in only running the CDK directory `lint` and `test` commands if there are staged changes detected **pre commit**, and no longer checks this on pre-push. This should speed up pushing changes to remote.

## How can we measure success?

This should decrease the amount of time waiting pre-push for ordinary changes in the repo and only run the checks when certain changes are about to be committed.

## Have we considered potential risks?

This is a non-risky change and only affects developer experience.
