### PR TITLE
Add tests for apiDeploymentSettings

### DIFF
--- a/apps/newsletters-api/src/apiDeploymentSettings.spec.ts
+++ b/apps/newsletters-api/src/apiDeploymentSettings.spec.ts
@@ -1,0 +1,148 @@
+import {
+	isServingReadEndpoints,
+	isServingReadWriteEndpoints,
+	isServingUI,
+	isUndefinedAndNotProduction,
+} from './apiDeploymentSettings';
+
+const ORIGINAL_ENV = process.env;
+beforeEach(() => {
+	jest.resetModules();
+	process.env = { ...ORIGINAL_ENV };
+});
+afterEach(() => {
+	process.env = ORIGINAL_ENV;
+});
+
+describe('isUndefinedAndNotProduction', () => {
+	it('returns false when environment variable is undefined and NODE_ENV is production', () => {
+		process.env.NODE_ENV = 'production';
+		const result = isUndefinedAndNotProduction(undefined);
+		expect(result).toBe(false);
+	});
+	it('returns true when environment variable is undefined and NODE_ENV is not production', () => {
+		process.env.NODE_ENV = 'development';
+		expect(isUndefinedAndNotProduction(undefined)).toBe(true);
+	});
+	it('returns false when environment variable is not undefined and NODE_ENV is production', () => {
+		process.env.NODE_ENV = 'production';
+		expect(isUndefinedAndNotProduction('true')).toBe(false);
+	});
+	it('returns false when environment variable is not undefined and NODE_ENV is not production', () => {
+		process.env.NODE_ENV = 'development';
+		expect(isUndefinedAndNotProduction('false')).toBe(false);
+	});
+});
+
+describe('isServingUI', () => {
+	it('returns false when NEWSLETTERS_UI_SERVE is undefined and NODE_ENV is production', () => {
+		process.env.NODE_ENV = 'production';
+		process.env.NEWSLETTERS_UI_SERVE = undefined;
+		expect(isServingUI()).toBe(false);
+	});
+	it('returns true when NEWSLETTERS_UI_SERVE is undefined and NODE_ENV is not production', () => {
+		process.env.NODE_ENV = 'development';
+		process.env.NEWSLETTERS_UI_SERVE = undefined;
+		expect(isServingUI()).toBe(true);
+	});
+	it('returns true when NEWSLETTERS_UI_SERVE is true and NODE_ENV is production', () => {
+		process.env.NODE_ENV = 'production';
+		process.env.NEWSLETTERS_UI_SERVE = 'true';
+		expect(isServingUI()).toBe(true);
+	});
+	it('returns true when NEWSLETTERS_UI_SERVE is true and NODE_ENV is not production', () => {
+		process.env.NODE_ENV = 'development';
+		process.env.NEWSLETTERS_UI_SERVE = 'true';
+		expect(isServingUI()).toBe(true);
+	});
+	it('returns false when NEWSLETTERS_UI_SERVE is false and NODE_ENV is production', () => {
+		process.env.NODE_ENV = 'production';
+		process.env.NEWSLETTERS_UI_SERVE = 'false';
+		expect(isServingUI()).toBe(false);
+	});
+	it('returns false when NEWSLETTERS_UI_SERVE is false and NODE_ENV is not production', () => {
+		process.env.NODE_ENV = 'development';
+		process.env.NEWSLETTERS_UI_SERVE = 'false';
+		expect(isServingUI()).toBe(false);
+	});
+});
+
+describe('isServingReadEndpoints', () => {
+	it('returns false when NEWSLETTERS_API_READ and NEWSLETTERS_API_READ_WRITE are undefined and NODE_ENV is production', () => {
+		process.env.NODE_ENV = 'production';
+		process.env.NEWSLETTERS_API_READ = undefined;
+		process.env.NEWSLETTERS_API_READ_WRITE = undefined;
+		expect(isServingReadEndpoints()).toBe(false);
+	});
+	it('returns true when NEWSLETTERS_API_READ and NEWSLETTERS_API_READ_WRITE are undefined and NODE_ENV is not production', () => {
+		process.env.NODE_ENV = 'development';
+		process.env.NEWSLETTERS_API_READ = undefined;
+		process.env.NEWSLETTERS_API_READ_WRITE = undefined;
+		expect(isServingReadEndpoints()).toBe(true);
+	});
+	it('returns true when NEWSLETTERS_API_READ is true and NODE_ENV is production', () => {
+		process.env.NODE_ENV = 'production';
+		process.env.NEWSLETTERS_API_READ = 'true';
+		expect(isServingReadEndpoints()).toBe(true);
+	});
+	it('returns true when NEWSLETTERS_API_READ is true and NODE_ENV is not production', () => {
+		process.env.NODE_ENV = 'development';
+		process.env.NEWSLETTERS_API_READ = 'true';
+		expect(isServingReadEndpoints()).toBe(true);
+	});
+	it('returns true when NEWSLETTERS_API_READ_WRITE is true and NODE_ENV is production', () => {
+		process.env.NODE_ENV = 'production';
+		process.env.NEWSLETTERS_API_READ_WRITE = 'true';
+		expect(isServingReadEndpoints()).toBe(true);
+	});
+	it('returns true when NEWSLETTERS_API_READ_WRITE is true and NODE_ENV is not production', () => {
+		process.env.NODE_ENV = 'development';
+		process.env.NEWSLETTERS_API_READ_WRITE = 'true';
+		expect(isServingReadEndpoints()).toBe(true);
+	});
+	it('returns false when NEWSLETTERS_API_READ and NEWSLETTERS_API_READ_WRITE are false and NODE_ENV is production', () => {
+		process.env.NODE_ENV = 'production';
+		process.env.NEWSLETTERS_API_READ = 'false';
+		process.env.NEWSLETTERS_API_READ_WRITE = 'false';
+		expect(isServingReadEndpoints()).toBe(false);
+	});
+	it('returns false when NEWSLETTERS_API_READ and NEWSLETTERS_API_READ_WRITE are false and NODE_ENV is not production', () => {
+		process.env.NODE_ENV = 'development';
+		process.env.NEWSLETTERS_API_READ = 'false';
+		process.env.NEWSLETTERS_API_READ_WRITE = 'false';
+		expect(isServingReadEndpoints()).toBe(false);
+	});
+});
+
+describe('isServingReadWriteEndpoints', () => {
+	it('returns false when NEWSLETTERS_API_READ_WRITE is undefined and NODE_ENV is production', () => {
+		process.env.NODE_ENV = 'production';
+		process.env.NEWSLETTERS_API_READ_WRITE = undefined;
+		expect(isServingReadWriteEndpoints()).toBe(false);
+	});
+	it('returns true when NEWSLETTERS_API_READ_WRITE is undefined and NODE_ENV is not production', () => {
+		process.env.NODE_ENV = 'development';
+		process.env.NEWSLETTERS_API_READ_WRITE = undefined;
+		expect(isServingReadWriteEndpoints()).toBe(true);
+	});
+	it('returns true when NEWSLETTERS_API_READ_WRITE is true and NODE_ENV is production', () => {
+		process.env.NODE_ENV = 'production';
+		process.env.NEWSLETTERS_API_READ_WRITE = 'true';
+		expect(isServingReadWriteEndpoints()).toBe(true);
+	});
+	it('returns true when NEWSLETTERS_API_READ_WRITE is true and NODE_ENV is not production', () => {
+		process.env.NODE_ENV = 'development';
+		process.env.NEWSLETTERS_API_READ_WRITE = 'true';
+		expect(isServingReadWriteEndpoints()).toBe(true);
+	});
+	it('returns false when NEWSLETTERS_API_READ_WRITE is false and NODE_ENV is production', () => {
+		process.env.NODE_ENV = 'production';
+		process.env.NEWSLETTERS_API_READ_WRITE = 'false';
+		expect(isServingReadWriteEndpoints()).toBe(false);
+	});
+	it('returns false when NEWSLETTERS_API_READ_WRITE is false and NODE_ENV is not production', () => {
+		process.env.NODE_ENV = 'development';
+		process.env.NEWSLETTERS_API_READ_WRITE = 'false';
+		expect(isServingReadWriteEndpoints()).toBe(false);
+	});
+});

