### PR TITLE
Remove superfluous text from rendering options start page

### DIFF
--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/start.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/start.ts
@@ -9,8 +9,6 @@ export const startLayout: WizardStepLayout<DraftStorage> = {
 
 This wizard is to choose the options for how an article-based newsletter will appear in Email-rendering.
 
-You do **not need to complete** this wizard for **fronts-based newsletters or newsletters that do not use Email-rendering**.
-
 `,
 	label: 'Start',
 	buttons: {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

When the rendering options wizard was first created, it was available for all newsletters, with a warning that it only needed to be completed for article-based newsletters.

Now the wizard is only available for article-based newsletters, and so the warning has been removed.

## How to test

Run `yarn dev`
Select the `Edit | Article Rendering` option for one of the article-based newsletters on the list of Drafts

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Before
![Screenshot 2023-04-25 at 12 07 07](https://user-images.githubusercontent.com/74301289/234259274-cec08e61-1712-43e4-b64a-7ca852250c6b.png)

After
![Screenshot 2023-04-25 at 12 06 33](https://user-images.githubusercontent.com/74301289/234259327-9a61b1e5-3a2d-4052-94f7-1b3746e534f3.png)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
