### PR TITLE
navigate back to the list after updating the newsletter

### DIFF
--- a/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
+++ b/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
@@ -1,5 +1,6 @@
 import { Alert, Container, Snackbar } from '@mui/material';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import type {
 	ApiResponse,
 	NewsletterData,
@@ -13,6 +14,7 @@ interface Props {
 
 export const EditNewsletterForm = ({ originalItem }: Props) => {
 	const [item, setItem] = useState(originalItem);
+	const navigate = useNavigate();
 	const [errorMessage, setErrorMessage] = useState<string | undefined>();
 	const [confirmationMessage, setConfirmationMessage] = useState<
 		string | undefined
@@ -41,6 +43,7 @@ export const EditNewsletterForm = ({ originalItem }: Props) => {
 		if (castResponse.ok) {
 			setItem(castResponse.data);
 			setConfirmationMessage('newsletter updated!');
+			navigate('../');
 		} else {
 			setErrorMessage(castResponse.message);
 		}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Implements the change here: 
https://github.com/guardian/newsletters-nx/pull/94#discussion_r1172360344
Submitting the 'edit newsletter' form navigates the user back to the list

## How to test
- `npm run dev`
- http://localhost:4200/newsletters/edit/avon-recumbent
- change the name and hit submit - if the update is successful, the user is navigated back to the list view, which the change showing