--- a/apps/newsletters-api/src/apiDeploymentSettings.ts
+++ b/apps/newsletters-api/src/apiDeploymentSettings.ts
@@ -11,19 +11,33 @@
  * 	NEWSLETTERS_UI_SERVE=false npm run dev
  */
 
-function undefinedAndNotProduction(envVar: string | undefined): boolean {
-	return envVar === undefined && process.env.NODE !== 'production';
+export function isUndefinedAndNotProduction(
+	envVar: string | undefined,
+): boolean {
+	return envVar === undefined && process.env.NODE_ENV !== 'production';
 }
 
-export const isServingUI =
-	undefinedAndNotProduction(process.env.NEWSETTERS_UI_SERVE) ||
-	process.env.NEWSLETTERS_UI_SERVE === 'true';
+export const isServingUI = () => {
+	const undefinedAndNotProduction = isUndefinedAndNotProduction(
+		process.env.NEWSLETTERS_UI_SERVE,
+	);
+	const isUIServe = process.env.NEWSLETTERS_UI_SERVE === 'true';
+	return undefinedAndNotProduction || isUIServe;
+};
 
-export const isServingReadWriteEndpoints =
-	undefinedAndNotProduction(process.env.NEWSLETTERS_API_READ_WRITE) ||
-	process.env.NEWSLETTERS_API_READ_WRITE === 'true';
+export const isServingReadWriteEndpoints = () => {
+	const undefinedAndNotProduction = isUndefinedAndNotProduction(
+		process.env.NEWSLETTERS_API_READ_WRITE,
+	);
+	const isApiReadWrite = process.env.NEWSLETTERS_API_READ_WRITE === 'true';
+	return undefinedAndNotProduction || isApiReadWrite;
+};
 
-export const isServingReadEndpoints =
-	undefinedAndNotProduction(process.env.NEWSLETTERS_API_READ) ||
-	process.env.NEWSLETTERS_API_READ === 'true' ||
-	isServingReadWriteEndpoints;
+export const isServingReadEndpoints = () => {
+	const undefinedAndNotProduction = isUndefinedAndNotProduction(
+		process.env.NEWSLETTERS_API_READ,
+	);
+	const isApiRead = process.env.NEWSLETTERS_API_READ === 'true';
+	const isApiReadWrite = isServingReadWriteEndpoints();
+	return undefinedAndNotProduction || isApiRead || isApiReadWrite;
+};

--- a/apps/newsletters-api/src/main.ts
+++ b/apps/newsletters-api/src/main.ts
@@ -12,13 +12,13 @@ import { registerUIServer } from './register-ui-server';
 
 const app = Fastify();
 registerHealthRoute(app);
-if (isServingUI) {
+if (isServingUI()) {
 	registerUIServer(app);
 }
-if (isServingReadWriteEndpoints) {
+if (isServingReadWriteEndpoints()) {
 	registerCurrentStepRoute(app);
 }
-if (isServingReadEndpoints) {
+if (isServingReadEndpoints()) {
 	registerNewsletterRoutes(app);
 	registerDraftsRoutes(app);
 }

--- a/apps/newsletters-api/src/register-ui-server.ts
+++ b/apps/newsletters-api/src/register-ui-server.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import fastifyStatic from '@fastify/static';
+import { fastifyStatic } from '@fastify/static';
 import type { FastifyInstance } from 'fastify';
 
 export function registerUIServer(app: FastifyInstance) {


### PR DESCRIPTION
## What does this change?

Adds a series of tests to check that API deployment settings are correct for combinations of the following environment variables:
- NODE_ENV - whether or not it's 'production'
- NEWSLETTERS_UI_SERVE - 'true' or 'false'
- NEWSLETTERS_API_READ - 'true' or 'false'
- NEWSLETTERS_API_READ_WRITE - 'true' or false'

In writing the tests, it was found that a number of changes needed to be made to apiDeploymentSettings:
- checking process.env.NODE_ENV rather than process.env.NODE
- defining interim constants and returning the OR of those constants, instead of calculating the OR in the return statement (otherwise the correct values were not always returned)

## How to test

`npm run test`
