### PR TITLE
Fix region focus dropdown

### DIFF
--- a/libs/newsletters-data-client/src/fixtures/newsletter-fixtures.ts
+++ b/libs/newsletters-data-client/src/fixtures/newsletter-fixtures.ts
@@ -14,6 +14,7 @@ export const TECHSCAPE_IN_NEW_FORMAT: NewsletterData = {
 	group: 'News in depth',
 	description:
 		"Alex Hern's weekly dive in to how technology is shaping our lives",
+	regionFocus: '',
 	frequency: 'Weekly',
 	listIdV1: -1,
 	listId: 6013,
@@ -57,6 +58,7 @@ export const VALID_TECHSCAPE: LegacyNewsletter = {
 	group: 'News in depth',
 	description:
 		"Alex Hern's weekly dive in to how technology is shaping our lives",
+	regionFocus: '',
 	frequency: 'Weekly',
 	listIdV1: -1,
 	listId: 6013,

--- a/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
@@ -75,7 +75,7 @@ export const newsletterDataSchema = z.object({
 	group: nonEmptyString(),
 	headline: z.string().optional(),
 	description: nonEmptyString(),
-	regionFocus: z.string().optional(),
+	regionFocus: regionFocusEnumSchema,
 	frequency: nonEmptyString(),
 	listId: z.number(),
 	listIdV1: z.number(),


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Somewhere along the line, the Region Focus dropdown was accidentally replaced by a text entry field.  The dropdown has been reinstated.

## How to test

Run `npm run dev`
Select the Demo Create Newsletter Wizard or select the View button for an existing draft newsletter
Move to the fourth page of the wizard

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Before
![Screenshot 2023-04-05 at 11 22 10](https://user-images.githubusercontent.com/74301289/230054232-9be597c6-cde6-4839-8995-ece7cf8ab089.png)

After
![Screenshot 2023-04-05 at 11 13 18](https://user-images.githubusercontent.com/74301289/230054263-138180d3-7efd-4ea4-943e-77f40f12798f.png)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
