### PR TITLE
Display fields automatically calculated from the entered Name

### DIFF
--- a/libs/newsletter-workflow/src/lib/calculateFieldsFromName.ts
+++ b/libs/newsletter-workflow/src/lib/calculateFieldsFromName.ts
@@ -1,0 +1,34 @@
+import { deriveNewsletterFieldsFromName } from '@newsletters-nx/newsletters-data-client';
+import type { WizardFormData } from '@newsletters-nx/state-machine';
+
+export const calculateFieldsFromName = (
+	formData: WizardFormData,
+): WizardFormData => {
+	const derivedFields = deriveNewsletterFieldsFromName(formData.name as string);
+	const updatedFormData: WizardFormData = {
+		...formData,
+		...{
+			identityName: derivedFields.identityName,
+		},
+		...{
+			brazeSubscribeEventNamePrefix:
+				derivedFields.brazeSubscribeEventNamePrefix,
+		},
+		...{
+			brazeNewsletterName: derivedFields.brazeNewsletterName,
+		},
+		...{
+			brazeSubscribeAttributeName: derivedFields.brazeSubscribeAttributeName,
+		},
+		...{
+			brazeSubscribeAttributeNameAlternate:
+				derivedFields.brazeSubscribeAttributeNameAlternate
+					? derivedFields.brazeSubscribeAttributeNameAlternate[0]
+					: undefined,
+		},
+		...{ campaignName: derivedFields.campaignName },
+		...{ campaignCode: derivedFields.campaignCode },
+	};
+
+	return updatedFormData;
+};

--- a/libs/newsletter-workflow/src/lib/calculateFieldsFromName.ts
+++ b/libs/newsletter-workflow/src/lib/calculateFieldsFromName.ts
@@ -1,12 +1,9 @@
 import { deriveNewsletterFieldsFromName } from '@newsletters-nx/newsletters-data-client';
 import type { WizardFormData } from '@newsletters-nx/state-machine';
 
