### PR TITLE
Change first page of Edit Draft

### DIFF
--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/editDraftNewsletterLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/editDraftNewsletterLayout.ts
@@ -3,9 +3,7 @@ import { executeCreate } from '../../executeCreate';
 import { formSchemas } from './formSchemas';
 
 export const editDraftNewsletterLayout: WizardStepLayout = {
-	staticMarkdown: `# Edit a draft newsletter
-
-This wizard allows you to edit an existing draft newsletter, guiding you through the process of creating a newsletter using email-rendering.
+	staticMarkdown: `# Name Your Newsletter
 
 The first step is to enter the name for your newsletter, for example **Down to Earth**.
 


### PR DESCRIPTION
## What does this change?

Change the text on the first step of the Edit Draft Newsletter wizard, as requested on this Trello ticket: https://trello.com/c/Wp1flRdp

## How to test

Run `npm run dev`
Select Drafts
Select the View button for one of the drafts in table

## How can we measure success?

Check the text has been updated as requested

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Before
![Screenshot 2023-04-05 at 09 36 15](https://user-images.githubusercontent.com/74301289/230029056-79b1c9b2-1d14-496a-8683-799bd3a4ec3a.png)

After
![Screenshot 2023-04-05 at 09 36 48](https://user-images.githubusercontent.com/74301289/230029093-cb547c50-e169-43d6-add0-bd85050f8a42.png)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
