### PR TITLE
Dblatcher/generic wizards

### DIFF
--- a/libs/newsletter-workflow/src/lib/executeCreate.ts
+++ b/libs/newsletter-workflow/src/lib/executeCreate.ts
@@ -1,4 +1,7 @@
-import type { DraftNewsletterData } from '@newsletters-nx/newsletters-data-client';
+import type {
+	DraftNewsletterData,
+	DraftStorage,
+} from '@newsletters-nx/newsletters-data-client';
 import {
 	draftNewsletterDataToFormData,
 	formDataToDraftNewsletterData,
@@ -15,7 +18,7 @@ import { formSchemas } from '../lib/steps/newsletterData/formSchemas';
 import { calculateFieldsFromName } from './calculateFieldsFromName';
 import { executeModify } from './executeModify';
 
-export const executeCreate: AsyncExecution = async (
+export const executeCreate: AsyncExecution<DraftStorage> = async (
 	stepData,
 	stepLayout,
 	storageInstance,

--- a/libs/newsletter-workflow/src/lib/executeModify.ts
+++ b/libs/newsletter-workflow/src/lib/executeModify.ts
@@ -13,9 +13,9 @@ import type {
 	WizardStepLayout,
 } from '@newsletters-nx/state-machine';
 
-export const executeModify: AsyncExecution = async (
+export const executeModify: AsyncExecution<DraftStorage> = async (
 	stepData: WizardStepData,
-	stepLayout?: WizardStepLayout,
+	stepLayout?: WizardStepLayout<DraftStorage>,
 	storageInstance?: DraftStorage,
 ): Promise<WizardFormData | string> => {
 	if (!storageInstance) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/brazeLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/brazeLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
@@ -27,7 +28,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'of the newsletter',
 );
 
-export const brazeLayout: WizardStepLayout = {
+export const brazeLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown,
 	label: 'Braze',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/cancelLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/cancelLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 
 const markdownToDisplay = `
@@ -6,7 +7,7 @@ const markdownToDisplay = `
 Collection of newsletter data was cancelled.
 `.trim();
 
-export const cancelLayout: WizardStepLayout = {
+export const cancelLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown: markdownToDisplay,
 	buttons: {},
 	role: 'EARLY_EXIT',

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/categoryLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/categoryLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
@@ -24,7 +25,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const categoryLayout: WizardStepLayout = {
+export const categoryLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown,
 	label: 'Production Category',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/completeDataCollectionLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/completeDataCollectionLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
@@ -21,7 +22,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const completeDataCollectionLayout: WizardStepLayout = {
+export const completeDataCollectionLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown,
 	label: 'Complete Data Collection',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/createDraftNewsletterLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/createDraftNewsletterLayout.ts
@@ -1,8 +1,9 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeCreate } from '../../executeCreate';
 import { formSchemas } from './formSchemas';
 
-export const createDraftNewsletterLayout: WizardStepLayout = {
+export const createDraftNewsletterLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown: `# Start creating a newsletter
 
 Welcome!  This wizard will guide you through the process of creating a newsletter using email-rendering.

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/dateLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/dateLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
@@ -36,7 +37,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const dateLayout: WizardStepLayout = {
+export const dateLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown,
 	label: 'Launch/Promotion Dates',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/designBriefLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/designBriefLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
@@ -22,7 +23,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const designBriefLayout: WizardStepLayout = {
+export const designBriefLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown,
 	label: 'Design Brief',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/editBrazeLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/editBrazeLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
@@ -18,7 +19,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'of the newsletter',
 );
 
-export const editBrazeLayout: WizardStepLayout = {
+export const editBrazeLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown,
 	dynamicMarkdown(requestData, responseData) {
 		if (!responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/editDraftNewsletterLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/editDraftNewsletterLayout.ts
@@ -1,8 +1,9 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeCreate } from '../../executeCreate';
 import { formSchemas } from './formSchemas';
 
-export const editDraftNewsletterLayout: WizardStepLayout = {
+export const editDraftNewsletterLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown: `# Name Your Newsletter
 
 The first step is to enter the name for your newsletter, for example **Down to Earth**.

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/editIdentityNameLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/editIdentityNameLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
@@ -18,7 +19,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'of the newsletter',
 );
 
-export const editIdentityNameLayout: WizardStepLayout = {
+export const editIdentityNameLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown,
 	dynamicMarkdown(requestData, responseData) {
 		if (!responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/editOphanLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/editOphanLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
@@ -18,7 +19,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'of the newsletter',
 );
 
-export const editOphanLayout: WizardStepLayout = {
+export const editOphanLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown,
 	dynamicMarkdown(requestData, responseData) {
 		if (!responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/emailCentralProductionLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/emailCentralProductionLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
@@ -30,7 +31,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const emailCentralProductionLayout: WizardStepLayout = {
+export const emailCentralProductionLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown,
 	label: 'Email CP',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/finishLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/finishLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
@@ -14,7 +15,7 @@ You can see your draft on the [details page](drafts/{{listId}}), which includes 
 
 const staticMarkdown = markdownTemplate.replace(regExPatterns.name, '');
 
-const finishLayout: WizardStepLayout = {
+const finishLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown: staticMarkdown,
 	label: 'Finish',
 	buttons: {},

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/frequencyLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/frequencyLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
@@ -35,7 +36,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const frequencyLayout: WizardStepLayout = {
+export const frequencyLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown,
 	label: 'Send Frequency',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/identityNameLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/identityNameLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
@@ -21,7 +22,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'of the newsletter',
 );
 
-export const identityNameLayout: WizardStepLayout = {
+export const identityNameLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown,
 	label: 'Identity Name',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/index.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/index.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardLayout } from '@newsletters-nx/state-machine';
 import { brazeLayout } from './brazeLayout';
 import { cancelLayout } from './cancelLayout';
@@ -22,7 +23,7 @@ import { signUpLayout } from './signUpLayout';
 import { tagsLayout } from './tagsLayout';
 import { thrasherLayout } from './thrasherLayout';
 
-export const newsletterDataLayout: WizardLayout = {
+export const newsletterDataLayout: WizardLayout<DraftStorage> = {
 	createDraftNewsletter: createDraftNewsletterLayout,
 	editDraftNewsletter: editDraftNewsletterLayout,
 	category: categoryLayout,

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/onlineArticleLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/onlineArticleLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type {
 	WizardStepData,
 	WizardStepLayout,
@@ -23,7 +24,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const onlineArticleLayout: WizardStepLayout = {
+export const onlineArticleLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown,
 	label: 'Online Article',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/ophanLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/ophanLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
@@ -23,7 +24,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'of the newsletter',
 );
 
-export const ophanLayout: WizardStepLayout = {
+export const ophanLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown,
 	label: 'Ophan',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/pillarLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/pillarLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type {
 	WizardStepData,
 	WizardStepLayout,
@@ -21,7 +22,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const pillarLayout: WizardStepLayout = {
+export const pillarLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown,
 	label: 'Pillar',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/regionFocusLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/regionFocusLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type {
 	WizardStepData,
 	WizardStepLayout,
@@ -19,7 +20,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const regionFocusLayout: WizardStepLayout = {
+export const regionFocusLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown,
 	label: 'Geo Focus',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/signUpLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/signUpLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type {
 	WizardStepData,
 	WizardStepLayout,
@@ -21,7 +22,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const signUpLayout: WizardStepLayout = {
+export const signUpLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown,
 	label: 'Sign Up',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/tagsLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/tagsLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
@@ -32,7 +33,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const tagsLayout: WizardStepLayout = {
+export const tagsLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown,
 	label: 'Tag Setup',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/thrasherLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/thrasherLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
@@ -26,7 +27,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const thrasherLayout: WizardStepLayout = {
+export const thrasherLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown,
 	label: 'Thrashers',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/cancelLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/cancelLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 
 const markdownToDisplay = `
@@ -6,7 +7,7 @@ const markdownToDisplay = `
 Setting the render options was cancelled.
 `.trim();
 
-export const cancelLayout: WizardStepLayout = {
+export const cancelLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown: markdownToDisplay,
 	buttons: {},
 	role: 'EARLY_EXIT',

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/finishLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/finishLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
@@ -14,7 +15,7 @@ You can see the full details of **{{name}}** on the [details page](drafts/{{list
 
 const staticMarkdown = markdownTemplate.replace(regExPatterns.name, '');
 
-const finishLayout: WizardStepLayout = {
+const finishLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown: staticMarkdown,
 	label: 'Finish',
 	buttons: {},

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/footerLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/footerLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
@@ -20,7 +21,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const footerLayout: WizardStepLayout = {
+export const footerLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown,
 	label: 'Footer Setup',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/imageLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/imageLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
@@ -18,7 +19,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const imageLayout: WizardStepLayout = {
+export const imageLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown,
 	label: 'Images',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/index.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/index.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardLayout } from '@newsletters-nx/state-machine';
 import { cancelLayout } from './cancelLayout';
 import { finishLayout } from './finishLayout';
@@ -9,7 +10,7 @@ import { podcastLayout } from './podcastLayout';
 import { readMoreLayout } from './readMoreLayout';
 import { startLayout } from './start';
 
-export const renderingOptionsLayout: WizardLayout = {
+export const renderingOptionsLayout: WizardLayout<DraftStorage> = {
 	start: startLayout,
 	cancel: cancelLayout,
 	newsletterHeader: newsletterHeaderLayout,

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/linkListLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/linkListLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
@@ -24,7 +25,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const linkListLayout: WizardStepLayout = {
+export const linkListLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown,
 	label: 'Link List Sections',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/newsletterHeaderLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/newsletterHeaderLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
@@ -28,7 +29,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const newsletterHeaderLayout: WizardStepLayout = {
+export const newsletterHeaderLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown,
 	label: 'Header Setup',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/podcastLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/podcastLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
@@ -24,7 +25,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const podcastLayout: WizardStepLayout = {
+export const podcastLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown,
 	label: 'Podcast Sections',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/readMoreLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/readMoreLayout.ts
@@ -1,3 +1,4 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
@@ -23,7 +24,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const readMoreLayout: WizardStepLayout = {
+export const readMoreLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown,
 	label: 'Read More Sections',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/start.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/start.ts
@@ -1,6 +1,7 @@
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 
-export const startLayout: WizardStepLayout = {
+export const startLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown: `# Set Rendering Template Options
 
 This wizard is to choose the options for how an article-based newsletter will appear in Email-rendering.

--- a/libs/state-machine/src/lib/StateMachineError.ts
+++ b/libs/state-machine/src/lib/StateMachineError.ts
@@ -3,6 +3,7 @@ export enum StateMachineErrorCode {
 	NoSuchButton,
 	StorageAccessError,
 	StepMethodFailed,
+	NoSuchItem,
 	Unhandled,
 }
 

--- a/libs/state-machine/src/lib/handleWizardRequest.ts
+++ b/libs/state-machine/src/lib/handleWizardRequest.ts
@@ -1,4 +1,3 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import { makeResponse } from './makeResponse';
 import { setupInitialState } from './setupInitialState';
 import { stateMachineButtonPressed } from './stateMachineButtonPressed';
@@ -7,7 +6,9 @@ import { stateMachineSkipPressed } from './stateMachineSkipPressed';
 import type {
 	CurrentStepRouteRequest,
 	CurrentStepRouteResponse,
+	GenericStorageInterface,
 	WizardLayout,
+	WizardStepLayout,
 } from './types';
 
 /**
@@ -24,15 +25,21 @@ import type {
  * or any of the methods defined on the WizardLayoutStep throws
  * any exceptions.
  */
-export async function handleWizardRequestAndReturnWizardResponse(
+export async function handleWizardRequestAndReturnWizardResponse<
+	T extends GenericStorageInterface,
+>(
 	requestBody: CurrentStepRouteRequest,
-	wizardLayout: WizardLayout,
-	draftStorage: DraftStorage,
+	wizardLayout: WizardLayout<T>,
+	genericInterface: T,
 ): Promise<CurrentStepRouteResponse> {
 	try {
 		const stepData =
 			requestBody.stepToSkipToId !== undefined
-				? await stateMachineSkipPressed(requestBody, wizardLayout, draftStorage)
+				? await stateMachineSkipPressed(
+						requestBody,
+						wizardLayout as WizardLayout,
+						genericInterface,
+				  )
 				: requestBody.buttonId !== undefined
 				? await stateMachineButtonPressed(
 						requestBody.buttonId,
@@ -41,9 +48,9 @@ export async function handleWizardRequestAndReturnWizardResponse(
 							formData: requestBody.formData,
 						},
 						wizardLayout,
-						draftStorage,
+						genericInterface,
 				  )
-				: await setupInitialState(requestBody, draftStorage);
+				: await setupInitialState(requestBody, genericInterface);
 
 		const nextStep = wizardLayout[stepData.currentStepId];
 
@@ -55,7 +62,11 @@ export async function handleWizardRequestAndReturnWizardResponse(
 			);
 		}
 
-		return makeResponse(requestBody, stepData, nextStep);
+		return makeResponse(
+			requestBody,
+			stepData,
+			nextStep as WizardStepLayout<unknown>,
+		);
 	} catch (error) {
 		if (error instanceof StateMachineError) {
 			throw error;

--- a/libs/state-machine/src/lib/handleWizardRequest.ts
+++ b/libs/state-machine/src/lib/handleWizardRequest.ts
@@ -37,7 +37,7 @@ export async function handleWizardRequestAndReturnWizardResponse<
 			requestBody.stepToSkipToId !== undefined
 				? await stateMachineSkipPressed(
 						requestBody,
-						wizardLayout as WizardLayout,
+						wizardLayout,
 						genericInterface,
 				  )
 				: requestBody.buttonId !== undefined

--- a/libs/state-machine/src/lib/setupInitialState.ts
+++ b/libs/state-machine/src/lib/setupInitialState.ts
@@ -1,11 +1,14 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import { draftNewsletterDataToFormData } from '@newsletters-nx/newsletters-data-client';
 import { StateMachineError, StateMachineErrorCode } from './StateMachineError';
-import type { CurrentStepRouteRequest, WizardStepData } from './types';
+import type {
+	CurrentStepRouteRequest,
+	GenericStorageInterface,
+	WizardStepData,
+} from './types';
 
-export async function setupInitialState(
+export async function setupInitialState<T extends GenericStorageInterface>(
 	requestBody: CurrentStepRouteRequest,
-	storageInstance?: DraftStorage,
+	storageInstance?: T,
 ): Promise<WizardStepData> {
 	if (!storageInstance) {
 		throw new StateMachineError(

--- a/libs/state-machine/src/lib/stateMachineButtonPressed.spec.ts
+++ b/libs/state-machine/src/lib/stateMachineButtonPressed.spec.ts
@@ -12,7 +12,7 @@ beforeEach(() => {
 	mockStepData = Object.assign({}, initialStep);
 });
 
-const mockWizardLayout: WizardLayout = {
+const mockWizardLayout: WizardLayout<DraftStorage> = {
 	step1: {
 		staticMarkdown: 'Step 1',
 		buttons: {

--- a/libs/state-machine/src/lib/stateMachineButtonPressed.spec.ts
+++ b/libs/state-machine/src/lib/stateMachineButtonPressed.spec.ts
@@ -1,5 +1,3 @@
-import { InMemoryDraftStorage } from '@newsletters-nx/newsletters-data-client';
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import { stateMachineButtonPressed } from './stateMachineButtonPressed';
 import type { WizardLayout, WizardStepData } from './types';
 
@@ -12,7 +10,7 @@ beforeEach(() => {
 	mockStepData = Object.assign({}, initialStep);
 });
 
-const mockWizardLayout: WizardLayout<DraftStorage> = {
+const mockWizardLayout: WizardLayout = {
 	step1: {
 		staticMarkdown: 'Step 1',
 		buttons: {
@@ -61,7 +59,7 @@ const mockWizardLayout: WizardLayout<DraftStorage> = {
 	},
 };
 
-const mockStorage: DraftStorage = new InMemoryDraftStorage();
+const mockStorage = {};
 
 describe('stateMachineButtonPressed', () => {
 	it('should throw if buttonPressed is invalid', async () => {

--- a/libs/state-machine/src/lib/stateMachineButtonPressed.ts
+++ b/libs/state-machine/src/lib/stateMachineButtonPressed.ts
@@ -1,6 +1,9 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import { StateMachineError, StateMachineErrorCode } from './StateMachineError';
-import type { WizardLayout, WizardStepData } from './types';
+import type {
+	GenericStorageInterface,
+	WizardLayout,
+	WizardStepData,
+} from './types';
 import {
 	makeStepDataWithErrorMessage,
 	validateIncomingFormData,
@@ -15,11 +18,13 @@ import {
  *  - the currentStepId for the next step and the submitted form data
  *  if the step was success
  */
-export async function stateMachineButtonPressed(
+export async function stateMachineButtonPressed<
+	T extends GenericStorageInterface,
+>(
 	buttonPressed: string,
 	incomingStepData: WizardStepData,
-	wizardLayout: WizardLayout,
-	storageInstance: DraftStorage,
+	wizardLayout: WizardLayout<T>,
+	storageInstance: T,
 ): Promise<WizardStepData> {
 	const currentStepLayout = wizardLayout[incomingStepData.currentStepId];
 	const buttonPressedDetails = currentStepLayout?.buttons[buttonPressed];

--- a/libs/state-machine/src/lib/stateMachineButtonPressed.ts
+++ b/libs/state-machine/src/lib/stateMachineButtonPressed.ts
@@ -39,7 +39,7 @@ export async function stateMachineButtonPressed<
 	const incomingDataError = validateIncomingFormData(
 		incomingStepData.currentStepId,
 		incomingStepData.formData,
-		wizardLayout,
+		wizardLayout as WizardLayout,
 	);
 	if (incomingDataError) {
 		return makeStepDataWithErrorMessage(

--- a/libs/state-machine/src/lib/stateMachineSkipPressed.ts
+++ b/libs/state-machine/src/lib/stateMachineSkipPressed.ts
@@ -21,7 +21,7 @@ import {
 
 export async function stateMachineSkipPressed(
 	requestBody: CurrentStepRouteRequest,
-	wizardLayout: WizardLayout,
+	wizardLayout: WizardLayout<DraftStorage>,
 	storageInstance?: DraftStorage,
 ): Promise<WizardStepData> {
 	if (!storageInstance) {

--- a/libs/state-machine/src/lib/stateMachineSkipPressed.ts
+++ b/libs/state-machine/src/lib/stateMachineSkipPressed.ts
@@ -43,7 +43,7 @@ export async function stateMachineSkipPressed(
 	const incomingDataError = validateIncomingFormData(
 		requestBody.stepId,
 		requestBody.formData,
-		wizardLayout,
+		wizardLayout as WizardLayout<unknown>,
 	);
 	if (incomingDataError) {
 		return makeStepDataWithErrorMessage(

--- a/libs/state-machine/src/lib/stateMachineSkipPressed.ts
+++ b/libs/state-machine/src/lib/stateMachineSkipPressed.ts
@@ -14,7 +14,7 @@ import type {
 	WizardStepData,
 } from './types';
 import {
-	getExistingItem,
+	getFormDataForExistingItem,
 	makeStepDataWithErrorMessage,
 	validateIncomingFormData,
 } from './utility';
@@ -53,10 +53,8 @@ export async function stateMachineSkipPressed(
 		);
 	}
 
-	const existingItem = await getExistingItem(requestBody, storageInstance);
-	const existingFormData: FormDataRecord = existingItem
-		? draftNewsletterDataToFormData(existingItem)
-		: {};
+	const existingFormData =
+		(await getFormDataForExistingItem(requestBody, storageInstance)) ?? {};
 	const combinedFormData: FormDataRecord = {
 		...existingFormData,
 		...{ ...requestBody.formData },

--- a/libs/state-machine/src/lib/types.ts
+++ b/libs/state-machine/src/lib/types.ts
@@ -1,10 +1,11 @@
 import type {
-	DraftStorage,
 	FormDataRecord,
 	WIZARD_BUTTON_TYPES,
 } from '@newsletters-nx/newsletters-data-client';
 import type { ZodObject, ZodRawShape } from 'zod';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- needs to be completey generic?
+export type GenericStorageInterface = any;
 export type WizardFormData = FormDataRecord;
 
 /**
@@ -25,39 +26,39 @@ export interface WizardStepData {
 	errorMessage?: string;
 }
 
-type AsyncValidator = (
+type AsyncValidator<T extends GenericStorageInterface> = (
 	stepData: WizardStepData,
-	stepLayout?: WizardStepLayout,
-	storageInstance?: DraftStorage,
+	stepLayout?: WizardStepLayout<T>,
+	storageInstance?: T,
 ) => Promise<string | undefined>;
 
-type Validator = (
+type Validator<T extends GenericStorageInterface> = (
 	stepData: WizardStepData,
-	stepLayout?: WizardStepLayout,
-	storageInstance?: DraftStorage,
+	stepLayout?: WizardStepLayout<T>,
+	storageInstance?: T,
 ) => string | undefined;
 
-export type AsyncExecution = (
+export type AsyncExecution<T extends GenericStorageInterface> = (
 	stepData: WizardStepData,
-	stepLayout?: WizardStepLayout,
-	storageInstance?: DraftStorage,
+	stepLayout?: WizardStepLayout<T>,
+	storageInstance?: T,
 ) => Promise<WizardFormData | string>;
 
-type Execution = (
+type Execution<T extends GenericStorageInterface> = (
 	stepData: WizardStepData,
-	stepLayout?: WizardStepLayout,
-	storageInstance?: DraftStorage,
+	stepLayout?: WizardStepLayout<T>,
+	storageInstance?: T,
 ) => WizardFormData | string;
 
-export interface WizardStepLayoutButton {
+export type WizardStepLayoutButton<T extends GenericStorageInterface> = {
 	buttonType: keyof typeof WIZARD_BUTTON_TYPES;
 	label: string;
 	stepToMoveTo: string;
-	onAfterStepStartValidate?: AsyncValidator | Validator;
-	onBeforeStepChangeValidate?: AsyncValidator | Validator;
-	executeStep?: AsyncExecution | Execution;
-}
-export interface WizardStepLayout {
+	onAfterStepStartValidate?: AsyncValidator<T> | Validator<T>;
+	onBeforeStepChangeValidate?: AsyncValidator<T> | Validator<T>;
+	executeStep?: AsyncExecution<T> | Execution<T>;
+};
+export interface WizardStepLayout<T extends GenericStorageInterface> {
 	label?: string;
 	role?: 'EDIT_START' | 'CREATE_START' | 'EARLY_EXIT';
 	parentStepId?: string;
@@ -65,12 +66,15 @@ export interface WizardStepLayout {
 	dynamicMarkdown?: {
 		(requestData?: WizardFormData, responseData?: WizardFormData): string;
 	};
-	buttons: Record<string, WizardStepLayoutButton>;
+	buttons: Record<string, WizardStepLayoutButton<T>>;
 	schema?: ZodObject<ZodRawShape>;
 	canSkipTo?: boolean;
 }
 
-export type WizardLayout = Record<string, WizardStepLayout>;
+export type WizardLayout<T extends GenericStorageInterface> = Record<
+	string,
+	WizardStepLayout<T>
+>;
 
 /**
  * Interface for the data payload sent to by the client for a single step in the wizard.

--- a/libs/state-machine/src/lib/types.ts
+++ b/libs/state-machine/src/lib/types.ts
@@ -50,7 +50,9 @@ type Execution<T extends GenericStorageInterface> = (
 	storageInstance?: T,
 ) => WizardFormData | string;
 
-export type WizardStepLayoutButton<T extends GenericStorageInterface> = {
+export type WizardStepLayoutButton<
+	T extends GenericStorageInterface = unknown,
+> = {
 	buttonType: keyof typeof WIZARD_BUTTON_TYPES;
 	label: string;
 	stepToMoveTo: string;
@@ -58,7 +60,7 @@ export type WizardStepLayoutButton<T extends GenericStorageInterface> = {
 	onBeforeStepChangeValidate?: AsyncValidator<T> | Validator<T>;
 	executeStep?: AsyncExecution<T> | Execution<T>;
 };
-export interface WizardStepLayout<T extends GenericStorageInterface> {
+export interface WizardStepLayout<T extends GenericStorageInterface = unknown> {
 	label?: string;
 	role?: 'EDIT_START' | 'CREATE_START' | 'EARLY_EXIT';
 	parentStepId?: string;
@@ -71,7 +73,7 @@ export interface WizardStepLayout<T extends GenericStorageInterface> {
 	canSkipTo?: boolean;
 }
 
-export type WizardLayout<T extends GenericStorageInterface> = Record<
+export type WizardLayout<T extends GenericStorageInterface = unknown> = Record<
 	string,
 	WizardStepLayout<T>
 >;

--- a/libs/state-machine/src/lib/types.ts
+++ b/libs/state-machine/src/lib/types.ts
@@ -73,10 +73,9 @@ export interface WizardStepLayout<T extends GenericStorageInterface = unknown> {
 	canSkipTo?: boolean;
 }
 
-export type WizardLayout<T extends GenericStorageInterface = unknown> = Record<
-	string,
-	WizardStepLayout<T>
->;
+export type WizardLayout<
+	T extends GenericStorageInterface = GenericStorageInterface,
+> = Record<string, WizardStepLayout<T>>;
 
 /**
  * Interface for the data payload sent to by the client for a single step in the wizard.

--- a/libs/state-machine/src/lib/utility.ts
+++ b/libs/state-machine/src/lib/utility.ts
@@ -4,8 +4,9 @@ import type {
 } from '@newsletters-nx/newsletters-data-client';
 import {
 	draftNewsletterDataToFormData,
-	DraftStorage,
 	formDataToDraftNewsletterData,
+	InMemoryDraftStorage,
+	S3DraftStorage,
 } from '@newsletters-nx/newsletters-data-client';
 import { StateMachineError, StateMachineErrorCode } from './StateMachineError';
 import type {
@@ -59,7 +60,10 @@ export const getFormDataForExistingItem = async (
 	requestBody: CurrentStepRouteRequest,
 	storageInstance: unknown,
 ): Promise<FormDataRecord | undefined> => {
-	if (storageInstance instanceof DraftStorage) {
+	if (
+		storageInstance instanceof S3DraftStorage ||
+		storageInstance instanceof InMemoryDraftStorage
+	) {
 		const listId =
 			typeof requestBody.formData?.['listId'] === 'number'
 				? requestBody.formData['listId']
@@ -94,7 +98,10 @@ export const modifyExistingItemWithFormData = async (
 	formData: FormDataRecord,
 	storageInstance: unknown,
 ): Promise<FormDataRecord | undefined> => {
-	if (storageInstance instanceof DraftStorage) {
+	if (
+		storageInstance instanceof S3DraftStorage ||
+		storageInstance instanceof InMemoryDraftStorage
+	) {
 		// formDataToDraftNewsletterData CAN THROW
 		const newDraftWithId: DraftWithId = {
 			...formDataToDraftNewsletterData(formData),

--- a/libs/state-machine/src/lib/utility.ts
+++ b/libs/state-machine/src/lib/utility.ts
@@ -6,7 +6,6 @@ import type {
 import { StateMachineError, StateMachineErrorCode } from './StateMachineError';
 import type {
 	CurrentStepRouteRequest,
-	GenericStorageInterface,
 	WizardLayout,
 	WizardStepData,
 } from './types';
@@ -29,7 +28,7 @@ export const makeStepDataWithErrorMessage = (
 export const validateIncomingFormData = (
 	stepId: string,
 	formData: FormDataRecord | undefined,
-	wizardLayout: WizardLayout<GenericStorageInterface>,
+	wizardLayout: WizardLayout<unknown>,
 ) => {
 	const currentStepLayout = wizardLayout[stepId];
 	const formSchemaForIncomingStep = currentStepLayout?.schema;

--- a/libs/state-machine/src/lib/utility.ts
+++ b/libs/state-machine/src/lib/utility.ts
@@ -6,6 +6,7 @@ import type {
 import { StateMachineError, StateMachineErrorCode } from './StateMachineError';
 import type {
 	CurrentStepRouteRequest,
+	GenericStorageInterface,
 	WizardLayout,
 	WizardStepData,
 } from './types';
@@ -28,7 +29,7 @@ export const makeStepDataWithErrorMessage = (
 export const validateIncomingFormData = (
 	stepId: string,
 	formData: FormDataRecord | undefined,
-	wizardLayout: WizardLayout,
+	wizardLayout: WizardLayout<GenericStorageInterface>,
 ) => {
 	const currentStepLayout = wizardLayout[stepId];
 	const formSchemaForIncomingStep = currentStepLayout?.schema;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Changes `WizardLayouts` and its sub-types (eg `AsyncValidator`, `WizardStepLayoutButton`) to  generic type with a parameter for the type of the "storageInstance" passed to the step event function (eg `executeStep`), so that Wizards are not tied to the `DraftStorage` class and can potentially interface with any set of external services.

Defines the existing layouts, "newsletterDataLayout" and "renderingOptionsLayout" as being `WizardLayout<DraftStorage>`

Refactors the code in the state-machine library to be generalised about the type of "storageInstance" the `WizardLayout` uses

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
All functionality will be unaffected by this PR.

## How can we measure success?

Will be possible to define wizards that take steps other than creating and editing draft newsletters - this in currently needed for the "launch newsletter wizard"

## Have we considered potential risks?

There is further refactoring needed to remove references to `DraftStorage` from the state-machine library's "utility" module.



