### PR TITLE
Added Not found page.

### DIFF
--- a/apps/newsletters-ui/src/app/ComingSoonPage.tsx
+++ b/apps/newsletters-ui/src/app/ComingSoonPage.tsx
@@ -1,0 +1,11 @@
+import { Container, Grid } from '@mui/material';
+
+export const ComingSoon = () => (
+	<Container maxWidth="lg">
+		<Grid container spacing={3} rowSpacing={6} paddingY={2}>
+			<Grid item xs={6} sm={4} display={'flex'}>
+				Coming soon...
+			</Grid>
+		</Grid>
+	</Container>
+);

--- a/apps/newsletters-ui/src/app/NotFoundPage.tsx
+++ b/apps/newsletters-ui/src/app/NotFoundPage.tsx
@@ -1,0 +1,11 @@
+import {Container, Grid} from '@mui/material';
+
+export const NotFoundPage = () => (
+	<Container maxWidth="lg">
+		<Grid container spacing={3} rowSpacing={6} paddingY={2}>
+			<Grid item xs={6} sm={4} display={'flex'}>
+				Page not found
+			</Grid>
+		</Grid>
+	</Container>
+);

--- a/apps/newsletters-ui/src/app/routes/home.tsx
+++ b/apps/newsletters-ui/src/app/routes/home.tsx
@@ -1,8 +1,10 @@
 import type { RouteObject } from 'react-router-dom';
+import { ComingSoon } from '../ComingSoonPage';
 import { HomeMenu } from '../components/HomeMenu';
 import { ErrorPage } from '../ErrorPage';
 import { Layout } from '../Layout';
 import { listLoader } from '../loaders/newsletters';
+import { NotFoundPage } from '../NotFoundPage';
 
 export const homeRoute: RouteObject = {
 	path: '/',
@@ -17,12 +19,12 @@ export const homeRoute: RouteObject = {
 		},
 		{
 			path: 'templates',
-			element: <span>Coming soon...</span>,
+			element: <ComingSoon />,
 		},
 		{
 			path: 'thrashers',
-			element: <span>Coming soon...</span>,
+			element: <ComingSoon />,
 		},
-		{ path: '*', element: <ErrorPage /> },
+		{ path: '*', element: <NotFoundPage /> },
 	],
 };


### PR DESCRIPTION
Where request received for unknown route, indicate this with a Not found response.

Extracted `Coming soon` to a component and styled consistently with the rest of the app

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a not found response where we do not have a. matching route in the newsletters UI.

## How to test

- Checkout out the branch or deploy to code.
- Visit a URL that does not exist
- Verify `Not Found` response

The reason that this logic in the Error page was not working in the expected way is that there is no error. The`*` route matches any non-specified request. Another way to approach this would be to remove that catch-all route and allow the error element to display. 

The approach taken here makes it explicit what we are returning for a non-matched route, though we could add conditional login in the Error component too.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

It works

## Images

![404](https://user-images.githubusercontent.com/3277259/231742695-113cc81d-be1e-4604-8574-71d1bd44075a.gif)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

