### PR TITLE
Add missing date fields

### DIFF
--- a/apps/newsletters-api/static/newsletters.local.json
+++ b/apps/newsletters-api/static/newsletters.local.json
@@ -31,8 +31,10 @@
 		"creationTimeStamp": 1636052205655,
 		"cancellationTimeStamp": 1648969683066,
 		"figmaIncludesThrashers": false,
+		"launchDate": "1970-01-02T00:21:18.876Z",
 		"signUpPageDate": "1970-01-02T00:21:18.876Z",
 		"thrasherDate": "1970-01-02T00:21:18.876Z",
+		"privateUntilLaunch": false,
 		"onlineArticle": "Web for all sends"
 	},
 	{
@@ -67,8 +69,10 @@
 		"creationTimeStamp": 1618699981727,
 		"cancellationTimeStamp": 1650218254336,
 		"figmaIncludesThrashers": false,
+		"launchDate": "1970-01-02T00:21:18.876Z",
 		"signUpPageDate": "1970-01-02T00:21:18.876Z",
 		"thrasherDate": "1970-01-02T00:21:18.876Z",
+		"privateUntilLaunch": false,
 		"onlineArticle": "Web for all sends"
 	},
 	{
@@ -104,8 +108,10 @@
 		],
 		"creationTimeStamp": 1628684935554,
 		"figmaIncludesThrashers": false,
+		"launchDate": "1970-01-02T00:21:18.876Z",
 		"signUpPageDate": "1970-01-02T00:21:18.876Z",
 		"thrasherDate": "1970-01-02T00:21:18.876Z",
+		"privateUntilLaunch": false,
 		"onlineArticle": "Web for all sends"
 	},
 	{
@@ -141,8 +147,10 @@
 		],
 		"creationTimeStamp": 1633646570591,
 		"figmaIncludesThrashers": false,
+		"launchDate": "1970-01-02T00:21:18.876Z",
 		"signUpPageDate": "1970-01-02T00:21:18.876Z",
 		"thrasherDate": "1970-01-02T00:21:18.876Z",
+		"privateUntilLaunch": false,
 		"onlineArticle": "Web for all sends"
 	},
 	{
@@ -177,8 +185,10 @@
 		],
 		"creationTimeStamp": 1636033387328,
 		"figmaIncludesThrashers": false,
+		"launchDate": "1970-01-02T00:21:18.876Z",
 		"signUpPageDate": "1970-01-02T00:21:18.876Z",
 		"thrasherDate": "1970-01-02T00:21:18.876Z",
+		"privateUntilLaunch": false,
 		"onlineArticle": "Web for all sends"
 	}
 ]

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
@@ -138,8 +138,10 @@ export const formSchemas = {
 
 	promotionDates: newsletterDataSchema
 		.pick({
+			launchDate: true,
 			signUpPageDate: true,
 			thrasherDate: true,
+			privateUntilLaunch: true,
 		})
-		.describe('choose the dates you want promotions to appear'),
+		.describe('choose the launch date and promotion plans'),
 };

--- a/libs/newsletters-data-client/src/fixtures/newsletter-fixtures.ts
+++ b/libs/newsletters-data-client/src/fixtures/newsletter-fixtures.ts
@@ -38,8 +38,10 @@ export const TECHSCAPE_IN_NEW_FORMAT: NewsletterData = {
 
 	creationTimeStamp: 87678876,
 	figmaIncludesThrashers: false,
+	launchDate: new Date(87678876),
 	signUpPageDate: new Date(87678876),
 	thrasherDate: new Date(87678876),
+	privateUntilLaunch: false,
 	onlineArticle: 'Web for all sends',
 };
 

--- a/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
@@ -101,8 +101,10 @@ export const newsletterDataSchema = z.object({
 	composerTag: z.string().optional(),
 	composerCampaignTag: z.string().optional(),
 
+	launchDate: z.coerce.date(),
 	signUpPageDate: z.coerce.date(),
 	thrasherDate: z.coerce.date(),
+	privateUntilLaunch: z.boolean(),
 	onlineArticle: onlineArticleSchema,
 
 	renderingOptions: renderingOptionsSchema.optional(),

--- a/libs/newsletters-data-client/src/lib/transformWizardData.spec.ts
+++ b/libs/newsletters-data-client/src/lib/transformWizardData.spec.ts
@@ -45,11 +45,13 @@ const VALID_DRAFT_WITH_NESTED_OBJECT: DraftNewsletterData = {
 
 const FORM_DATA_WITH_DATES: FormDataRecord = {
 	name: 'test name',
+	launchDate: new Date('01-02-2023'),
 	signUpPageDate: new Date('10-10-2020').toDateString(),
 	thrasherDate: new Date('10-10-2021'),
 };
 const DRAFT_WITH_DATES: DraftNewsletterData = {
 	name: 'test name',
+	launchDate: new Date('01-02-2023'),
 	signUpPageDate: new Date('10-10-2020'),
 	thrasherDate: new Date('10-10-2021'),
 };

--- a/tools/scripts/deno/generate-newsletters.js
+++ b/tools/scripts/deno/generate-newsletters.js
@@ -110,8 +110,10 @@ const generateNewsletter = () => {
 			status === 'cancelled' ? timeStampForZeroToOneYearsAgo : undefined,
 
 		figmaIncludesThrashers: false,
+		launchDate: new Date(87678876),
 		signUpPageDate: new Date(87678876),
 		thrasherDate: new Date(87678876),
+		privateUntilLaunch: false,
 		onlineArticle: 'Web for all sends',
 	};
 	return newsletter;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The text on the launch date & promotions page of the wizard implied that we would be asking the user for a Launch Date, and whether or not the newsletter needed to be private until launch, but these fields had initially been omitted.  They have now been added.

## How to test

Run `npm run dev`
Select the Demo Create Newsletter Wizard or select the View button for an existing draft newsletter
Move to the second page of the wizard

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Before
![Screenshot 2023-04-05 at 10 51 56](https://user-images.githubusercontent.com/74301289/230046737-ffecfd5a-da2a-4d49-b213-1dd72f6873e4.png)

After
![Screenshot 2023-04-05 at 10 50 01](https://user-images.githubusercontent.com/74301289/230046770-44a63095-ec01-4d81-9edf-c8aed0249f28.png)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
