### PR TITLE
Add user friendly field labels

### DIFF
--- a/apps/newsletters-ui/src/app/components/SchemaForm/SchemaField.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/SchemaField.tsx
@@ -49,7 +49,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 	};
 
 	const standardProps = {
-		label: field.key,
+		label: field.description ?? field.key,
 		inputHandler,
 		readOnly: !!field.readOnly,
 		optional: !!field.optional,

--- a/apps/newsletters-ui/src/app/components/SchemaForm/index.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/index.tsx
@@ -86,6 +86,7 @@ export function SchemaForm<T extends z.ZodRawShape>({
 
 		fields.push({
 			key,
+			description: zod.description,
 			optional: zod.isOptional(),
 			type,
 			value: data[key],

--- a/apps/newsletters-ui/src/app/components/SchemaForm/util.ts
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/util.ts
@@ -3,6 +3,7 @@ import { isStringArray } from '../../util';
 
 export interface FieldDef {
 	key: string;
+	description?: string;
 	optional: boolean;
 	type: string;
 	value: unknown;

--- a/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
@@ -37,23 +37,31 @@ export const singleThrasherLocation = z.enum([
 export type SingleThrasherLocation = z.infer<typeof singleThrasherLocation>;
 
 export const renderingOptionsSchema = z.object({
-	displayDate: z.boolean(),
-	displayStandfirst: z.boolean(),
-	contactEmail: z.string().email(),
-	displayImageCaptions: z.boolean(),
-	linkListSubheading: z.array(z.string()).optional(),
-	podcastSubheading: z.array(z.string()).optional(),
-	readMoreSubheading: z.string().optional(),
-	readMoreWording: z.string().optional(),
-	readMoreUrl: z.string().url().optional(),
+	displayDate: z.boolean().describe('display date?'),
+	displayStandfirst: z.boolean().describe('display standfirst?'),
+	contactEmail: z.string().email().describe('contact email'),
+	displayImageCaptions: z.boolean().describe('display image captions?'),
+	linkListSubheading: z
+		.array(z.string())
+		.optional()
+		.describe('link list subheading'),
+	podcastSubheading: z
+		.array(z.string())
+		.optional()
+		.describe('podcast subheading'),
+	readMoreSubheading: z.string().optional().describe('read more subheading'),
+	readMoreWording: z.string().optional().describe('read more wording'),
+	readMoreUrl: z.string().url().optional().describe('read more url'),
 });
 export type RenderingOptions = z.infer<typeof renderingOptionsSchema>;
 
 export const thrasherOptionsSchema = z.object({
-	singleThrasher: z.boolean(),
-	multiThrasher: z.boolean(),
-	singleThrasherLocation: singleThrasherLocation,
-	thrasherDescription: z.string(),
+	singleThrasher: z.boolean().describe('single thrasher required?'),
+	multiThrasher: z.boolean().describe('multi-thrasher(s) required?'),
+	singleThrasherLocation: singleThrasherLocation.describe(
+		'single thrasher location',
+	),
+	thrasherDescription: z.string().describe('thrasher description'),
 });
 export type ThrasherOptions = z.infer<typeof thrasherOptionsSchema>;
 
@@ -63,19 +71,19 @@ export type ThrasherOptions = z.infer<typeof thrasherOptionsSchema>;
  * The actual data model is TBC.
  */
 export const newsletterDataSchema = z.object({
-	identityName: kebabCasedString(),
+	identityName: kebabCasedString().describe('identity name'),
 	name: nonEmptyString(),
 	restricted: z.boolean(),
 	status: z.enum(['paused', 'cancelled', 'live']),
-	emailConfirmation: z.boolean(),
+	emailConfirmation: z.boolean().describe('email confirmation'),
 	brazeSubscribeAttributeName: underscoreCasedString(),
 	brazeSubscribeEventNamePrefix: underscoreCasedString(),
 	brazeNewsletterName: underscoreCasedString(),
 	theme: themeEnumSchema,
 	group: nonEmptyString(),
-	headline: z.string().optional(),
-	description: nonEmptyString(),
-	regionFocus: regionFocusEnumSchema,
+	headline: z.string().optional().describe('sign up headline'),
+	description: nonEmptyString().describe('sign up description'),
+	regionFocus: regionFocusEnumSchema.describe('region focus'),
 	frequency: nonEmptyString(),
 	listId: z.number(),
 	listIdV1: z.number(),
@@ -89,23 +97,25 @@ export const newsletterDataSchema = z.object({
 		.optional(),
 	signupPage: z.string().optional(),
 	exampleUrl: z.string().optional(),
-	designBriefDoc: z.string().optional(),
-	figmaDesignUrl: z.string().url().optional(),
-	figmaIncludesThrashers: z.boolean(),
+	designBriefDoc: z.string().optional().describe('design brief doc'),
+	figmaDesignUrl: z.string().url().optional().describe('figma design url'),
+	figmaIncludesThrashers: z
+		.boolean()
+		.describe('figma design includes thrashers?'),
 	illustrationCircle: z.string().optional(),
 
 	creationTimeStamp: z.number(),
 	cancellationTimeStamp: z.number().optional(),
 
-	seriesTag: z.string().optional(),
-	composerTag: z.string().optional(),
-	composerCampaignTag: z.string().optional(),
+	seriesTag: z.string().optional().describe('series tag'),
+	composerTag: z.string().optional().describe('composer tag'),
+	composerCampaignTag: z.string().optional().describe('composer campaign tag'),
 
-	launchDate: z.coerce.date(),
-	signUpPageDate: z.coerce.date(),
-	thrasherDate: z.coerce.date(),
-	privateUntilLaunch: z.boolean(),
-	onlineArticle: onlineArticleSchema,
+	launchDate: z.coerce.date().describe('launch date'),
+	signUpPageDate: z.coerce.date().describe('sign up page date'),
+	thrasherDate: z.coerce.date().describe('thrasher date'),
+	privateUntilLaunch: z.boolean().describe('needs to be private until launch?'),
+	onlineArticle: onlineArticleSchema.describe('location of article'),
 
 	renderingOptions: renderingOptionsSchema.optional(),
 	thrasherOptions: thrasherOptionsSchema.optional(),


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Where needed, instead of displaying the key for each field in the wizard, displays a more user-friendly description (the need for this became a bit more pronounced when the data structure was changed to included nested fields)

The user-friendly descriptions are displayed in lowercase so that they're consistent with the keys automatically used when a description is unnecessary

## How to test

Run `npm run dev`
Select Demo Create Newsletter Wizard, or select View Draft Newsletters and click Update against an existing draft newsletter
Navigate through the wizard

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

An example of nested field labels before
![Screenshot 2023-04-05 at 14 51 13](https://user-images.githubusercontent.com/74301289/230103311-465ddc7f-654b-4665-a4b7-3dbc750b186c.png)

After
![Screenshot 2023-04-05 at 14 52 04](https://user-images.githubusercontent.com/74301289/230103367-e7eb0660-a7bd-4d17-851e-9b1e93496fbf.png)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
