### PR TITLE
Dblatcher/dynamic wizard markdown

### DIFF
--- a/apps/newsletters-api/src/app/routes/currentStep.ts
+++ b/apps/newsletters-api/src/app/routes/currentStep.ts
@@ -90,8 +90,14 @@ export function registerCurrentStepRoute(app: FastifyInstance) {
 					.send({ message: 'No next step found', body: body });
 			}
 
+			const { staticMarkdown, dynamicMarkdown } = nextWizardStepLayout;
+
+			const markdown = dynamicMarkdown
+				? dynamicMarkdown(body.formData, result.formData)
+				: staticMarkdown;
+
 			return {
-				markdownToDisplay: nextWizardStepLayout.markdownToDisplay,
+				markdownToDisplay: markdown,
 				currentStepId: result.currentStepId,
 				buttons: convertWizardStepLayoutButtonsToWizardButtons(
 					nextWizardStepLayout.buttons,

--- a/libs/newsletter-workflow/src/lib/getValuesFromRecord.ts
+++ b/libs/newsletter-workflow/src/lib/getValuesFromRecord.ts
@@ -1,4 +1,4 @@
-import { WizardFormData } from '@newsletters-nx/state-machine';
+import type { WizardFormData } from '@newsletters-nx/state-machine';
 
 export const getStringValuesFromRecord = (
 	record: WizardFormData,

--- a/libs/newsletter-workflow/src/lib/getValuesFromRecord.ts
+++ b/libs/newsletter-workflow/src/lib/getValuesFromRecord.ts
@@ -1,0 +1,14 @@
+import { WizardFormData } from '@newsletters-nx/state-machine';
+
+export const getStringValuesFromRecord = (
+	record: WizardFormData,
+	keys: string[],
+): string[] => {
+	return keys.map((key) => {
+		const value = record[key];
+		if (typeof value === 'undefined') {
+			return '';
+		}
+		return value.toString();
+	});
+};

--- a/libs/newsletter-workflow/src/lib/regExPatterns.ts
+++ b/libs/newsletter-workflow/src/lib/regExPatterns.ts
@@ -1,0 +1,3 @@
+export const regExPatterns = {
+	name: /{{name}}/g,
+} as const

--- a/libs/newsletter-workflow/src/lib/steps/cancelLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/cancelLayout.ts
@@ -7,6 +7,6 @@ Creation of the newsletter was cancelled.
 `.trim();
 
 export const cancelLayout: WizardStepLayout = {
-	markdownToDisplay,
+	staticMarkdown: markdownToDisplay,
 	buttons: {},
 };

--- a/libs/newsletter-workflow/src/lib/steps/createNewsletterLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/createNewsletterLayout.ts
@@ -2,7 +2,7 @@ import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeCreate } from '../executeCreate';
 
 export const createNewsletterLayout: WizardStepLayout = {
-	markdownToDisplay: `# Create a newsletter
+	staticMarkdown: `# Create a newsletter
 
 This wizard will guide you through the process of creating and launching a new newsletter using email-rendering.
 

--- a/libs/newsletter-workflow/src/lib/steps/descriptionLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/descriptionLayout.ts
@@ -16,7 +16,7 @@ This will appear on the sign up page e.g.
 `.trim();
 
 export const descriptionLayout: WizardStepLayout = {
-	markdownToDisplay,
+	staticMarkdown: markdownToDisplay,
 	buttons: {
 		back: {
 			buttonType: 'RED',

--- a/libs/newsletter-workflow/src/lib/steps/finishLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/finishLayout.ts
@@ -1,4 +1,5 @@
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
+import { getStringValuesFromRecord } from '../getValuesFromRecord';
 
 const markdownTemplate = `# Finished
 
@@ -13,11 +14,7 @@ const finishLayout: WizardStepLayout = {
 		if (!responseData) {
 			return staticMarkdown;
 		}
-		const { name = '' } = responseData;
-		if (typeof name !== 'string') {
-			return staticMarkdown;
-		}
-
+		const [name = 'NAME'] = getStringValuesFromRecord(responseData, ['name']);
 		return markdownTemplate.replace('{{name}}', name);
 	},
 };

--- a/libs/newsletter-workflow/src/lib/steps/finishLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/finishLayout.ts
@@ -1,12 +1,25 @@
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 
-const markdownToDisplay = `# Finished
+const markdownTemplate = `# Finished
 
-You have reached the end of the wizard.`;
+You have reached the end of the wizard. The draft newsletter **{{name}}** has been created.`;
+
+const staticMarkdown = markdownTemplate.replace('{{name}}', '');
 
 const finishLayout: WizardStepLayout = {
-	markdownToDisplay,
+	staticMarkdown: staticMarkdown,
 	buttons: {},
+	dynamicMarkdown(requestData, responseData) {
+		if (!responseData) {
+			return staticMarkdown;
+		}
+		const { name = '' } = responseData;
+		if (typeof name !== 'string') {
+			return staticMarkdown;
+		}
+
+		return markdownTemplate.replace('{{name}}', name);
+	},
 };
 
 export { finishLayout };

--- a/libs/newsletter-workflow/src/lib/steps/finishLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/finishLayout.ts
@@ -1,11 +1,12 @@
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { getStringValuesFromRecord } from '../getValuesFromRecord';
+import { regExPatterns } from '../regExPatterns';
 
 const markdownTemplate = `# Finished
 
 You have reached the end of the wizard. The draft newsletter **{{name}}** has been created.`;
 
-const staticMarkdown = markdownTemplate.replace('{{name}}', '');
+const staticMarkdown = markdownTemplate.replace(regExPatterns.name, '');
 
 const finishLayout: WizardStepLayout = {
 	staticMarkdown: staticMarkdown,
@@ -15,7 +16,7 @@ const finishLayout: WizardStepLayout = {
 			return staticMarkdown;
 		}
 		const [name = 'NAME'] = getStringValuesFromRecord(responseData, ['name']);
-		return markdownTemplate.replace('{{name}}', name);
+		return markdownTemplate.replace(regExPatterns.name, name);
 	},
 };
 

--- a/libs/newsletter-workflow/src/lib/steps/pillarLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/pillarLayout.ts
@@ -3,6 +3,7 @@ import type {
 	WizardStepLayout,
 } from '@newsletters-nx/state-machine';
 import { executeModify } from '../executeModify';
+import { getStringValuesFromRecord } from '../getValuesFromRecord';
 
 const markdownTemplate = `
 # Select a Pillar
@@ -26,11 +27,7 @@ export const pillarLayout: WizardStepLayout = {
 		if (!responseData) {
 			return staticMarkdown;
 		}
-		const { name = '' } = responseData;
-		if (typeof name !== 'string') {
-			return staticMarkdown;
-		}
-
+		const [name = 'NAME'] = getStringValuesFromRecord(responseData, ['name']);
 		return markdownTemplate.replace('{{name}}', name);
 	},
 	buttons: {

--- a/libs/newsletter-workflow/src/lib/steps/pillarLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/pillarLayout.ts
@@ -4,10 +4,10 @@ import type {
 } from '@newsletters-nx/state-machine';
 import { executeModify } from '../executeModify';
 
-const markdownToDisplay = `
+const markdownTemplate = `
 # Select a Pillar
 
-Now we choose the pillar that the newletter will appear under.
+Now we choose the pillar that **{{name}}** will appear under.
 
 For example:
 news, opinion, sport, culture, lifestyle
@@ -18,8 +18,21 @@ news, opinion, sport, culture, lifestyle
 
 `.trim();
 
+const staticMarkdown = markdownTemplate.replace('{{name}}', 'the newsletter');
+
 export const pillarLayout: WizardStepLayout = {
-	markdownToDisplay,
+	staticMarkdown,
+	dynamicMarkdown(requestData, responseData) {
+		if (!responseData) {
+			return staticMarkdown;
+		}
+		const { name = '' } = responseData;
+		if (typeof name !== 'string') {
+			return staticMarkdown;
+		}
+
+		return markdownTemplate.replace('{{name}}', name);
+	},
 	buttons: {
 		back: {
 			buttonType: 'RED',

--- a/libs/newsletter-workflow/src/lib/steps/pillarLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/pillarLayout.ts
@@ -4,9 +4,10 @@ import type {
 } from '@newsletters-nx/state-machine';
 import { executeModify } from '../executeModify';
 import { getStringValuesFromRecord } from '../getValuesFromRecord';
+import { regExPatterns } from '../regExPatterns';
 
 const markdownTemplate = `
-# Select a Pillar
+# Select a Pillar for {{name}}
 
 Now we choose the pillar that **{{name}}** will appear under.
 
@@ -19,7 +20,10 @@ news, opinion, sport, culture, lifestyle
 
 `.trim();
 
-const staticMarkdown = markdownTemplate.replace('{{name}}', 'the newsletter');
+const staticMarkdown = markdownTemplate.replace(
+	regExPatterns.name,
+	'the newsletter',
+);
 
 export const pillarLayout: WizardStepLayout = {
 	staticMarkdown,
@@ -28,7 +32,7 @@ export const pillarLayout: WizardStepLayout = {
 			return staticMarkdown;
 		}
 		const [name = 'NAME'] = getStringValuesFromRecord(responseData, ['name']);
-		return markdownTemplate.replace('{{name}}', name);
+		return markdownTemplate.replace(regExPatterns.name, name);
 	},
 	buttons: {
 		back: {

--- a/libs/state-machine/src/lib/stateMachineButtonPressed.spec.ts
+++ b/libs/state-machine/src/lib/stateMachineButtonPressed.spec.ts
@@ -14,7 +14,7 @@ beforeEach(() => {
 
 const mockWizardLayout: WizardLayout = {
 	step1: {
-		markdownToDisplay: 'Step 1',
+		staticMarkdown: 'Step 1',
 		buttons: {
 			next: {
 				buttonType: 'RED',
@@ -35,7 +35,7 @@ const mockWizardLayout: WizardLayout = {
 		},
 	},
 	step2: {
-		markdownToDisplay: 'Step 2',
+		staticMarkdown: 'Step 2',
 		buttons: {
 			prev: {
 				buttonType: 'RED',
@@ -56,7 +56,7 @@ const mockWizardLayout: WizardLayout = {
 		},
 	},
 	exit: {
-		markdownToDisplay: 'Exit',
+		staticMarkdown: 'Exit',
 		buttons: {},
 	},
 };

--- a/libs/state-machine/src/lib/types.ts
+++ b/libs/state-machine/src/lib/types.ts
@@ -59,7 +59,10 @@ export interface WizardStepLayoutButton {
 	executeStep?: AsyncExecution | Execution;
 }
 export interface WizardStepLayout {
-	markdownToDisplay: string;
+	staticMarkdown: string;
+	dynamicMarkdown?: {
+		(requestData?: WizardFormData, responseData?: WizardFormData): string;
+	};
 	buttons: Record<string, WizardStepLayoutButton>;
 }
 


### PR DESCRIPTION
## What does this change?

Wizard steps have an optional `dynamicMarkdown` method, which is passed the incoming (from the client) `WizardFormData` and outgoing (to the client) `WizardFormData` to produce a string of markdown to display to the user.

The existing `markDownToDisplay` property is renamed `staticMarkdown`.

If a step does not have a `dynamicMarkdown` method, the "currentStep" handler falls back to the `staticMarkdown`.

## How to test

Use the wizard - there are dynamic uses of the newsletter name on the 'Pillar" and "finished" steps

## How can we measure success?
The responses to the user can be customised based on the data they sent and /or the resulting change on the server.

## Have we considered potential risks?
Adds some complexity - have tried to add some helpers to make defining and populating a template from the data a bit easier.

## images
<img width="707" alt="Screenshot 2023-02-24 at 15 44 26" src="https://user-images.githubusercontent.com/30567854/221222338-1e2e7bbd-a937-4b18-a851-745de4d6688c.png">
