### PR TITLE
David/wizard forms

### DIFF
--- a/apps/newsletters-api/src/app/routes/currentStep.ts
+++ b/apps/newsletters-api/src/app/routes/currentStep.ts
@@ -13,8 +13,6 @@ import {
 	stateMachineButtonPressed,
 } from '@newsletters-nx/state-machine';
 
-
-
 const convertWizardStepLayoutButtonsToWizardButtons = (
 	layoutButtons: WizardStepLayout['buttons'],
 ): CurrentStepRouteResponse['buttons'] => {
@@ -63,14 +61,20 @@ export function registerCurrentStepRoute(app: FastifyInstance) {
 								body.buttonId,
 								{
 									currentStepId: body.stepId,
-									formData : body.formData,
+									formData: body.formData,
 								},
 								newslettersWorkflowStepLayout,
 						  )
 						: setupInitialState();
 			} catch (error) {
 				if (error instanceof Error) {
-					return res.status(400).send({ message: error.message, body: body });
+					const errorResponse: CurrentStepRouteResponse = {
+						errorMessage: error.message,
+						currentStepId: body.stepId,
+					};
+					return res
+						.status(400)
+						.send(errorResponse);
 				}
 			}
 
@@ -86,6 +90,7 @@ export function registerCurrentStepRoute(app: FastifyInstance) {
 			return {
 				markdownToDisplay: nextWizardStepLayout.markdownToDisplay,
 				currentStepId: result.currentStepId,
+				errorMessage: result.errorMessage,
 				buttons: convertWizardStepLayoutButtonsToWizardButtons(
 					nextWizardStepLayout.buttons,
 				),

--- a/apps/newsletters-api/src/app/routes/currentStep.ts
+++ b/apps/newsletters-api/src/app/routes/currentStep.ts
@@ -63,8 +63,7 @@ export function registerCurrentStepRoute(app: FastifyInstance) {
 								body.buttonId,
 								{
 									currentStepId: body.stepId,
-									formData : undefined,
-									errorMessage: undefined,
+									formData : body.formData,
 								},
 								newslettersWorkflowStepLayout,
 						  )

--- a/apps/newsletters-api/src/app/routes/currentStep.ts
+++ b/apps/newsletters-api/src/app/routes/currentStep.ts
@@ -72,9 +72,7 @@ export function registerCurrentStepRoute(app: FastifyInstance) {
 						errorMessage: error.message,
 						currentStepId: body.stepId,
 					};
-					return res
-						.status(400)
-						.send(errorResponse);
+					return res.status(400).send(errorResponse);
 				}
 			}
 