-export const calculateFieldsFromName = (
-	formData: WizardFormData,
-): WizardFormData => {
-	const derivedFields = deriveNewsletterFieldsFromName(formData.name as string);
-	const updatedFormData: WizardFormData = {
-		...formData,
+export const calculateFieldsFromName = (formName: string): WizardFormData => {
+	const derivedFields = deriveNewsletterFieldsFromName(formName);
+	const updatedFormData: Partial<WizardFormData> = {
 		...{
 			identityName: derivedFields.identityName,
 		},

--- a/libs/newsletter-workflow/src/lib/executeCreate.ts
+++ b/libs/newsletter-workflow/src/lib/executeCreate.ts
@@ -3,6 +3,7 @@ import type {
 	AsyncExecution,
 	WizardFormData,
 } from '@newsletters-nx/state-machine';
+import { calculateFieldsFromName } from './calculateFieldsFromName';
 import { executeModify } from './executeModify';
 
 export const executeCreate: AsyncExecution = async (
@@ -10,12 +11,12 @@ export const executeCreate: AsyncExecution = async (
 	stepLayout,
 	storageInstance,
 ): Promise<WizardFormData | string> => {
-	const schema = formSchemas['createNewsletter'];
+	const schema = formSchemas['createNewsletter']; // TODO - this needs to be generalised
 	if (!storageInstance) {
 		throw new Error('no storageInstance');
 	}
-	const parseResult = schema.safeParse(stepData.formData);
 
+	const parseResult = schema.safeParse(stepData.formData);
 	if (!parseResult.success) {
 		return `Form data is invalid for schema: ${
 			schema.description ?? '[no description]'
@@ -24,8 +25,10 @@ export const executeCreate: AsyncExecution = async (
 
 	const listId = stepData.formData ? stepData.formData['listId'] : undefined;
 	if (!listId) {
+		// TO DO - calculating fields from the Name at this point is not generic
+		// would it be better done somewhere else?
 		const storageResponse = await storageInstance.createDraftNewsletter({
-			...parseResult.data,
+			...calculateFieldsFromName(parseResult.data),
 			listId: undefined,
 		});
 		if (storageResponse.ok) {

--- a/libs/newsletter-workflow/src/lib/executeCreate.ts
+++ b/libs/newsletter-workflow/src/lib/executeCreate.ts
@@ -27,8 +27,13 @@ export const executeCreate: AsyncExecution = async (
 	if (!listId) {
 		// TO DO - calculating fields from the Name at this point is not generic
 		// would it be better done somewhere else?
+		const derivedFields =
+			typeof parseResult.data.name === 'string' && !!parseResult.data.name
+				? calculateFieldsFromName(parseResult.data.name)
+				: {};
 		const storageResponse = await storageInstance.createDraftNewsletter({
-			...calculateFieldsFromName(parseResult.data),
+			...parseResult.data,
+			...derivedFields,
 			listId: undefined,
 		});
 		if (storageResponse.ok) {

--- a/libs/newsletter-workflow/src/lib/newsletter-workflow.ts
+++ b/libs/newsletter-workflow/src/lib/newsletter-workflow.ts
@@ -1,4 +1,5 @@
 import type { WizardLayout } from '@newsletters-nx/state-machine';
+import { calculatedFieldLayout } from './steps/calculatedFieldLayout';
 import { cancelLayout } from './steps/cancelLayout';
 import { createNewsletterLayout } from './steps/createNewsletterLayout';
 import { descriptionLayout } from './steps/descriptionLayout';
@@ -8,6 +9,7 @@ import { pillarLayout } from './steps/pillarLayout';
 export const newslettersWorkflowStepLayout: WizardLayout = {
 	createNewsletter: createNewsletterLayout,
 	cancel: cancelLayout,
+	calculatedFields: calculatedFieldLayout,
 	pillar: pillarLayout,
 	description: descriptionLayout,
 	finish: finishLayout,

--- a/libs/newsletter-workflow/src/lib/newsletter-workflow.ts
+++ b/libs/newsletter-workflow/src/lib/newsletter-workflow.ts
@@ -1,15 +1,19 @@
 import type { WizardLayout } from '@newsletters-nx/state-machine';
-import { calculatedFieldLayout } from './steps/calculatedFieldLayout';
+import { brazeLayout } from './steps/brazeLayout';
 import { cancelLayout } from './steps/cancelLayout';
 import { createNewsletterLayout } from './steps/createNewsletterLayout';
 import { descriptionLayout } from './steps/descriptionLayout';
 import { finishLayout } from './steps/finishLayout';
+import { identityNameLayout } from './steps/identityNameLayout';
+import { ophanLayout } from './steps/ophanLayout';
 import { pillarLayout } from './steps/pillarLayout';
 
 export const newslettersWorkflowStepLayout: WizardLayout = {
 	createNewsletter: createNewsletterLayout,
 	cancel: cancelLayout,
-	calculatedFields: calculatedFieldLayout,
+	identityName: identityNameLayout,
+	braze: brazeLayout,
+	ophan: ophanLayout,
 	pillar: pillarLayout,
 	description: descriptionLayout,
 	finish: finishLayout,

--- a/libs/newsletter-workflow/src/lib/steps/brazeLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/brazeLayout.ts
@@ -11,7 +11,7 @@ They have been calculated automatically from the Name that you entered on a prev
 `.trim();
 
 export const brazeLayout: WizardStepLayout = {
-	markdownToDisplay,
+	staticMarkdown: markdownToDisplay,
 	buttons: {
 		back: {
 			buttonType: 'RED',

--- a/libs/newsletter-workflow/src/lib/steps/brazeLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/brazeLayout.ts
@@ -4,7 +4,7 @@ import { executeModify } from '../executeModify';
 const markdownToDisplay = `
 # Modify Braze Values
 
-These are tracking fields used by Braze.  TODO - MORE INFORMATION HERE
+These are tracking fields used by Braze.
 
 They have been calculated automatically from the Name that you entered on a previous step of the wizard, but you can change them if you need.
 

--- a/libs/newsletter-workflow/src/lib/steps/brazeLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/brazeLayout.ts
@@ -1,0 +1,33 @@
+import type { WizardStepLayout } from '@newsletters-nx/state-machine';
+import { executeModify } from '../executeModify';
+
+const markdownToDisplay = `
+# Modify Braze Values
+
+These are tracking fields used by Braze.  TODO - MORE INFORMATION HERE
+
+They have been calculated automatically from the Name that you entered on a previous step of the wizard, but you can change them if you need.
+
+`.trim();
+
+export const brazeLayout: WizardStepLayout = {
+	markdownToDisplay,
+	buttons: {
+		back: {
+			buttonType: 'RED',
+			label: 'Back',
+			stepToMoveTo: 'identityName',
+			executeStep: executeModify,
+		},
+		next: {
+			buttonType: 'GREEN',
+			label: 'Next',
+			stepToMoveTo: 'ophan',
+			onBeforeStepChangeValidate: () => {
+				// TO DO - check that braze values do not already exist in other draft or actual newsletter
+				return undefined;
+			},
+			executeStep: executeModify,
+		},
+	},
+};

--- a/libs/newsletter-workflow/src/lib/steps/calculatedFieldLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/calculatedFieldLayout.ts
@@ -1,0 +1,31 @@
+import type { WizardStepLayout } from '@newsletters-nx/state-machine';
+import { executeModify } from '../executeModify';
+
+const markdownToDisplay = `
+# Modify Calculated Fields
+
+The following fields have been calculated from the Name that you entered on the previous step of the wizard.
+
+`.trim();
+
+export const calculatedFieldLayout: WizardStepLayout = {
+	markdownToDisplay,
+	buttons: {
+		back: {
+			buttonType: 'RED',
+			label: 'Back',
+			stepToMoveTo: 'createNewsletter',
+			executeStep: executeModify,
+		},
+		next: {
+			buttonType: 'GREEN',
+			label: 'Next',
+			stepToMoveTo: 'pillar',
+			onBeforeStepChangeValidate: () => {
+				// TO DO - check that identityName does not already exist in other draft or actual newsletter
+				return undefined;
+			},
+			executeStep: executeModify,
+		},
+	},
+};

--- a/libs/newsletter-workflow/src/lib/steps/createNewsletterLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/createNewsletterLayout.ts
@@ -21,7 +21,7 @@ For example:
 		next: {
 			buttonType: 'GREEN',
 			label: 'Next',
-			stepToMoveTo: 'pillar',
+			stepToMoveTo: 'calculatedFields',
 			onBeforeStepChangeValidate: (stepData): string | undefined => {
 				const name = stepData.formData ? stepData.formData['name'] : undefined;
 				return name ? undefined : 'NO NAME PROVIDED';

--- a/libs/newsletter-workflow/src/lib/steps/createNewsletterLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/createNewsletterLayout.ts
@@ -21,7 +21,7 @@ For example:
 		next: {
 			buttonType: 'GREEN',
 			label: 'Next',
-			stepToMoveTo: 'calculatedFields',
+			stepToMoveTo: 'identityName',
 			onBeforeStepChangeValidate: (stepData): string | undefined => {
 				const name = stepData.formData ? stepData.formData['name'] : undefined;
 				return name ? undefined : 'NO NAME PROVIDED';

--- a/libs/newsletter-workflow/src/lib/steps/identityNameLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/identityNameLayout.ts
@@ -1,0 +1,33 @@
+import type { WizardStepLayout } from '@newsletters-nx/state-machine';
+import { executeModify } from '../executeModify';
+
+const markdownToDisplay = `
+# Modify Identity Name
+
+This is a unique identifier for the newsletter, used internally by the system and not displayed to newsletter readers.
+
+It has been calculated automatically from the Name that you entered on the previous step of the wizard, but you can change it if you need.
+
+`.trim();
+
+export const identityNameLayout: WizardStepLayout = {
+	markdownToDisplay,
+	buttons: {
+		back: {
+			buttonType: 'RED',
+			label: 'Back',
+			stepToMoveTo: 'createNewsletter',
+			executeStep: executeModify,
+		},
+		next: {
+			buttonType: 'GREEN',
+			label: 'Next',
+			stepToMoveTo: 'braze',
+			onBeforeStepChangeValidate: () => {
+				// TO DO - check that identityName does not already exist in other draft or actual newsletter
+				return undefined;
+			},
+			executeStep: executeModify,
+		},
+	},
+};

--- a/libs/newsletter-workflow/src/lib/steps/identityNameLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/identityNameLayout.ts
@@ -11,7 +11,7 @@ It has been calculated automatically from the Name that you entered on the previ
 `.trim();
 
 export const identityNameLayout: WizardStepLayout = {
-	markdownToDisplay,
+	staticMarkdown: markdownToDisplay,
 	buttons: {
 		back: {
 			buttonType: 'RED',

--- a/libs/newsletter-workflow/src/lib/steps/ophanLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/ophanLayout.ts
@@ -2,19 +2,21 @@ import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeModify } from '../executeModify';
 
 const markdownToDisplay = `
-# Modify Calculated Fields
+# Modify Ophan Campaign Values
 
-The following fields have been calculated from the Name that you entered on the previous step of the wizard.
+These are tracking fields used by Ophan.
+
+They have been calculated automatically from the Name that you entered on a previous step of the wizard, but you can change them if you need.
 
 `.trim();
 
-export const calculatedFieldLayout: WizardStepLayout = {
+export const ophanLayout: WizardStepLayout = {
 	markdownToDisplay,
 	buttons: {
 		back: {
 			buttonType: 'RED',
 			label: 'Back',
-			stepToMoveTo: 'createNewsletter',
+			stepToMoveTo: 'braze',
 			executeStep: executeModify,
 		},
 		next: {
@@ -22,7 +24,7 @@ export const calculatedFieldLayout: WizardStepLayout = {
 			label: 'Next',
 			stepToMoveTo: 'pillar',
 			onBeforeStepChangeValidate: () => {
-				// TO DO - check that identityName does not already exist in other draft or actual newsletter
+				// TO DO - check that ophan values do not already exist in other draft or actual newsletter
 				return undefined;
 			},
 			executeStep: executeModify,

--- a/libs/newsletter-workflow/src/lib/steps/ophanLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/ophanLayout.ts
@@ -11,7 +11,7 @@ They have been calculated automatically from the Name that you entered on a prev
 `.trim();
 
 export const ophanLayout: WizardStepLayout = {
-	markdownToDisplay,
+	staticMarkdown: markdownToDisplay,
 	buttons: {
 		back: {
 			buttonType: 'RED',

--- a/libs/newsletter-workflow/src/lib/steps/pillarLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/pillarLayout.ts
@@ -24,7 +24,7 @@ export const pillarLayout: WizardStepLayout = {
 		back: {
 			buttonType: 'RED',
 			label: 'Back',
-			stepToMoveTo: 'calculatedFields',
+			stepToMoveTo: 'ophan',
 			executeStep: executeModify,
 		},
 		finish: {

--- a/libs/newsletter-workflow/src/lib/steps/pillarLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/pillarLayout.ts
@@ -24,7 +24,7 @@ export const pillarLayout: WizardStepLayout = {
 		back: {
 			buttonType: 'RED',
 			label: 'Back',
-			stepToMoveTo: 'createNewsletter',
+			stepToMoveTo: 'calculatedFields',
 			executeStep: executeModify,
 		},
 		finish: {

--- a/libs/state-machine/src/schemas/index.ts
+++ b/libs/state-machine/src/schemas/index.ts
@@ -3,12 +3,25 @@ import { z, ZodBoolean, ZodEnum, ZodNumber, ZodString } from 'zod';
 
 type FormData = Record<string, string | number | boolean | undefined>;
 
+// TODO - move these definitions to a separate file
 export const formSchemas = {
 	createNewsletter: z
 		.object({
 			name: z.string(),
 		})
 		.describe('Input the name for the new newsletter'),
+
+	calculatedFields: z
+		.object({
+			identityName: z.string(),
+			brazeSubscribeEventNamePrefix: z.string(),
+			brazeNewsletterName: z.string(),
+			brazeSubscribeAttributeName: z.string(),
+			brazeSubscribeAttributeNameAlternate: z.string(),
+			campaignName: z.string(),
+			campaignCode: z.string(),
+		})
+		.describe('Edit the calculated fields if required'),
 
 	pillar: z
 		.object({
@@ -29,6 +42,9 @@ export const getFormSchema = (
 ): z.ZodObject<z.ZodRawShape> | undefined => {
 	if (stepId === 'createNewsletter') {
 		return formSchemas.createNewsletter;
+	}
+	if (stepId === 'calculatedFields') {
+		return formSchemas.calculatedFields;
 	}
 	if (stepId === 'pillar') {
 		return formSchemas.pillar;

--- a/libs/state-machine/src/schemas/index.ts
+++ b/libs/state-machine/src/schemas/index.ts
@@ -11,17 +11,27 @@ export const formSchemas = {
 		})
 		.describe('Input the name for the new newsletter'),
 
-	calculatedFields: z
+	identityName: z
 		.object({
 			identityName: z.string(),
+		})
+		.describe('Edit the identity name if required'),
+
+	braze: z
+		.object({
 			brazeSubscribeEventNamePrefix: z.string(),
 			brazeNewsletterName: z.string(),
 			brazeSubscribeAttributeName: z.string(),
 			brazeSubscribeAttributeNameAlternate: z.string(),
+		})
+		.describe('Edit the Braze values if required'),
+
+	ophan: z
+		.object({
 			campaignName: z.string(),
 			campaignCode: z.string(),
 		})
-		.describe('Edit the calculated fields if required'),
+		.describe('Edit the Ophan values if required'),
 
 	pillar: z
 		.object({
@@ -43,8 +53,14 @@ export const getFormSchema = (
 	if (stepId === 'createNewsletter') {
 		return formSchemas.createNewsletter;
 	}
-	if (stepId === 'calculatedFields') {
-		return formSchemas.calculatedFields;
+	if (stepId === 'identityName') {
+		return formSchemas.identityName;
+	}
+	if (stepId === 'braze') {
+		return formSchemas.braze;
+	}
+	if (stepId === 'ophan') {
+		return formSchemas.ophan;
 	}
 	if (stepId === 'pillar') {
 		return formSchemas.pillar;


### PR DESCRIPTION
## What does this change?

After the user enters a Name and presses the Next button, three new pages of the wizard are displayed showing the fields automatically calculated from the Name field, and allowing them to be modified if required.

Validation needs to be added to ensure that the entered fields do not already exist (in any other draft or actual newsletter)

## How to test

Run `npm run dev` and navigate through the wizard

## Images

https://user-images.githubusercontent.com/74301289/221370633-512dc1ce-1c6a-445d-bbac-019cc40985af.mov





