### PR TITLE
[TEST] Fix newsletters deploy

### DIFF
--- a/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
+++ b/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
@@ -199,7 +199,7 @@ unzip /tmp/newsletters-tool.zip -d /opt/newsletters-tool
 chown -R ubuntu /opt/newsletters-tool
 export NEWSLETTERS_API_READ=true
 export NEWSLETTERS_UI_SERVE=true
-su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool /opt/newsletters-tool/dist/apps/newsletters-api/main.cjs'",
+su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool /opt/newsletters-tool/dist/apps/newsletters-api/index.cjs'",
               ],
             ],
           },

--- a/cdk/lib/newsletters-tool.ts
+++ b/cdk/lib/newsletters-tool.ts
@@ -47,7 +47,7 @@ export class NewslettersTool extends GuStack {
 			`chown -R ubuntu /opt/${app}`, // change ownership of the copied files to ubuntu user
 			`export NEWSLETTERS_API_READ=true`,
 			`export NEWSLETTERS_UI_SERVE=true`,
-			`su ubuntu -c '/usr/local/node/pm2 start --name ${app} /opt/${app}/dist/apps/newsletters-api/main.cjs'`, // run the main entrypoint file as ubuntu user using pm2
+			`su ubuntu -c '/usr/local/node/pm2 start --name ${app} /opt/${app}/dist/apps/newsletters-api/index.cjs'`, // run the main entrypoint file as ubuntu user using pm2
 		].join('\n');
 	};
 


### PR DESCRIPTION
## What does this change?

This PR is a draft branch of https://github.com/guardian/newsletters-nx/pull/49 intended to test a fix for the newsletters-tool deployment. Currently the deployment fails as the ASG never stabilises indicating the [application is failing its healthcheck](https://riffraff.gutools.co.uk/deployment/view/444c9b3f-fe52-47b2-9a92-18161dd1deab), so there is a problem starting the application or serving the healthcheck correctly.

Looking at the [logs for the service we see](https://logs.gutools.co.uk/app/discover#/doc/afa91900-5e8b-11e8-ba01-2b66550a44f2/logstash-frontend-2023.03.15?id=rwm35YYBp4nx_p7_Eo4S): `[PM2][ERROR] Script not found: /opt/newsletters-tool/dist/apps/newsletters-api/main.cjs`.

Further seeing what is being inflated on the instance [we find `main.cjs` is not in the archive](https://logs.gutools.co.uk/goto/bc25cde0-c344-11ed-9879-b7910179e6f2). Instead:

`inflating: /opt/newsletters-tool/dist/apps/newsletters-api/index.cjs`

If we look at the GitHub action logs, you can also see that this is [what is being packaged](https://github.com/guardian/newsletters-nx/actions/runs/4417550153/jobs/7743411998#step:6:77):

`adding: dist/apps/newsletters-api/index.cjs (deflated 82%)`

This change is intended to point the entrypoint to the correct location so `pm2` will start as expected.

Going forward i'd suggest putting the [build logic in a script that can be run locally](https://github.com/guardian/tracker/blob/main/script/ci) to produce the same artefact that is built in CI so that any issues with CI can be reproduced more easily.

Deploying [this branch fails](https://riffraff.gutools.co.uk/deployment/view/67f811af-d656-4593-a4dc-55543a873481) but this looks to be because the previous broken ASG deployment needs resolving. Someone will need to [follow the instructions](https://riffraff.gutools.co.uk/docs/howto/fix-a-failed-deploy) for fixing a failed autoscaling deploy and then re-attempt deployment.






