### PR TITLE
Copy updates

### DIFF
--- a/apps/newsletters-ui/index.html
+++ b/apps/newsletters-ui/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<title>NewslettersUi</title>
+		<title>Newsletters Launch Wizard’</title>
 		<base href="/" />
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/apps/newsletters-ui/src/app/Layout.tsx
+++ b/apps/newsletters-ui/src/app/Layout.tsx
@@ -12,7 +12,6 @@ const Frame = styled.div`
 	flex-direction: column;
 	height: 100vh;
 	box-sizing: border-box;
-	overflow: hidden;
 	align-items: stretch;
 
 	>

--- a/apps/newsletters-ui/src/app/components/DraftsTable.tsx
+++ b/apps/newsletters-ui/src/app/components/DraftsTable.tsx
@@ -81,7 +81,7 @@ export const DraftsTable = ({ drafts }: Props) => {
 				},
 			},
 			{
-				Header: 'delete',
+				Header: 'Delete',
 				Cell: ({ row: { original } }) => {
 					const draft = original as DraftNewsletterData;
 
@@ -99,7 +99,7 @@ export const DraftsTable = ({ drafts }: Props) => {
 				},
 			},
 			{
-				Header: 'launch',
+				Header: 'Launch',
 				Cell: ({ row: { original } }) => {
 					const draft = original as DraftNewsletterData;
 

--- a/apps/newsletters-ui/src/app/components/NewslettersTable.tsx
+++ b/apps/newsletters-ui/src/app/components/NewslettersTable.tsx
@@ -66,14 +66,14 @@ export const NewslettersTable = ({ newsletters }: Props) => {
 				Cell: formatCellBoolean,
 			},
 			{
-				Header: 'edit',
+				Header: 'Edit',
 				Cell: ({ row: { original } }) => {
 					const newsletter = original as NewsletterData;
 					return (
 						<NavigateButton
 							href={`/newsletters/edit/${newsletter.identityName}`}
 						>
-							edit
+							Edit
 						</NavigateButton>
 					);
 				},

--- a/apps/newsletters-ui/src/app/components/SchemaForm/SelectInput.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/SelectInput.tsx
@@ -33,7 +33,7 @@ export const SelectInput: FunctionComponent<
 					label={label}
 					onChange={handleChange}
 				>
-					{optional && <MenuItem value={undefToken}>[UNDEFINED]</MenuItem>}
+					{optional && <MenuItem value={undefToken}>Select value</MenuItem>}
 					{options.map((option) => (
 						<MenuItem key={option} value={option}>
 							{option}

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/isReady.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/isReady.ts
@@ -45,7 +45,7 @@ export const isReadyLayout: WizardStepLayout<LaunchService> = {
 
 		return populated;
 	},
-	label: 'check if ready',
+	label: 'Check if ready',
 	buttons: {
 		cancel: {
 			buttonType: 'RED',

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/categoryLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/categoryLayout.ts
@@ -14,11 +14,11 @@ const markdownTemplate = `
 
 Editorial newsletters can be produced in three ways:
 
-**article-based**: Each chapter of the newsletter is written as a composer article.
+- **article-based**: Each chapter of the newsletter is written as a composer article.
 
-**fronts-based**: The newsletters are generated from a fronts page.
+- **fronts-based**: The newsletters are generated from a fronts page.
 
