### PR TITLE
Dblatcher/wizard on homepage

### DIFF
--- a/apps/newsletters-ui/index.html
+++ b/apps/newsletters-ui/index.html
@@ -14,6 +14,11 @@
 			rel="stylesheet"
 			href="https://fonts.googleapis.com/icon?family=Material+Icons"
 		/>
+		<style>
+			body {
+				margin: 0;
+			}
+		</style>
 
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />

--- a/apps/newsletters-ui/src/app/Layout.tsx
+++ b/apps/newsletters-ui/src/app/Layout.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/react';
+import styled from '@emotion/styled';
 import {
 	brand,
 	space,
@@ -7,32 +7,47 @@ import {
 import { Outlet, useLocation } from 'react-router-dom';
 import { MainNav } from './components/MainNav';
 
-const headerStyle = css`
-	margin-bottom: ${space[6]}px;
-	padding: ${space[1]}px;
-	border-bottom: 2px solid ${brand[300]};
-	background-color: ${brand[800]};
+const Frame = styled.div`
+	display: flex;
+	flex-direction: column;
+	height: 100vh;
+	box-sizing: border-box;
+	overflow: hidden;
+	align-items: stretch;
 
-	h1 {
-		${textSansObjectStyles.xlarge({ fontStyle: 'italic' })};
-		margin: 0;
-		color: ${brand[300]};
+	> header {
+		padding: ${space[1]}px;
+		border-bottom: 2px solid ${brand[300]};
+		background-color: ${brand[800]};
+		box-sizing: border-box;
+
+		h1 {
+			${textSansObjectStyles.xlarge({ fontStyle: 'italic' })};
+			margin: 0;
+			color: ${brand[300]};
+		}
 	}
-`;
 
-const footerStyle = css`
-	margin-top: ${space[3]}px;
-	padding: ${space[1]}px;
-	border-top: 2px solid ${brand[300]};
-	background-color: ${brand[800]};
+	> main {
+		box-sizing: border-box;
+		flex: 1;
+		overflow: auto;
+	}
+
+	> footer {
+		box-sizing: border-box;
+		padding: ${space[1]}px;
+		border-top: 2px solid ${brand[300]};
+		background-color: ${brand[800]};
+	}
 `;
 
 export function Layout() {
 	const location = useLocation();
 
 	return (
-		<>
-			<header css={headerStyle}>
+		<Frame>
+			<header>
 				<h1>Have I Got Newsletters For You</h1>
 				<MainNav pathname={location.pathname} />
 			</header>
@@ -41,9 +56,9 @@ export function Layout() {
 				<Outlet />
 			</main>
 
-			<footer css={footerStyle}>
+			<footer>
 				<b>Footer</b>
 			</footer>
-		</>
+		</Frame>
 	);
 }

--- a/apps/newsletters-ui/src/app/Layout.tsx
+++ b/apps/newsletters-ui/src/app/Layout.tsx
@@ -6,6 +6,7 @@ import {
 	textSansObjectStyles,
 } from '@guardian/source-foundations';
 import { Outlet, useLocation } from 'react-router-dom';
+import { FooterContents } from './components/FooterContents';
 import { MainNav } from './components/MainNav';
 
 const Frame = styled.div`
@@ -57,7 +58,7 @@ export function Layout() {
 			</main>
 
 			<footer>
-				<b>Footer</b>
+				<FooterContents />
 			</footer>
 		</Frame>
 	);

--- a/apps/newsletters-ui/src/app/Layout.tsx
+++ b/apps/newsletters-ui/src/app/Layout.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import {
 	brand,
+	brandAlt,
 	space,
 	textSansObjectStyles,
 } from '@guardian/source-foundations';
@@ -17,8 +18,8 @@ const Frame = styled.div`
 
 	> header {
 		padding: ${space[1]}px;
-		border-bottom: 2px solid ${brand[300]};
-		background-color: ${brand[800]};
+		border-bottom: 2px solid ${brand[400]};
+		background-color: ${brandAlt[400]};
 		box-sizing: border-box;
 
 		h1 {
@@ -48,7 +49,6 @@ export function Layout() {
 	return (
 		<Frame>
 			<header>
-				<h1>Have I Got Newsletters For You</h1>
 				<MainNav pathname={location.pathname} />
 			</header>
 

--- a/apps/newsletters-ui/src/app/components/FooterContents.tsx
+++ b/apps/newsletters-ui/src/app/components/FooterContents.tsx
@@ -1,0 +1,10 @@
+import { Typography } from '@mui/material';
+import { Container } from '@mui/system';
+
+export function FooterContents() {
+	return (
+		<Container maxWidth="lg">
+			<Typography component={'span'}>Newsletters tool</Typography>
+		</Container>
+	);
+}

--- a/apps/newsletters-ui/src/app/components/HomeMenu.tsx
+++ b/apps/newsletters-ui/src/app/components/HomeMenu.tsx
@@ -42,7 +42,7 @@ const ButtonGridItem = ({
 
 	return (
 		<Grid item xs={6} sm={4} display={'flex'}>
-			<Button {...buttonProps} fullWidth>
+			<Button {...buttonProps} fullWidth size="large">
 				{content}
 			</Button>
 		</Grid>

--- a/apps/newsletters-ui/src/app/components/HomeMenu.tsx
+++ b/apps/newsletters-ui/src/app/components/HomeMenu.tsx
@@ -52,7 +52,7 @@ const ButtonGridItem = ({
 export function HomeMenu() {
 	return (
 		<Container maxWidth={'lg'}>
-			<Grid container spacing={3} rowSpacing={6}>
+			<Grid container spacing={3} rowSpacing={6} paddingY={2}>
 				<ButtonGridItem
 					path="/newsletters"
 					content={'View current newsletters'}

--- a/apps/newsletters-ui/src/app/components/HomeMenu.tsx
+++ b/apps/newsletters-ui/src/app/components/HomeMenu.tsx
@@ -11,7 +11,7 @@ const ContainerStyle = styled.div`
 	}
 `;
 
-export function NewslettersHome() {
+export function HomeMenu() {
 	const navigate = useNavigate();
 
 	return (

--- a/apps/newsletters-ui/src/app/components/HomeMenu.tsx
+++ b/apps/newsletters-ui/src/app/components/HomeMenu.tsx
@@ -1,46 +1,80 @@
-import styled from '@emotion/styled';
+import type {
+	ButtonPropsColorOverrides,
+	ButtonPropsVariantOverrides,
+} from '@mui/material';
+import { Button, Grid } from '@mui/material';
+import { Container } from '@mui/system';
+import type { OverridableStringUnion } from '@mui/types';
+import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router';
 
-const ContainerStyle = styled.div`
-	display: grid;
-	grid-template-columns: auto auto auto;
-	column-gap: 40px;
-	row-gap: 25px;
-	@media (max-width: 375px) {
-		grid-template-columns: auto;
-	}
-`;
-
-export function HomeMenu() {
+const ButtonGridItem = ({
+	path,
+	content,
+	color = 'primary',
+	variant = 'outlined',
+}: {
+	path?: string;
+	content: ReactNode;
+	color?: OverridableStringUnion<
+		| 'secondary'
+		| 'inherit'
+		| 'primary'
+		| 'success'
+		| 'error'
+		| 'info'
+		| 'warning',
+		ButtonPropsColorOverrides
+	>;
+	variant?: OverridableStringUnion<
+		'text' | 'outlined' | 'contained',
+		ButtonPropsVariantOverrides
+	>;
+}) => {
 	const navigate = useNavigate();
 
+	const buttonProps = {
+		onClick: path ? () => navigate(path) : undefined,
+		disabled: !path,
+		color,
+		variant,
+	};
+
 	return (
-		<ContainerStyle>
-			<button onClick={() => navigate('/newsletters')}>
-				View current newsletters
-			</button>
+		<Grid item xs={6} sm={4} display={'flex'}>
+			<Button {...buttonProps} fullWidth>
+				{content}
+			</Button>
+		</Grid>
+	);
+};
 
-			<button onClick={() => navigate('/drafts')}>
-				View draft newsletters
-			</button>
-
-			<button onClick={() => navigate('/newsletters/create')}>
-				Create new newsletter
-			</button>
-
-			<button onClick={() => navigate('/demo/newsletter-data')}>
-				Demo create newsletter wizard
-			</button>
-
-			<button onClick={() => navigate('/demo/launch-newsletter')}>
-				Demo launch newsletter wizard
-			</button>
-
-			<button onClick={() => navigate('/demo/forms')}>Demo form</button>
-
-			<button disabled title="Not implemented yet">
-				Update newsletter
-			</button>
-		</ContainerStyle>
+export function HomeMenu() {
+	return (
+		<Container maxWidth={'lg'}>
+			<Grid container spacing={3} rowSpacing={6}>
+				<ButtonGridItem
+					path="/newsletters"
+					content={'View current newsletters'}
+				/>
+				<ButtonGridItem path="/drafts" content={'View draft newsletters'} />
+				<ButtonGridItem
+					path="/newsletters/create"
+					content={'Create new newsletter'}
+				/>
+				<ButtonGridItem
+					path="/demo/newsletter-data"
+					content={'Demo create newsletter wizard'}
+					color="success"
+					variant="contained"
+				/>
+				<ButtonGridItem
+					path="/demo/launch-newsletter"
+					content={'Demo launch newsletter wizard'}
+				/>
+				<ButtonGridItem path="/demo/forms" content={'Demo form'} />
+				<ButtonGridItem content={'Update newsletter'} />
+			</Grid>
+		</Container>
 	);
 }

--- a/apps/newsletters-ui/src/app/components/MainNav.tsx
+++ b/apps/newsletters-ui/src/app/components/MainNav.tsx
@@ -1,10 +1,6 @@
-import { css } from '@emotion/react';
-import {
-	neutral,
-	space,
-	textSansObjectStyles,
-} from '@guardian/source-foundations';
-import { Link } from 'react-router-dom';
+import { Button, ButtonGroup, Typography } from '@mui/material';
+import { Container } from '@mui/system';
+import { useNavigate } from 'react-router-dom';
 
 interface Props {
 	pathname: string;
@@ -23,50 +19,32 @@ const navLinks: NavLink[] = [
 	{ path: '/thrashers', label: 'Thrashers' },
 ];
 
-const navStyle = css`
-	display: flex;
-	padding: ${space[2]}px 0;
-	flex-wrap: wrap;
-
-	a {
-		${textSansObjectStyles.medium({ fontWeight: 'light' })};
-		flex-wrap: nowrap;
-		flex-basis: 220px;
-		margin-right: ${space[2]}px;
-		margin-bottom: ${space[2]}px;
-		padding: ${space[1]}px;
-		background-color: ${neutral[97]};
-		color: ${neutral[7]};
-		text-decoration: none;
-		text-align: center;
-
-		&.current {
-			${textSansObjectStyles.medium({ fontWeight: 'bold' })};
-			background-color: ${neutral[7]};
-			color: ${neutral[97]};
-		}
-	}
-`;
-
 export function MainNav({ pathname }: Props) {
-	const getLinkClass = (linkPath: string): string | undefined => {
+	const navigate = useNavigate();
+	const getButtonVariant = (linkPath: string): 'contained' | 'outlined' => {
 		if (linkPath === pathname) {
-			return 'current';
+			return 'contained';
 		}
-		return undefined;
+		return 'outlined';
 	};
 
 	return (
-		<nav css={navStyle}>
-			{navLinks.map((link) => (
-				<Link
-					key={link.path}
-					to={link.path}
-					className={getLinkClass(link.path)}
-				>
-					{link.label}
-				</Link>
-			))}
-		</nav>
+		<Container maxWidth="lg">
+			<ButtonGroup component={'nav'}>
+				{navLinks.map((link) => (
+					<Button
+						color="info"
+						variant={getButtonVariant(link.path)}
+						onClick={() => {
+							navigate(link.path);
+						}}
+						key={link.path}
+					>
+						{link.label}
+					</Button>
+				))}
+			</ButtonGroup>
+			<Typography component={'h1'}>Have I Got Newsletters For You</Typography>
+		</Container>
 	);
 }

--- a/apps/newsletters-ui/src/app/components/MainNav.tsx
+++ b/apps/newsletters-ui/src/app/components/MainNav.tsx
@@ -18,6 +18,7 @@ interface NavLink {
 const navLinks: NavLink[] = [
 	{ path: '/', label: 'Home' },
 	{ path: '/newsletters', label: 'Newsletters' },
+	{ path: '/drafts', label: 'Drafts' },
 	{ path: '/templates', label: 'Email Templates' },
 	{ path: '/thrashers', label: 'Thrashers' },
 ];

--- a/apps/newsletters-ui/src/app/components/NewslettersHome.tsx
+++ b/apps/newsletters-ui/src/app/components/NewslettersHome.tsx
@@ -16,11 +16,11 @@ export function NewslettersHome() {
 
 	return (
 		<ContainerStyle>
-			<button onClick={() => navigate('/newsletters/all')}>
+			<button onClick={() => navigate('/newsletters')}>
 				View current newsletters
 			</button>
 
-			<button onClick={() => navigate('/newsletters/drafts')}>
+			<button onClick={() => navigate('/drafts')}>
 				View draft newsletters
 			</button>
 

--- a/apps/newsletters-ui/src/app/components/Wizard.tsx
+++ b/apps/newsletters-ui/src/app/components/Wizard.tsx
@@ -1,4 +1,4 @@
-import { Alert } from '@mui/material';
+import { Alert, Box } from '@mui/material';
 import { useCallback, useEffect, useState } from 'react';
 import {
 	getFormSchema,
@@ -137,7 +137,7 @@ export const Wizard: React.FC<WizardProps> = ({
 	const formSchema = getFormSchema(wizardId, serverData.currentStepId);
 
 	return (
-		<>
+		<Box paddingY={2}>
 			<StepNav
 				currentStepId={serverData.currentStepId}
 				stepList={getStepList(wizardId)}
@@ -170,6 +170,6 @@ export const Wizard: React.FC<WizardProps> = ({
 					key={`${key}${button.label}`}
 				/>
 			))}
-		</>
+		</Box>
 	);
 };

--- a/apps/newsletters-ui/src/app/routes/drafts.tsx
+++ b/apps/newsletters-ui/src/app/routes/drafts.tsx
@@ -6,7 +6,7 @@ import { Layout } from '../Layout';
 import { draftDetailLoader, draftListLoader } from '../loaders/newsletters';
 
 export const draftRoute: RouteObject = {
-	path: '/newsletters/drafts',
+	path: '/drafts',
 	element: <Layout />,
 	errorElement: <ErrorPage />,
 	children: [

--- a/apps/newsletters-ui/src/app/routes/home.tsx
+++ b/apps/newsletters-ui/src/app/routes/home.tsx
@@ -1,5 +1,5 @@
 import type { RouteObject } from 'react-router-dom';
-import { NewslettersHome } from '../components/NewslettersHome';
+import { HomeMenu } from '../components/HomeMenu';
 import { ErrorPage } from '../ErrorPage';
 import { Layout } from '../Layout';
 import { listLoader } from '../loaders/newsletters';
@@ -12,7 +12,7 @@ export const homeRoute: RouteObject = {
 	children: [
 		{
 			path: '',
-			element: <NewslettersHome />,
+			element: <HomeMenu />,
 			loader: listLoader,
 		},
 		{

--- a/apps/newsletters-ui/src/app/routes/home.tsx
+++ b/apps/newsletters-ui/src/app/routes/home.tsx
@@ -1,21 +1,19 @@
 import type { RouteObject } from 'react-router-dom';
-import { redirect } from 'react-router-dom';
-import { HealthCheck } from '../components/HealthCheck';
+import { NewslettersHome } from '../components/NewslettersHome';
 import { ErrorPage } from '../ErrorPage';
 import { Layout } from '../Layout';
+import { listLoader } from '../loaders/newsletters';
 
 export const homeRoute: RouteObject = {
 	path: '/',
 	element: <Layout />,
 	errorElement: <ErrorPage />,
+
 	children: [
 		{
 			path: '',
-			action: () => redirect('/newsletters'),
-		},
-		{
-			path: 'api/',
-			element: <HealthCheck />,
+			element: <NewslettersHome />,
+			loader: listLoader,
 		},
 		{
 			path: 'templates',

--- a/apps/newsletters-ui/src/app/routes/newsletters.tsx
+++ b/apps/newsletters-ui/src/app/routes/newsletters.tsx
@@ -1,5 +1,4 @@
 import type { RouteObject } from 'react-router-dom';
-import { NewslettersHome } from '../components/NewslettersHome';
 import { NewsletterCreateView } from '../components/views/NewsletterCreateView';
 import { NewsletterDetailView } from '../components/views/NewsletterDetailView';
 import { NewslettersListView } from '../components/views/NewslettersListView';
@@ -14,11 +13,6 @@ export const newslettersRoute: RouteObject = {
 	children: [
 		{
 			path: '',
-			element: <NewslettersHome />,
-			loader: listLoader,
-		},
-		{
-			path: 'all',
 			element: <NewslettersListView />,
 			loader: listLoader,
 		},


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
 - Rearranges the routing so the main menu with the "Demo Create Newsletter" button is on the homepage.
 - Redesigns the main main  using a material UI Grid instead of CSS ("Demo Create Newsletter" is made more prominent than the other buttons)
 - Redesigns the main nav using material UI Button Group
 - adjusts the Layout to have the footer at the bottom of the page.

based on this ticket:
https://trello.com/c/thFGBb6F/329-deploy-code-where-the-user-interface-redirects-automatically-to-the-wizard-demo-so-we-can-allow-our-stakeholders-to-dig-into-our
Although the user is not redirected into the wizard, the app will start on the page with the button to launch it.


## How to test
`npm run dev`

## How can we measure success?
Looks nicer, easier to get to the wizard for testing.


## Images

|before | after |
|----|----|
|![localhost_4200_ (1)](https://user-images.githubusercontent.com/30567854/228839684-f71a576e-b1e6-4a24-8007-ed07a426bae0.png)|![localhost_4200_](https://user-images.githubusercontent.com/30567854/228839658-770887a2-d571-4279-8a53-8dc70dcac107.png)|



