### PR TITLE
Remove superfluous console logs

### DIFF
--- a/apps/newsletters-api/src/app/routes/health.ts
+++ b/apps/newsletters-api/src/app/routes/health.ts
@@ -3,7 +3,6 @@ import type { FastifyInstance } from 'fastify';
 export function registerHealthRoute(app: FastifyInstance) {
 	/** Health check endpoint */
 	app.get('/healthcheck', (req, res) => {
-		console.log('====> Health check endpoint called');
 		return res.send({ message: 'Newsletters API running' });
 	});
 }

--- a/apps/newsletters-ui/src/app/components/Wizard.tsx
+++ b/apps/newsletters-ui/src/app/components/Wizard.tsx
@@ -69,7 +69,6 @@ export const Wizard: React.FC<WizardProps> = ({
 			})
 				.then((response) => response.json())
 				.then((data: CurrentStepRouteResponse) => {
-					console.table(data);
 					const listIdOnData = data.formData?.listId;
 					if (typeof listIdOnData === 'number') {
 						setListId(listIdOnData);

--- a/libs/state-machine/src/lib/stateMachineButtonPressed.ts
+++ b/libs/state-machine/src/lib/stateMachineButtonPressed.ts
@@ -19,10 +19,7 @@ export async function stateMachineButtonPressed(
 ): Promise<WizardStepData> {
 	const currentStepLayout = wizardLayout[incomingStepData.currentStepId];
 	const buttonPressedDetails = currentStepLayout?.buttons[buttonPressed];
-
 	const formSchemaForIncomingStep = currentStepLayout?.schema;
-	console.log('form data should be:', formSchemaForIncomingStep?.description);
-	console.table(incomingStepData.formData);
 
 	if (!buttonPressedDetails) {
 		throw new StateMachineError(


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

When developing the wizard structure and data storage, a number of `console.log` and `console.table` were added to the code to aid in debugging.  Now that this has been stable for some time, these have been removed to reduce the noise

## How to test

Run `npm run dev`
When navigating through the wizard, the terminal should no longer display the console logging messages

## How can we measure success?

## Have we considered potential risks?

## Images

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