--- a/apps/newsletters-api/src/app/routes/currentStep.ts
+++ b/apps/newsletters-api/src/app/routes/currentStep.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { newslettersWorkflowStepLayout } from '@newsletters-nx/newsletter-workflow';
 import type {
+	CurrentStepRouteRequest,
 	CurrentStepRouteResponse,
 	WizardButton,
 	WizardStepData,
@@ -12,19 +13,7 @@ import {
 	stateMachineButtonPressed,
 } from '@newsletters-nx/state-machine';
 
-interface CurrentStepRouteParams {
-	/** If the newletterId is undefined then this is a new newsletter otherwise
-	 * an existing one */
-	newsletterId?: string;
-	/** ID of the button that was pressed to get to the current step */
-	buttonId?: string;
-}
 
-// TODO: This is a dummy for the S3 bucket.
-// Make the current step id optional
-const stepData: WizardStepData = {
-	currentStepId: 'createNewsletter',
-};
 
 const convertWizardStepLayoutButtonsToWizardButtons = (
 	layoutButtons: WizardStepLayout['buttons'],
@@ -55,10 +44,10 @@ const convertWizardStepLayoutButtonsToWizardButtons = (
  * @param app - Fastify instance to add the route to
  */
 export function registerCurrentStepRoute(app: FastifyInstance) {
-	app.post<{ Body: CurrentStepRouteParams }>(
+	app.post<{ Body: CurrentStepRouteRequest }>(
 		'/v1/currentstep',
 		async (req, res): Promise<CurrentStepRouteResponse> => {
-			const body: CurrentStepRouteParams = req.body;
+			const body: CurrentStepRouteRequest = req.body;
 
 			if (body.newsletterId === undefined) {
 				return res
@@ -72,7 +61,11 @@ export function registerCurrentStepRoute(app: FastifyInstance) {
 					body.buttonId !== undefined
 						? await stateMachineButtonPressed(
 								body.buttonId,
-								stepData,
+								{
+									currentStepId: body.stepId,
+									formData : undefined,
+									errorMessage: undefined,
+								},
 								newslettersWorkflowStepLayout,
 						  )
 						: setupInitialState();

--- a/apps/newsletters-ui/src/app/components/Wizard.tsx
+++ b/apps/newsletters-ui/src/app/components/Wizard.tsx
@@ -20,7 +20,9 @@ export const Wizard: React.FC<WizardProps> = () => {
 	const [wizardStep, setWizardStep] = useState<
 		CurrentStepRouteResponse | undefined
 	>(undefined);
-	const [serverErrorMesssage, setServerErrorMessage] = useState<string | undefined>();
+	const [serverErrorMesssage, setServerErrorMessage] = useState<
+		string | undefined
+	>();
 
 	const fetchStep = (body: CurrentStepRouteRequest) => {
 		return fetch(`/api/v1/currentstep`, {
@@ -71,7 +73,9 @@ export const Wizard: React.FC<WizardProps> = () => {
 	return (
 		<>
 			<MarkdownView markdown={wizardStep.markdownToDisplay ?? ''} />
-			{wizardStep.errorMessage && <p>Please try again: {wizardStep.errorMessage}</p>}
+			{wizardStep.errorMessage && (
+				<p>Please try again: {wizardStep.errorMessage}</p>
+			)}
 			{Object.entries(wizardStep.buttons ?? {}).map(([key, button]) => (
 				<WizardButton
 					id={button.id}

--- a/apps/newsletters-ui/src/app/components/Wizard.tsx
+++ b/apps/newsletters-ui/src/app/components/Wizard.tsx
@@ -20,6 +20,7 @@ export const Wizard: React.FC<WizardProps> = () => {
 	const [wizardStep, setWizardStep] = useState<
 		CurrentStepRouteResponse | undefined
 	>(undefined);
+	const [errorMesssage, setErrorMessage] = useState<string | undefined>();
 
 	const fetchStep = (body: CurrentStepRouteRequest) => {
 		return fetch(`/api/v1/currentstep`, {
@@ -31,9 +32,16 @@ export const Wizard: React.FC<WizardProps> = () => {
 		})
 			.then((response) => response.json())
 			.then((data: CurrentStepRouteResponse) => {
+				if (data.errorMessage) {
+					console.warn(data.errorMessage)
+					setErrorMessage(data.errorMessage)
+					return
+				}
+
 				setWizardStep(data as unknown as CurrentStepRouteResponse);
 			})
 			.catch((error: unknown /* FIXME! */) => {
+				setErrorMessage('Wizard failed')
 				console.error('Error invoking next step of wizard:', error);
 			});
 	};
@@ -47,6 +55,15 @@ export const Wizard: React.FC<WizardProps> = () => {
 
 	if (wizardStep === undefined) {
 		return <p>'loading'</p>;
+	}
+
+	if (errorMesssage) {
+		return (
+			<p>
+				<b>ERROR:</b>
+				<span>{errorMesssage}</span>
+			</p>
+		);
 	}
 
 	const handleButtonClick = (id: string) => () => {

--- a/apps/newsletters-ui/src/app/components/Wizard.tsx
+++ b/apps/newsletters-ui/src/app/components/Wizard.tsx
@@ -20,7 +20,7 @@ export const Wizard: React.FC<WizardProps> = () => {
 	const [wizardStep, setWizardStep] = useState<
 		CurrentStepRouteResponse | undefined
 	>(undefined);
-	const [errorMesssage, setErrorMessage] = useState<string | undefined>();
+	const [serverErrorMesssage, setServerErrorMessage] = useState<string | undefined>();
 
 	const fetchStep = (body: CurrentStepRouteRequest) => {
 		return fetch(`/api/v1/currentstep`, {
@@ -32,16 +32,10 @@ export const Wizard: React.FC<WizardProps> = () => {
 		})
 			.then((response) => response.json())
 			.then((data: CurrentStepRouteResponse) => {
-				if (data.errorMessage) {
-					console.warn(data.errorMessage)
-					setErrorMessage(data.errorMessage)
-					return
-				}
-
 				setWizardStep(data as unknown as CurrentStepRouteResponse);
 			})
 			.catch((error: unknown /* FIXME! */) => {
-				setErrorMessage('Wizard failed')
+				setServerErrorMessage('Wizard failed');
 				console.error('Error invoking next step of wizard:', error);
 			});
 	};
@@ -57,11 +51,11 @@ export const Wizard: React.FC<WizardProps> = () => {
 		return <p>'loading'</p>;
 	}
 
-	if (errorMesssage) {
+	if (serverErrorMesssage) {
 		return (
 			<p>
 				<b>ERROR:</b>
-				<span>{errorMesssage}</span>
+				<span>{serverErrorMesssage}</span>
 			</p>
 		);
 	}
@@ -77,6 +71,7 @@ export const Wizard: React.FC<WizardProps> = () => {
 	return (
 		<>
 			<MarkdownView markdown={wizardStep.markdownToDisplay ?? ''} />
+			{wizardStep.errorMessage && <p>Please try again: {wizardStep.errorMessage}</p>}
 			{Object.entries(wizardStep.buttons ?? {}).map(([key, button]) => (
 				<WizardButton
 					id={button.id}

--- a/apps/newsletters-ui/src/app/components/Wizard.tsx
+++ b/apps/newsletters-ui/src/app/components/Wizard.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useState } from 'react';
-import type { CurrentStepRouteResponse } from '@newsletters-nx/state-machine';
+import type {
+	CurrentStepRouteRequest,
+	CurrentStepRouteResponse,
+} from '@newsletters-nx/state-machine';
 import { MarkdownView } from './MarkdownView';
 import { WizardButton } from './WizardButton';
 
@@ -18,7 +21,7 @@ export const Wizard: React.FC<WizardProps> = () => {
 		CurrentStepRouteResponse | undefined
 	>(undefined);
 
-	const fetchStep = (body: Record<string, string>) => {
+	const fetchStep = (body: CurrentStepRouteRequest) => {
 		return fetch(`/api/v1/currentstep`, {
 			method: 'POST',
 			headers: {
@@ -34,22 +37,26 @@ export const Wizard: React.FC<WizardProps> = () => {
 				console.error('Error invoking next step of wizard:', error);
 			});
 	};
+
 	useEffect(() => {
 		void fetchStep({
 			newsletterId: 'test',
+			stepId: '',
 		});
 	}, []);
+
+	if (wizardStep === undefined) {
+		return <p>'loading'</p>;
+	}
 
 	const handleButtonClick = (id: string) => () => {
 		void fetchStep({
 			newsletterId: 'test',
 			buttonId: id,
+			stepId: wizardStep.currentStepId || '',
 		});
 	};
 
-	if (wizardStep === undefined) {
-		return <p>'loading'</p>;
-	}
 	return (
 		<>
 			<MarkdownView markdown={wizardStep.markdownToDisplay ?? ''} />
@@ -61,7 +68,7 @@ export const Wizard: React.FC<WizardProps> = () => {
 					onClick={() => {
 						handleButtonClick(button.id)();
 					}}
-					key={key + button.label}
+					key={`${key}${button.label}`}
 				/>
 			))}
 		</>

--- a/libs/newsletter-workflow/src/lib/newsletter-workflow.ts
+++ b/libs/newsletter-workflow/src/lib/newsletter-workflow.ts
@@ -1,65 +1,10 @@
-import { getPropertyDescription } from '@newsletters-nx/newsletters-data-client';
 import type {
 	WizardLayout,
-	WizardStepLayout,
 } from '@newsletters-nx/state-machine';
-
-const createNewsletterLayout: WizardStepLayout = {
-	markdownToDisplay: `# Create a new newsletter
-
-This wizard will guide you through the process of creating and launching a new newsletter using email-rendering`,
-	buttons: {
-		cancel: {
-			buttonType: 'RED',
-			label: 'Cancel',
-			stepToMoveTo: 'cancel',
-		},
-		start: {
-			buttonType: 'GREEN',
-			label: 'Start',
-			stepToMoveTo: 'newsletterName',
-			executeStep: (stepData, stepLayout): string | undefined => {
-				return undefined;
-			},
-		},
-	},
-};
-
-const cancelLayout: WizardStepLayout = {
-	markdownToDisplay: `# Cancelled
-
-Creation of the newsletter was cancelled.`,
-	buttons: {},
-};
-
-const finishLayout: WizardStepLayout = {
-	markdownToDisplay: `# Finished
-
-You have reached the end of the wizard.`,
-	buttons: {},
-};
-
-const newsletterNameLayout: WizardStepLayout = {
-	markdownToDisplay: `# Newsletter name
-
-${getPropertyDescription('name')}
-
-// Embed an image showing the rendered text.
-![Newsletter name](https://unsplash.com/photos/5Zg8ZQZJ9qM/download?force=true&w=640)
-`,
-	buttons: {
-		back: {
-			buttonType: 'RED',
-			label: 'Back',
-			stepToMoveTo: 'createNewsletter',
-		},
-		finish: {
-			buttonType: 'GREEN',
-			label: 'Finish',
-			stepToMoveTo: 'finish',
-		},
-	},
-};
+import { cancelLayout } from './steps/cancelLayout';
+import { createNewsletterLayout } from './steps/createNewsletterLayout';
+import { finishLayout } from './steps/finishLayout';
+import { newsletterNameLayout } from './steps/newsletterNameLayout';
 
 export const newslettersWorkflowStepLayout: WizardLayout = {
 	createNewsletter: createNewsletterLayout,

--- a/libs/newsletter-workflow/src/lib/newsletter-workflow.ts
+++ b/libs/newsletter-workflow/src/lib/newsletter-workflow.ts
@@ -1,6 +1,4 @@
-import type {
-	WizardLayout,
-} from '@newsletters-nx/state-machine';
+import type { WizardLayout } from '@newsletters-nx/state-machine';
 import { cancelLayout } from './steps/cancelLayout';
 import { createNewsletterLayout } from './steps/createNewsletterLayout';
 import { finishLayout } from './steps/finishLayout';

--- a/libs/newsletter-workflow/src/lib/steps/cancelLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/cancelLayout.ts
@@ -1,0 +1,12 @@
+import type { WizardStepLayout } from '@newsletters-nx/state-machine';
+
+const markdownToDisplay = `
+# Cancelled
+
+Creation of the newsletter was cancelled.
+`.trim();
+
+export const cancelLayout: WizardStepLayout = {
+	markdownToDisplay,
+	buttons: {},
+};

--- a/libs/newsletter-workflow/src/lib/steps/createNewsletterLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/createNewsletterLayout.ts
@@ -1,0 +1,22 @@
+import type { WizardStepLayout } from '@newsletters-nx/state-machine';
+
+export const createNewsletterLayout: WizardStepLayout = {
+	markdownToDisplay: `# Create a new newsletter
+
+This wizard will guide you through the process of creating and launching a new newsletter using email-rendering`,
+	buttons: {
+		cancel: {
+			buttonType: 'RED',
+			label: 'Cancel',
+			stepToMoveTo: 'cancel',
+		},
+		start: {
+			buttonType: 'GREEN',
+			label: 'Start',
+			stepToMoveTo: 'newsletterName',
+			executeStep: (stepData, stepLayout): string | undefined => {
+				return undefined;
+			},
+		},
+	},
+};

--- a/libs/newsletter-workflow/src/lib/steps/finishLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/finishLayout.ts
@@ -1,0 +1,12 @@
+import type { WizardStepLayout } from '@newsletters-nx/state-machine';
+
+const markdownToDisplay = `# Finished
+
+You have reached the end of the wizard.`;
+
+const finishLayout: WizardStepLayout = {
+	markdownToDisplay,
+	buttons: {},
+};
+
+export { finishLayout };

--- a/libs/newsletter-workflow/src/lib/steps/newsletterNameLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterNameLayout.ts
@@ -1,5 +1,5 @@
-import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { getPropertyDescription } from '@newsletters-nx/newsletters-data-client';
+import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 
 const markdownToDisplay = `
 # Newsletter name

--- a/libs/newsletter-workflow/src/lib/steps/newsletterNameLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterNameLayout.ts
@@ -1,5 +1,8 @@
 import { getPropertyDescription } from '@newsletters-nx/newsletters-data-client';
-import type { WizardStepLayout } from '@newsletters-nx/state-machine';
+import type {
+	WizardStepData,
+	WizardStepLayout,
+} from '@newsletters-nx/state-machine';
 
 const markdownToDisplay = `
 # Newsletter name
@@ -23,6 +26,16 @@ export const newsletterNameLayout: WizardStepLayout = {
 			buttonType: 'GREEN',
 			label: 'Finish',
 			stepToMoveTo: 'finish',
+			onBeforeStepChangeValidate: (
+				stepData: WizardStepData,
+				stepLayout?: WizardStepLayout,
+			) => {
+				if (!stepData.formData?.name) {
+					return 'NO NAME PROVIDED';
+				}
+
+				return undefined;
+			},
 		},
 	},
 };

--- a/libs/newsletter-workflow/src/lib/steps/newsletterNameLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterNameLayout.ts
@@ -1,0 +1,28 @@
+import type { WizardStepLayout } from '@newsletters-nx/state-machine';
+import { getPropertyDescription } from '@newsletters-nx/newsletters-data-client';
+
+const markdownToDisplay = `
+# Newsletter name
+
+${getPropertyDescription('name')}
+
+// Embed an image showing the rendered text.
+![Newsletter name](https://unsplash.com/photos/5Zg8ZQZJ9qM/download?force=true&w=640)
+
+`.trim();
+
+export const newsletterNameLayout: WizardStepLayout = {
+	markdownToDisplay,
+	buttons: {
+		back: {
+			buttonType: 'RED',
+			label: 'Back',
+			stepToMoveTo: 'createNewsletter',
+		},
+		finish: {
+			buttonType: 'GREEN',
+			label: 'Finish',
+			stepToMoveTo: 'finish',
+		},
+	},
+};

--- a/libs/state-machine/src/lib/stateMachineButtonPressed.ts
+++ b/libs/state-machine/src/lib/stateMachineButtonPressed.ts
@@ -2,10 +2,19 @@ import type { WizardLayout, WizardStepData } from './types';
 
 export function setupInitialState(): WizardStepData {
 	return {
-		currentStepId: 'createNewsletter',
+		currentStepId: 'createNewsletter', //  TO DO - this needs to be generalised - each WizardLayout could have a different initial step
 	};
 }
 
+/**
+ * Perform the vaidation and actions required for a button press.Result a
+ * new WizardStepData containing either:
+ *
+ *  - a copy of the incomingStepData with an error message added if the step
+ * failed; or
+ *  - the currentStepId for the next step and the submitted form data
+ *  if the step was success
+ */
 export async function stateMachineButtonPressed(
 	buttonPressed: string,
 	incomingStepData: WizardStepData,
@@ -20,13 +29,14 @@ export async function stateMachineButtonPressed(
 		);
 	}
 
-	// TO DO - stop mutating the input!
 	if (buttonPressedDetails.onAfterStepStartValidate) {
 		const validationResult =
 			await buttonPressedDetails.onAfterStepStartValidate(incomingStepData);
 		if (validationResult !== undefined) {
-			incomingStepData.errorMessage = validationResult;
-			return incomingStepData;
+			return {
+				...incomingStepData,
+				errorMessage: validationResult,
+			};
 		}
 	}
 
@@ -36,8 +46,10 @@ export async function stateMachineButtonPressed(
 			currentStepLayout,
 		);
 		if (validationResult !== undefined) {
-			incomingStepData.errorMessage = validationResult;
-			return incomingStepData;
+			return {
+				...incomingStepData,
+				errorMessage: validationResult,
+			};
 		}
 	}
 
@@ -48,14 +60,15 @@ export async function stateMachineButtonPressed(
 				currentStepLayout,
 			);
 		if (validationResult !== undefined) {
-			incomingStepData.errorMessage = validationResult;
-			return incomingStepData;
+			return {
+				...incomingStepData,
+				errorMessage: validationResult,
+			};
 		}
 	}
 
-	const returnValue = {
-		...incomingStepData,
+	return {
 		currentStepId: buttonPressedDetails.stepToMoveTo,
+		formData: incomingStepData.formData,
 	};
-	return returnValue;
 }

--- a/libs/state-machine/src/lib/stateMachineButtonPressed.ts
+++ b/libs/state-machine/src/lib/stateMachineButtonPressed.ts
@@ -8,52 +8,53 @@ export function setupInitialState(): WizardStepData {
 
 export async function stateMachineButtonPressed(
 	buttonPressed: string,
-	stepData: WizardStepData,
-	stepLayout: WizardLayout,
+	incomingStepData: WizardStepData,
+	wizardLayout: WizardLayout,
 ): Promise<WizardStepData> {
-	const wizardStepLayout = stepLayout[stepData.currentStepId];
-	const buttonPressedDetails = wizardStepLayout?.buttons[buttonPressed];
+	const currentStepLayout = wizardLayout[incomingStepData.currentStepId];
+	const buttonPressedDetails = currentStepLayout?.buttons[buttonPressed];
 
 	if (!buttonPressedDetails) {
 		throw new Error(
-			`Button ${buttonPressed} not found in step ${stepData.currentStepId}`,
+			`Button ${buttonPressed} not found in step ${incomingStepData.currentStepId}`,
 		);
 	}
 
+	// TO DO - stop mutating the input!
 	if (buttonPressedDetails.onAfterStepStartValidate) {
 		const validationResult =
-			await buttonPressedDetails.onAfterStepStartValidate(stepData);
+			await buttonPressedDetails.onAfterStepStartValidate(incomingStepData);
 		if (validationResult !== undefined) {
-			stepData.errorMessage = validationResult;
-			return stepData;
+			incomingStepData.errorMessage = validationResult;
+			return incomingStepData;
 		}
 	}
 
 	if (buttonPressedDetails.executeStep) {
 		const validationResult = await buttonPressedDetails.executeStep(
-			stepData,
-			wizardStepLayout,
+			incomingStepData,
+			currentStepLayout,
 		);
 		if (validationResult !== undefined) {
-			stepData.errorMessage = validationResult;
-			return stepData;
+			incomingStepData.errorMessage = validationResult;
+			return incomingStepData;
 		}
 	}
 
 	if (buttonPressedDetails.onBeforeStepChangeValidate) {
 		const validationResult =
 			await buttonPressedDetails.onBeforeStepChangeValidate(
-				stepData,
-				wizardStepLayout,
+				incomingStepData,
+				currentStepLayout,
 			);
 		if (validationResult !== undefined) {
-			stepData.errorMessage = validationResult;
-			return stepData;
+			incomingStepData.errorMessage = validationResult;
+			return incomingStepData;
 		}
 	}
 
 	const returnValue = {
-		...stepData,
+		...incomingStepData,
 		currentStepId: buttonPressedDetails.stepToMoveTo,
 	};
 	return returnValue;

--- a/libs/state-machine/src/lib/types.ts
+++ b/libs/state-machine/src/lib/types.ts
@@ -44,6 +44,21 @@ export interface WizardStepLayout {
 export type WizardLayout = Record<string, WizardStepLayout>;
 
 /**
+ * Interface for the data payload sent to by the client for a single step in the wizard.
+ */
+export interface CurrentStepRouteRequest {
+	/** If the newletterId is undefined then this is a new newsletter otherwise
+	 * an existing one */
+	newsletterId?: string;
+	/** ID of the button that was pressed to get to the current step */
+	buttonId?: string;
+	/**ID of the step the use was on when thye pressed the button */
+	stepId: string;
+	/** arbitrary data entered by the user into a form before pressing the button */
+	formData?: Record<string, string>;
+}
+
+/**
  * Interface for the response received from the server for a single step in the wizard.
  */
 export interface CurrentStepRouteResponse {

--- a/libs/state-machine/src/lib/types.ts
+++ b/libs/state-machine/src/lib/types.ts
@@ -68,4 +68,6 @@ export interface CurrentStepRouteResponse {
 	currentStepId: string;
 	/** Buttons to display for the current step. */
 	buttons?: Record<string, WizardButton>;
+
+	errorMessage?: string;
 }


### PR DESCRIPTION
## What does this change?

sets up the data flow for form data
fixes some bugs where the frontend wasn't sending the step Id through
renders errors in the component

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
