### PR TITLE
State edit forms

### DIFF
--- a/apps/newsletters-ui/src/app/components/SchemaForm/styling.ts
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/styling.ts
@@ -20,6 +20,6 @@ export const defaultFormStyle = css`
 		display: block;
 		${headlineObjectStyles.xxsmall({ fontWeight: 'bold' })};
 		border-bottom: 1px solid ${neutral[20]};
-		margin: 0.25rem 0;
+		margin: 0.25rem 0 1rem;
 	}
 `;

--- a/apps/newsletters-ui/src/app/components/SchemaForm/styling.ts
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/styling.ts
@@ -1,4 +1,4 @@
-import { headlineObjectStyles, palette } from '@guardian/source-foundations';
+import { palette } from '@guardian/source-foundations';
 import { css } from '@mui/material';
 
 const { neutral } = palette;
@@ -18,7 +18,7 @@ export const defaultFormStyle = css`
 
 	legend {
 		display: block;
-		${headlineObjectStyles.xxsmall({ fontWeight: 'bold' })};
+		font-weight: bold;
 		border-bottom: 1px solid ${neutral[20]};
 		margin: 0.25rem 0 1rem;
 	}

--- a/apps/newsletters-ui/src/app/components/StateEditForm.tsx
+++ b/apps/newsletters-ui/src/app/components/StateEditForm.tsx
@@ -11,6 +11,26 @@ interface Props {
 	setFormData: { (newData: WizardFormData): void };
 }
 
+const getValidationWarnings = (
+	formSchema: z.ZodObject<z.ZodRawShape>,
+	formData: WizardFormData,
+): Partial<Record<string, string>> => {
+	const parseResult = formSchema.safeParse(formData);
+	const validationWarnings: Partial<Record<string, string>> = {};
+
+	if (!parseResult.success) {
+		parseResult.error.issues.forEach((issue) => {
+			const { message, path, code } = issue;
+			const key = typeof path[0] === 'string' ? path[0] : undefined;
+
+			if (key) {
+				validationWarnings[key] = message || code;
+			}
+		});
+	}
+	return validationWarnings;
+};
+
 export const StateEditForm = ({ formSchema, formData, setFormData }: Props) => {
 	const changeFormData = (value: FieldValue, field: FieldDef) => {
 		const mod = getModification(value, field);
@@ -28,7 +48,7 @@ export const StateEditForm = ({ formSchema, formData, setFormData }: Props) => {
 			<SchemaForm
 				schema={formSchema}
 				data={formData}
-				validationWarnings={{}}
+				validationWarnings={getValidationWarnings(formSchema, formData)}
 				changeValue={changeFormData}
 			/>
 		</Paper>

--- a/apps/newsletters-ui/src/app/components/StateEditForm.tsx
+++ b/apps/newsletters-ui/src/app/components/StateEditForm.tsx
@@ -1,7 +1,9 @@
+import { Paper } from '@mui/material';
 import type { z } from 'zod';
 import type { WizardFormData } from '@newsletters-nx/state-machine';
 import type { FieldDef, FieldValue } from './SchemaForm';
 import { getModification, SchemaForm } from './SchemaForm';
+import { defaultFormStyle } from './SchemaForm/styling';
 
 interface Props {
 	formSchema: z.ZodObject<z.ZodRawShape>;
@@ -21,7 +23,7 @@ export const StateEditForm = ({ formSchema, formData, setFormData }: Props) => {
 	};
 
 	return (
-		<fieldset>
+		<Paper css={defaultFormStyle} elevation={3}>
 			<legend>{formSchema.description}</legend>
 			<SchemaForm
 				schema={formSchema}
@@ -29,6 +31,6 @@ export const StateEditForm = ({ formSchema, formData, setFormData }: Props) => {
 				validationWarnings={{}}
 				changeValue={changeFormData}
 			/>
-		</fieldset>
+		</Paper>
 	);
 };

--- a/apps/newsletters-ui/src/app/components/StateEditForm.tsx
+++ b/apps/newsletters-ui/src/app/components/StateEditForm.tsx
@@ -1,0 +1,34 @@
+import type { z } from 'zod';
+import type { WizardFormData } from '@newsletters-nx/state-machine';
+import type { FieldDef, FieldValue } from './SchemaForm';
+import { getModification, SchemaForm } from './SchemaForm';
+
+interface Props {
+	formSchema: z.ZodObject<z.ZodRawShape>;
+	formData: WizardFormData;
+	setFormData: { (newData: WizardFormData): void };
+}
+
+export const StateEditForm = ({ formSchema, formData, setFormData }: Props) => {
+	const changeFormData = (value: FieldValue, field: FieldDef) => {
+		const mod = getModification(value, field);
+		const revisedData = {
+			...formData,
+			...mod,
+		};
+
+		setFormData(revisedData);
+	};
+
+	return (
+		<fieldset>
+			<legend>{formSchema.description}</legend>
+			<SchemaForm
+				schema={formSchema}
+				data={formData}
+				validationWarnings={{}}
+				changeValue={changeFormData}
+			/>
+		</fieldset>
+	);
+};

--- a/apps/newsletters-ui/src/app/components/Wizard.tsx
+++ b/apps/newsletters-ui/src/app/components/Wizard.tsx
@@ -6,8 +6,7 @@ import type {
 	WizardFormData,
 } from '@newsletters-nx/state-machine';
 import { MarkdownView } from './MarkdownView';
-import type { FieldDef, FieldValue } from './SchemaForm';
-import { getModification, SchemaForm } from './SchemaForm';
+import { StateEditForm } from './StateEditForm';
 import { WizardButton } from './WizardButton';
 
 /**
@@ -95,30 +94,16 @@ export const Wizard: React.FC<WizardProps> = () => {
 
 	const formSchema = getFormSchema(serverData.currentStepId);
 
-	const changeFormData = (value: FieldValue, field: FieldDef) => {
-		const mod = getModification(value, field);
-		const revisedData = {
-			...formData,
-			...mod,
-		};
-
-		setFormData(revisedData);
-	};
-
 	return (
 		<>
 			<MarkdownView markdown={serverData.markdownToDisplay ?? ''} />
 
 			{formSchema && formData && (
-				<fieldset>
-					<legend>{formSchema.description}</legend>
-					<SchemaForm
-						schema={formSchema}
-						data={formData}
-						validationWarnings={{}}
-						changeValue={changeFormData}
-					/>
-				</fieldset>
+				<StateEditForm
+					formSchema={formSchema}
+					formData={formData}
+					setFormData={setFormData}
+				/>
 			)}
 
 			{serverData.errorMessage && (

--- a/libs/newsletters-data-client/src/index.ts
+++ b/libs/newsletters-data-client/src/index.ts
@@ -6,3 +6,4 @@ export * from './lib/wizard-button-type';
 export * from './lib/testQuestionaireSchema';
 export * from './lib/emailEmbedSchema';
 export * from './lib/storage';
+export * from './lib/schema-helpers';

--- a/libs/newsletters-data-client/src/lib/schema-helpers.ts
+++ b/libs/newsletters-data-client/src/lib/schema-helpers.ts
@@ -2,3 +2,11 @@ import { z } from 'zod';
 
 export const nonEmptyString = () =>
 	z.string().min(1, { message: 'Must not be empty' });
+
+export const kebabCasedString = () =>
+	z
+		.string()
+		.regex(
+			/^[a-z]+(-[a-z]+)*$/,
+			'Must be in kebab-case (only lower case words connected by dashes)',
+		);

--- a/libs/newsletters-data-client/src/lib/schema-helpers.ts
+++ b/libs/newsletters-data-client/src/lib/schema-helpers.ts
@@ -10,3 +10,11 @@ export const kebabCasedString = () =>
 			/^[a-z]+(-[a-z]+)*$/,
 			'Must be in kebab-case (only lower case words connected by dashes)',
 		);
+
+export const underscoreCasedString = () =>
+	z
+		.string()
+		.regex(
+			/^[a-zA-Z]+(_[a-zA-z]+)*$/,
+			'Must contain only letters and underscores',
+		);

--- a/libs/state-machine/src/schemas/index.ts
+++ b/libs/state-machine/src/schemas/index.ts
@@ -1,4 +1,7 @@
-import { themeEnumSchema } from '@newsletters-nx/newsletters-data-client';
+import {
+	kebabCasedString,
+	themeEnumSchema,
+} from '@newsletters-nx/newsletters-data-client';
 import { z, ZodBoolean, ZodEnum, ZodNumber, ZodString } from 'zod';
 
 type FormData = Record<string, string | number | boolean | undefined>;
@@ -13,7 +16,7 @@ export const formSchemas = {
 
 	identityName: z
 		.object({
-			identityName: z.string().regex(/^[a-z]+(-[a-z]+)*$/, 'must be in kebab-case (only lower case words connected by dashes)'),
+			identityName: kebabCasedString(),
 		})
 		.describe('Edit the identity name if required'),
 

--- a/libs/state-machine/src/schemas/index.ts
+++ b/libs/state-machine/src/schemas/index.ts
@@ -13,7 +13,7 @@ export const formSchemas = {
 
 	identityName: z
 		.object({
-			identityName: z.string(),
+			identityName: z.string().regex(/^[a-z]+(-[a-z]+)*$/, 'must be in kebab-case (only lower case words connected by dashes)'),
 		})
 		.describe('Edit the identity name if required'),
 

--- a/libs/state-machine/src/schemas/index.ts
+++ b/libs/state-machine/src/schemas/index.ts
@@ -4,8 +4,7 @@ import {
 	underscoreCasedString,
 } from '@newsletters-nx/newsletters-data-client';
 import { z, ZodBoolean, ZodEnum, ZodNumber, ZodString } from 'zod';
-
-type FormData = Record<string, string | number | boolean | undefined>;
+import type { WizardFormData } from '../lib/types';
 
 // TODO - move these definitions to a separate file
 export const formSchemas = {
@@ -60,20 +59,22 @@ export const getFormSchema = (
 	return matchingEntry ? matchingEntry[1] : undefined;
 };
 
-export const getFormBlankData = (stepId: string): FormData | undefined => {
+export const getFormBlankData = (
+	stepId: string,
+): WizardFormData | undefined => {
 	const schema = getFormSchema(stepId);
 	if (!schema) {
 		return undefined;
 	}
 
-	return Object.keys(schema.shape).reduce<FormData>((formData, key) => {
+	return Object.keys(schema.shape).reduce<WizardFormData>((formData, key) => {
 		const zod = schema.shape[key];
 
 		if (!zod) {
 			return formData;
 		}
 
-		const mod: FormData = {};
+		const mod: WizardFormData = {};
 
 		if (zod instanceof ZodString) {
 			mod[key] = '';

--- a/libs/state-machine/src/schemas/index.ts
+++ b/libs/state-machine/src/schemas/index.ts
@@ -50,26 +50,10 @@ export const formSchemas = {
 export const getFormSchema = (
 	stepId: string,
 ): z.ZodObject<z.ZodRawShape> | undefined => {
-	if (stepId === 'createNewsletter') {
-		return formSchemas.createNewsletter;
-	}
-	if (stepId === 'identityName') {
-		return formSchemas.identityName;
-	}
-	if (stepId === 'braze') {
-		return formSchemas.braze;
-	}
-	if (stepId === 'ophan') {
-		return formSchemas.ophan;
-	}
-	if (stepId === 'pillar') {
-		return formSchemas.pillar;
-	}
-	if (stepId === 'description') {
-		return formSchemas.description;
-	}
-
-	return undefined;
+	const matchingEntry = Object.entries(formSchemas).find(
+		([key]) => key === stepId,
+	);
+	return matchingEntry ? matchingEntry[1] : undefined;
 };
 
 export const getFormBlankData = (stepId: string): FormData | undefined => {

--- a/libs/state-machine/src/schemas/index.ts
+++ b/libs/state-machine/src/schemas/index.ts
@@ -1,6 +1,7 @@
 import {
 	kebabCasedString,
 	themeEnumSchema,
+	underscoreCasedString,
 } from '@newsletters-nx/newsletters-data-client';
 import { z, ZodBoolean, ZodEnum, ZodNumber, ZodString } from 'zod';
 
@@ -22,10 +23,10 @@ export const formSchemas = {
 
 	braze: z
 		.object({
-			brazeSubscribeEventNamePrefix: z.string(),
-			brazeNewsletterName: z.string(),
-			brazeSubscribeAttributeName: z.string(),
-			brazeSubscribeAttributeNameAlternate: z.string(),
+			brazeSubscribeEventNamePrefix: underscoreCasedString(),
+			brazeNewsletterName: underscoreCasedString(),
+			brazeSubscribeAttributeName: underscoreCasedString(),
+			brazeSubscribeAttributeNameAlternate: underscoreCasedString(),
 		})
 		.describe('Edit the Braze values if required'),
 


### PR DESCRIPTION
## What does this change?

- extracts the "render a form so the user can edit the formData in component state" logic from the `Wizard` component to `StateEditForm`
- support front end validation warnings on the forms 
- adds validation rules on the schemas for the `identityName` (kebab casing) and `brazeValues` steps (underscore casing)
- styling tweaks on the forms

## How to test

wizard still works - user is warned of improperly cased string values for the validated fields.

## How can we measure success?
Easier to refactor and re-use the form.
Allows us to prevent input of 'incorrect' strings for values that need the right format.

## Have we considered potential risks?

Using the zod Schema to specify the required string formats is useful, but we should also add unit tests to make sure the rules are wording as intended.

## Images


https://user-images.githubusercontent.com/30567854/222093630-d7ee9abb-0c9b-4288-b83b-c68f76949ab3.mov