-**manual-send**: The content of the email are generated manually or with an external tool.
+- **manual-send**: The content of the email are generated manually or with an external tool.
 
 If you aren't sure or none of the above fit, please select "other".
 

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/createDraftNewsletterLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/createDraftNewsletterLayout.ts
@@ -9,7 +9,7 @@ export const createDraftNewsletterLayout: WizardStepLayout<DraftStorage> = {
 
 Welcome!  This wizard will guide you through the process of creating a newsletter using email-rendering.
 
-The first step is to enter the name of your newsletter, for example **Down to Earth**.
+The first step is to enter the name of your newsletter. For example,  **Down to Earth**.
 
 `,
 	label: 'Enter Name',

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/dateLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/dateLayout.ts
@@ -23,9 +23,9 @@ This needs to be added in the UK timezone so the system can process this informa
 
 Will **{{name}}** be promoted (e.g. on thrashers) ahead of the launch day?  If so:
 
-- what date will the sign up page go live?
+- What date will the sign up page go live?
 
-- what date will the thrashers go live?
+- What date will the thrashers go live?
 
 ## Testing
 

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/finishLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/finishLayout.ts
@@ -4,9 +4,9 @@ import { executeSkip } from '../../executeSkip';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 
-const markdownTemplate = `# Finished
+const markdownTemplate = `# You're finished!
 
-You have reached the end of the wizard for newsletter **{{name}}**.
+Congratulations, you have reached the end of the wizard for newsletter **{{name}}**.
 
 You can see your draft on the [details page](drafts/{{listId}}), which includes the options to edit the data you have provided and provide additional details.
 

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
@@ -82,7 +82,7 @@ export const formSchemas = {
 		})
 		.describe('Select from the drop-down list'),
 
-	designBrief: newsletterDataSchema
+	newsletterDesign: newsletterDataSchema
 		.pick({
 			designBriefDoc: true,
 			figmaDesignUrl: true,

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/frequencyLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/frequencyLayout.ts
@@ -11,15 +11,16 @@ const markdownTemplate = `
 # Specify the send frequency of {{name}}
 
 Specify how regularly the newsletter will be sent e.g.
-- every day
-- every weekday
-- weekly
-- fortnightly
-- monthly
+- Every day
+- Every weekday
+- Weekly
+- Fortnightly
+- Monthly
+- Monthly
 
 You can also add a different frequency e.g.
-- weekly during election season
-- weekly for eight weeks (in the case of an asynchronous newsletter)
+- Weekly during election season
+- Weekly for eight weeks (in the case of an asynchronous newsletter)
 
 The frequency you specify will be shown on thrashers, on the sign up page and on the all newsletters page.
 

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/index.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/index.ts
@@ -4,10 +4,10 @@ import { cancelLayout } from './cancelLayout';
 import { categoryLayout } from './categoryLayout';
 import { createDraftNewsletterLayout } from './createDraftNewsletterLayout';
 import { dateLayout } from './dateLayout';
-import { designBriefLayout } from './designBriefLayout';
 import { editDraftNewsletterLayout } from './editDraftNewsletterLayout';
 import { finishLayout } from './finishLayout';
 import { frequencyLayout } from './frequencyLayout';
+import { newsletterDesignLayout } from './newsletterDesignLayout';
 import { onlineArticleLayout } from './onlineArticleLayout';
 import { pillarLayout } from './pillarLayout';
 import { regionFocusLayout } from './regionFocusLayout';
@@ -28,7 +28,7 @@ export const newsletterDataLayout: WizardLayout<DraftStorage> = {
 	onlineArticle: onlineArticleLayout,
 	tags: tagsLayout,
 	thrasher: thrasherLayout,
-	designBrief: designBriefLayout,
+	newsletterDesign: newsletterDesignLayout,
 	signUpPage: signUpPageLayout,
 	signUpEmbed: signUpEmbedLayout,
 	finish: finishLayout,

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/newsletterDesignLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/newsletterDesignLayout.ts
@@ -14,13 +14,8 @@ const markdownTemplate = `
 # Add the design brief and Figma design link for {{name}}
 
 Please share the following for **{{name}}**:
-- the design brief Google document
-- the signed off Figma design URL
-
-Does the Figma design file include images designs for thrashers?
-
-If so, please ensure the thrasher images are provided for both desktop and mobile widths.
-
+- The design brief Google document URL
+- The signed off and final Figma design URL, including thrasher designs for mobile and desktop
 `.trim();
 
 const staticMarkdown = markdownTemplate.replace(
@@ -28,9 +23,9 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const designBriefLayout: WizardStepLayout<DraftStorage> = {
+export const newsletterDesignLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown,
-	label: 'Design Brief',
+	label: 'Newsletter Design',
 	dynamicMarkdown(requestData, responseData) {
 		if (!responseData) {
 			return staticMarkdown;
@@ -50,10 +45,10 @@ export const designBriefLayout: WizardStepLayout<DraftStorage> = {
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
 			onBeforeStepChangeValidate: (stepData): string | undefined => {
-				const designBriefDoc = stepData.formData
+				const newsletterDesignDoc = stepData.formData
 					? stepData.formData['designBriefDoc']
 					: undefined;
-				if (!designBriefDoc) return 'NO DESIGN BRIEF DOC PROVIDED';
+				if (!newsletterDesignDoc) return 'NO DESIGN BRIEF DOC PROVIDED';
 				const figmaDesignUrl = stepData.formData
 					? stepData.formData['figmaDesignUrl']
 					: undefined;
@@ -77,7 +72,7 @@ export const designBriefLayout: WizardStepLayout<DraftStorage> = {
 			executeStep: executeModify,
 		},
 	},
-	schema: formSchemas.designBrief,
+	schema: formSchemas.newsletterDesign,
 	canSkipTo: true,
 	executeSkip: executeSkip,
 };

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/regionFocusLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/regionFocusLayout.ts
@@ -16,7 +16,7 @@ import { formSchemas } from './formSchemas';
 const markdownTemplate = `
 # Choose the Geo Focus for {{name}}
 
-Is **{{name}}** specific to a UK, Australia or US audience, or does it have international appeal?
+What’s the geo focus of **{{name}}**? UK, US, Australia or International??
 
 `.trim();
 

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/thrasherLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/thrasherLayout.ts
@@ -19,8 +19,6 @@ Should the single thrasher appear on app and web?
 
 Do you need one or more multi-thrashers i.e. sets where the thrasher for **{{name}}** is combined with thrashers for 2 or more other newsletters?
 
-***NEED TO DETERMINE THE BEST WAY TO CAPTURE THIS INFORMATION - CLEARLY A CHECKBOX IS INSUFFICIENT!***
-
 The description will appear on each thrasher e.g.
 
 ![Thrasher description](https://i.guim.co.uk/img/uploads/2023/03/15/thrasher.png?quality=85&dpr=2&width=300&s=d11e194cac6fd51bdd84fca862786501)

--- a/libs/state-machine/README.md
+++ b/libs/state-machine/README.md
@@ -1,11 +1,11 @@
 # state-machine
 
-The State-machine is library to support "Wizard" user interfaces where the user is guided through a series of step which impsct the state of a server-side application, such as entering or modifying data or instructing the application to take an action.
+The State-machine is library to support "Wizard" user interfaces where the user is guided through a series of step which inspect the state of a server-side application, such as entering or modifying data or instructing the application to take an action.
 
 It exports:
 
--   a set of types that can be imported into other libraries to define `WizardLayout`s for specific workflows.
--   a handler function to be called on the server side to validiate the user input against the parameters defined in the `WizardLayout`, dispatch and resulting actions and return the state information for the next step to the client
+-   A set of types that can be imported into other libraries to define `WizardLayout`s for specific workflows.
+-   A handler function to be called on the server side to validate the user input against the parameters defined in the `WizardLayout`, dispatch and resulting actions and return the state information for the next step to the client
 
 The aim is to keep this library generic, so it could be used for `WizardLayout` describing any workflow and any data model.
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

A selection of updates to copy as detailed in https://trello.com/c/2uM13EfL/404-copy-changes-for-ui-ahead-of-mvp-release-and-demo

This change includes a rename of `designBriefLayout` to `newsletterDesign`

