### PR TITLE
Dblatcher no edit dialogue if one option

### DIFF
--- a/apps/newsletters-ui/src/app/components/DraftsTable.tsx
+++ b/apps/newsletters-ui/src/app/components/DraftsTable.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import type { Column } from 'react-table';
 import { calculateProgress } from '@newsletters-nx/newsletters-data-client';
 import type { DraftNewsletterData } from '@newsletters-nx/newsletters-data-client';
+import { getEditDraftWizardLinks } from '../get-draft-edit-wizard-links';
 import { CircularProgressWithLabel } from './CircularProgressWithLabel';
 import { DeleteDraftButton } from './DeleteDraftButton';
 import { EditDraftDialog } from './EditDraftDialog';
@@ -66,6 +67,20 @@ export const DraftsTable = ({ drafts }: Props) => {
 				Header: 'Edit',
 				Cell: ({ row: { original } }) => {
 					const draft = original as DraftNewsletterData;
+					const links = getEditDraftWizardLinks(draft);
+
+					if (links.length === 1) {
+						const [link] = links;
+						return (
+							<NavigateButton
+								href={link?.href}
+								startIcon={'⚙'}
+								variant="outlined"
+							>
+								Edit
+							</NavigateButton>
+						);
+					}
 
 					return (
 						<Button

--- a/apps/newsletters-ui/src/app/components/EditDraftNavigateButtons.tsx
+++ b/apps/newsletters-ui/src/app/components/EditDraftNavigateButtons.tsx
@@ -1,42 +1,15 @@
 import type { DraftNewsletterData } from '@newsletters-nx/newsletters-data-client';
+import { getEditDraftWizardLinks } from '../get-draft-edit-wizard-links';
 import { NavigateButton } from './NavigateButton';
 
 interface Props {
 	draft: DraftNewsletterData;
 }
 
-type WizardLink = {
-	label: string;
-	href: string;
-};
-const getLinks = (draft: DraftNewsletterData): WizardLink[] => {
-	const { category, listId } = draft;
-
-	const links: WizardLink[] = [];
-
-	if (!listId) {
-		return links;
-	}
-
-	links.push({
-		label: 'Newsletter set-up',
-		href: `/newsletters/newsletter-data/${listId.toString()}`,
-	});
-
-	if (category === 'article-based') {
-		links.push({
-			label: 'Article Rendering',
-			href: `/newsletters/newsletter-data-rendering/${listId.toString()}`,
-		});
-	}
-
-	return links;
-};
-
 export const EditDraftNavigateButtons = ({ draft }: Props) => {
 	return (
 		<>
-			{getLinks(draft).map((link) => (
+			{getEditDraftWizardLinks(draft).map((link) => (
 				<NavigateButton key={link.href} href={link.href}>
 					{link.label}
 				</NavigateButton>

--- a/apps/newsletters-ui/src/app/get-draft-edit-wizard-links.ts
+++ b/apps/newsletters-ui/src/app/get-draft-edit-wizard-links.ts
@@ -1,0 +1,31 @@
+import type { DraftNewsletterData } from '@newsletters-nx/newsletters-data-client';
+
+export type WizardLink = {
+	label: string;
+	href: string;
+};
+export const getEditDraftWizardLinks = (
+	draft: DraftNewsletterData,
+): WizardLink[] => {
+	const { category, listId } = draft;
+
+	const links: WizardLink[] = [];
+
+	if (!listId) {
+		return links;
+	}
+
+	links.push({
+		label: 'Newsletter set-up',
+		href: `/newsletters/newsletter-data/${listId.toString()}`,
+	});
+
+	if (category === 'article-based') {
+		links.push({
+			label: 'Article Rendering',
+			href: `/newsletters/newsletter-data-rendering/${listId.toString()}`,
+		});
+	}
+
+	return links;
+};


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The draft table will render a link button going directly to the Edit Draft wizard when that is the only relevant wizard, instead of opening the dialog with the options.

In the current state of the application, that means direct link button will be rendered if the draft is not 'article-based' since that is the only condition where there is an extra wizard. If we add more wizards and update the `getEditDraftWizardLinks` function, the the logic in the draft table will still work (IE render the link dialog if there are more than one option, otherwise go to the only option directly).

https://trello.com/c/VROy98ZP/399-if-email-is-not-article-based-miss-out-modal-dialog-on-edit-option


## How to test

go to the drafts table - the edit buttons for the none "article rendering" drafts will go straight to the newsletterData wizard.
