### PR TITLE
Added container to Drafts / Newsletters to make the styling consistent

### DIFF
--- a/apps/newsletters-ui/src/app/ContentWrapper.tsx
+++ b/apps/newsletters-ui/src/app/ContentWrapper.tsx
@@ -2,8 +2,8 @@ import { Container, Grid } from '@mui/material';
 
 export const ContentWrapper = ({ children }: { children: React.ReactNode }) => (
 	<Container maxWidth="lg">
-		<Grid container spacing={3} rowSpacing={6} paddingY={2}>
-			<Grid item xs={6} sm={4} display={'flex'}>
+		<Grid container spacing={2} rowSpacing={2} paddingY={2}>
+			<Grid item xs={12} display={'flex'} direction={'column'}>
 				{children}
 			</Grid>
 		</Grid>

--- a/apps/newsletters-ui/src/app/components/GlobalFilter.tsx
+++ b/apps/newsletters-ui/src/app/components/GlobalFilter.tsx
@@ -1,3 +1,4 @@
+import { TextField } from '@mui/material';
 import { useState } from 'react';
 
 type Props = {
@@ -11,13 +12,12 @@ export const GlobalFilter = ({ setGlobalFilter }: Props) => {
 		setGlobalFilter(e.target.value || '');
 	};
 	return (
-		<span>
-			Search:&nbsp;
-			<input
-				value={filterValue}
-				onChange={handleChange}
-				placeholder={`Filter data...`}
-			/>
-		</span>
+		<TextField
+			id="search-for-newsletters"
+			label="Search for Newsletters"
+			variant="outlined"
+			onChange={handleChange}
+			value={filterValue}
+		/>
 	);
 };

--- a/apps/newsletters-ui/src/app/components/Table.tsx
+++ b/apps/newsletters-ui/src/app/components/Table.tsx
@@ -1,5 +1,7 @@
+import { Grid } from '@mui/material';
 import type { Cell, Column } from 'react-table';
 import { useGlobalFilter, useSortBy, useTable } from 'react-table';
+import { ContentWrapper } from '../ContentWrapper';
 import { tableStyle } from '../styles';
 import { ColumnData } from './ColumnData';
 import { ColumnHeader } from './ColumnHeader';
@@ -28,14 +30,18 @@ export const Table = ({ data, columns, defaultSortId }: TableProps) => {
 	} = useTable({ columns, data, initialState }, useGlobalFilter, useSortBy);
 
 	return (
-		<>
+		<ContentWrapper>
 			<div>Hide/Show Columns</div>
-			<div>
-				{allColumns.map((column) => (
-					<ColumnVisibility column={column} key={`visibility ${column.id}`} />
-				))}
-			</div>
-			<GlobalFilter setGlobalFilter={setGlobalFilter} />
+			<Grid container spacing={2} rowSpacing={2} paddingY={2}>
+				<Grid item xs={12} display={'flex'} direction={'column'}>
+					{allColumns.map((column) => (
+						<ColumnVisibility column={column} key={`visibility ${column.id}`} />
+					))}
+				</Grid>
+				<Grid item xs={12} display={'flex'} direction={'column'}>
+					<GlobalFilter setGlobalFilter={setGlobalFilter} />
+				</Grid>
+			</Grid>
 			<table {...getTableProps()} css={tableStyle}>
 				<thead>
 					{headerGroups.map((headerGroup) => (
@@ -59,6 +65,6 @@ export const Table = ({ data, columns, defaultSortId }: TableProps) => {
 					})}
 				</tbody>
 			</table>
-		</>
+		</ContentWrapper>
 	);
 };


### PR DESCRIPTION
Replaced search input with the Material Component for consistency with the Data collection forms

## What does this change?

Adds consistency to the layout & consistency to the input


## How to test

Check it out & test it behaves - search should still filter and the draft / newsletters table shou;ld have the same layout (ie padding) as the Wizards

## Images

![Screenshot 2023-04-24 at 08 21 16](https://user-images.githubusercontent.com/3277259/233926602-37bf0ec4-71d6-4f92-a130-37e25d322d57.png)
c.png)

![Screenshot 2023-04-24 at 08 21 01](https://user-images.githubusercontent.com/3277259/233926644-61ad4d87-78c0-4a32-a787-060650b0313a.png)

![Screenshot 2023-04-24 at 08 21 32](https://user-images.githubusercontent.com/3277259/233927472-91ff474f-324a-441e-8663-e92a1ce688c5.png)
