### PR TITLE
Default production category to blank

### DIFF
--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/categoryLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/categoryLayout.ts
@@ -1,5 +1,8 @@
 import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
-import type { WizardStepLayout } from '@newsletters-nx/state-machine';
+import type {
+	WizardStepData,
+	WizardStepLayout,
+} from '@newsletters-nx/state-machine';
 import {
 	getNextStepId,
 	getPreviousOrEditStartStepId,
@@ -50,6 +53,15 @@ export const categoryLayout: WizardStepLayout<DraftStorage> = {
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
+			onBeforeStepChangeValidate: (stepData: WizardStepData) => {
+				const productionCategory = stepData.formData
+					? stepData.formData['category']
+					: undefined;
+				if (!productionCategory || productionCategory === '') {
+					return 'NO PRODUCTION CATEGORY SELECTED';
+				}
+				return undefined;
+			},
 			executeStep: executeModify,
 		},
 	},

--- a/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
@@ -72,7 +72,7 @@ export const thrasherOptionsSchema = z.object({
 export type ThrasherOptions = z.infer<typeof thrasherOptionsSchema>;
 
 export const newsletterCategoriesSchema = z
-	.enum(['article-based', 'fronts-based', 'manual-send', 'other'])
+	.enum(['', 'article-based', 'fronts-based', 'manual-send', 'other'])
 	.describe('production category');
 export type NewsletterCategory = z.infer<typeof newsletterCategoriesSchema>;
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Defaults the Production Category to blank on the create newsletter wizard, so that users are forced to specifically select the category rather than just accepting the default

## How to test

`npm run dev`
Select the Create Newsletter Wizard
Enter a name and click Next
Ensure that
- no production category is displayed by default
- it's not possible to click next without selecting a production category

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![Screenshot 2023-05-03 at 15 14 10](https://user-images.githubusercontent.com/74301289/235946473-1982b577-46d8-4103-b7cf-477fa0a30126.png)

![Screenshot 2023-05-03 at 15 25 08](https://user-images.githubusercontent.com/74301289/235946501-6c40f5a5-d3bd-4a8a-9e65-ae12910fa291.png)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
