### PR TITLE
Implement delete

### DIFF
--- a/libs/newsletters-data-client/src/lib/newsletter-storage/InMemoryNewsletterStorage.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/InMemoryNewsletterStorage.ts
@@ -118,11 +118,10 @@ export class InMemoryNewsletterStorage implements NewsletterStorage {
 		}
 
 		this.memory.splice(this.memory.indexOf(match), 1);
-		const response: SuccessfulStorageResponse<NewsletterData> = {
+		return Promise.resolve({
 			ok: true,
-			data: match,
-		};
-		return Promise.resolve(response);
+			data: `newsletter #${listId} deleted`,
+		} as SuccessfulStorageResponse<string>);
 	}
 
 	list() {

--- a/libs/newsletters-data-client/src/lib/newsletter-storage/NewsletterStorage.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/NewsletterStorage.ts
@@ -43,7 +43,7 @@ export abstract class NewsletterStorage {
 	abstract delete(
 		listId: number,
 	): Promise<
-		SuccessfulStorageResponse<NewsletterData> | UnsuccessfulStorageResponse
+		SuccessfulStorageResponse<string> | UnsuccessfulStorageResponse
 	>;
 
 	abstract list(): Promise<

--- a/libs/newsletters-data-client/src/lib/newsletter-storage/NewsletterStorage.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/NewsletterStorage.ts
@@ -42,9 +42,7 @@ export abstract class NewsletterStorage {
 
 	abstract delete(
 		listId: number,
-	): Promise<
-		SuccessfulStorageResponse<string> | UnsuccessfulStorageResponse
-	>;
+	): Promise<SuccessfulStorageResponse<string> | UnsuccessfulStorageResponse>;
 
 	abstract list(): Promise<
 		SuccessfulStorageResponse<NewsletterData[]> | UnsuccessfulStorageResponse

--- a/libs/newsletters-data-client/src/lib/newsletter-storage/s3-newsletter-storage.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/s3-newsletter-storage.ts
@@ -100,15 +100,15 @@ export class S3NewsletterStorage implements NewsletterStorage {
 
 	async delete(
 		listId: number,
-	): Promise<
-		SuccessfulStorageResponse<string> | UnsuccessfulStorageResponse
-	> {
+	): Promise<SuccessfulStorageResponse<string> | UnsuccessfulStorageResponse> {
 		const newsletterToDelete = await this.read(listId);
 		if (!newsletterToDelete.ok) {
 			return newsletterToDelete;
 		}
 		try {
-			const { data: { listId, identityName } } = newsletterToDelete;
+			const {
+				data: { listId, identityName },
+			} = newsletterToDelete;
 			const key = `${this.OBJECT_PREFIX}${identityName}:${listId}.json`;
 			await this.deleteObject(key);
 		} catch (error) {
@@ -121,7 +121,7 @@ export class S3NewsletterStorage implements NewsletterStorage {
 		return {
 			ok: true,
 			data: `newsletter with id ${listId} deleted`,
-		}
+		};
 	}
 
 	async list(): Promise<


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a delete implementation for s3 newsletter storage
Fixes a bug where Modification errors in updates to launched newsletters were not being returned

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

The Delete function for s3 is not exposed in the API as we have yet to decide what we are doing when we want to remove a launched newsletter. Added the delete implementation for completeness. It may change. Review the code and that's enough. 

