### PR TITLE
Dblatcher indicate step completion

### DIFF
--- a/apps/newsletters-ui/src/app/components/SchemaForm/SelectInput.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/SelectInput.tsx
@@ -4,7 +4,7 @@ import type { FunctionComponent } from 'react';
 import { defaultFieldStyle } from './styling';
 import type { FieldProps } from './util';
 
-const undefToken = '_____';
+const EMPTY_STRING = '';
 
 export const SelectInput: FunctionComponent<
 	FieldProps & {
@@ -15,25 +15,22 @@ export const SelectInput: FunctionComponent<
 	}
 > = (props) => {
 	const { value, optional, options, inputHandler, label = 'value' } = props;
-
 	const handleChange = (event: SelectChangeEvent<string>) => {
-		if (event.target.value === undefToken) {
+		if (event.target.value === EMPTY_STRING) {
 			return inputHandler(undefined);
 		}
 		return inputHandler(event.target.value);
 	};
-	const valueWithUndefinedToken = value ?? undefToken;
+	const valueAsString = value ?? EMPTY_STRING;
 
 	return (
 		<div css={defaultFieldStyle}>
 			<FormControl fullWidth>
-				<InputLabel id="demo-simple-select-label">{label}</InputLabel>
-				<Select
-					value={valueWithUndefinedToken}
-					label={label}
-					onChange={handleChange}
-				>
-					{optional && <MenuItem value={undefToken}>Select value</MenuItem>}
+				<InputLabel id={`select-input-label-${label}-${options.toString()}`}>
+					{label}
+				</InputLabel>
+				<Select value={valueAsString} label={label} onChange={handleChange}>
+					{optional && <MenuItem value={EMPTY_STRING}>[none]</MenuItem>}
 					{options.map((option) => (
 						<MenuItem key={option} value={option}>
 							{option}

--- a/apps/newsletters-ui/src/app/components/SchemaForm/util.ts
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/util.ts
@@ -47,6 +47,9 @@ export function eventToString(event: FormEvent, defaultValue = ''): string {
 
 function fieldValueIsRightType(value: FieldValue, field: FieldDef): boolean {
 	if (field.type === 'ZodEnum') {
+		if (field.optional && typeof value === 'undefined') {
+			return true;
+		}
 		return field.enumOptions?.includes(value as string) ?? false;
 	}
 

--- a/apps/newsletters-ui/src/app/components/StepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StepNav.tsx
@@ -1,4 +1,5 @@
 import { css, Step, StepButton, StepLabel, Stepper } from '@mui/material';
+import { useState } from 'react';
 import type {
 	StepListing,
 	StepperConfig,
@@ -20,6 +21,17 @@ export const StepNav = ({
 	handleStepClick,
 	formData,
 }: Props) => {
+	// Validating formData aginst the schema for every step to see if the
+	// step is complete is potentially a fairly expensive operation.
+	// The state logic is so this is done only when the step changes,
+	// not every time the user changes the formData (which includes every
+	// key pressed in a text field).
+	const [currentStepIdOnLastRender, setCurrenStepIdOnLastRender] =
+		useState(currentStepId);
+	const [completionRecord, setCompletionRecord] = useState<
+		Partial<Record<string, boolean>>
+	>({});
+
 	const filteredStepList = stepperConfig.steps.filter((step) => {
 		if (step.parentStepId) {
 			return false;
@@ -37,6 +49,32 @@ export const StepNav = ({
 		}
 	});
 
+	const updateCompletion = () => {
+		const list = stepperConfig.steps.reduce<Partial<Record<string, boolean>>>(
+			(record, step) => {
+				const result = step.schema
+					? step.schema.safeParse(formData).success
+					: true;
+
+				return { ...record, [step.id]: result };
+			},
+			{},
+		);
+
+		setCompletionRecord(list);
+	};
+
+	// On the initial render, the completionRecord is set to {}
+	if (!Object.keys(completionRecord).length) {
+		updateCompletion();
+	}
+
+	// Update the completion record if the step has changed
+	if (currentStepId !== currentStepIdOnLastRender) {
+		setCurrenStepIdOnLastRender(currentStepId);
+		updateCompletion();
+	}
+
 	const currentStep = stepperConfig.steps.find(
 		(step) => step.id === currentStepId,
 	);
@@ -44,14 +82,13 @@ export const StepNav = ({
 	const isCurrent = (step: StepListing) =>
 		step.id === currentStep?.id || step.id === currentStep?.parentStepId;
 
+	const isComplete = (step: StepListing) => completionRecord[step.id];
+
 	const shouldRenderAsButton = (step: StepListing) =>
 		currentStep?.canSkipFrom &&
 		stepperConfig.isNonLinear &&
 		step.canSkipTo &&
 		!isCurrent(step);
-
-	const isComplete = (step: StepListing) =>
-		step.schema ? step.schema.safeParse(formData).success : true;
 
 	return (
 		<Stepper

--- a/apps/newsletters-ui/src/app/components/StepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StepNav.tsx
@@ -82,7 +82,8 @@ export const StepNav = ({
 	const isCurrent = (step: StepListing) =>
 		step.id === currentStep?.id || step.id === currentStep?.parentStepId;
 
-	const isComplete = (step: StepListing) => completionRecord[step.id];
+	const isComplete = (step: StepListing) =>
+		stepperConfig.indicateStepsComplete && completionRecord[step.id];
 
 	const shouldRenderAsButton = (step: StepListing) =>
 		currentStep?.canSkipFrom &&
@@ -102,7 +103,7 @@ export const StepNav = ({
 					css={css`
 						padding-bottom: 0.75rem;
 						padding-top: 0.75rem;
-						background-color: ${isComplete(step) ? 'green' : 'red'};
+						background-color: ${isComplete(step) ? 'green' : undefined};
 					`}
 					key={step.id}
 					active={isCurrent(step)}

--- a/apps/newsletters-ui/src/app/components/StepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StepNav.tsx
@@ -1,11 +1,16 @@
 import { css, Step, StepButton, StepLabel, Stepper } from '@mui/material';
-import type { StepListing, StepperConfig } from '@newsletters-nx/state-machine';
+import type {
+	StepListing,
+	StepperConfig,
+	WizardFormData,
+} from '@newsletters-nx/state-machine';
 
 interface Props {
 	currentStepId?: string;
 	stepperConfig: StepperConfig;
 	onEditTrack: boolean;
 	handleStepClick: { (stepId: string): void };
+	formData?: WizardFormData;
 }
 
 export const StepNav = ({
@@ -13,6 +18,7 @@ export const StepNav = ({
 	stepperConfig,
 	onEditTrack,
 	handleStepClick,
+	formData,
 }: Props) => {
 	const filteredStepList = stepperConfig.steps.filter((step) => {
 		if (step.parentStepId) {
@@ -44,6 +50,9 @@ export const StepNav = ({
 		step.canSkipTo &&
 		!isCurrent(step);
 
+	const isComplete = (step: StepListing) =>
+		step.schema ? step.schema.safeParse(formData).success : true;
+
 	return (
 		<Stepper
 			nonLinear={stepperConfig.isNonLinear}
@@ -56,6 +65,7 @@ export const StepNav = ({
 					css={css`
 						padding-bottom: 0.75rem;
 						padding-top: 0.75rem;
+						background-color: ${isComplete(step) ? 'green' : 'red'};
 					`}
 					key={step.id}
 					active={isCurrent(step)}

--- a/apps/newsletters-ui/src/app/components/Wizard.tsx
+++ b/apps/newsletters-ui/src/app/components/Wizard.tsx
@@ -182,6 +182,7 @@ export const Wizard: React.FC<WizardProps> = ({
 				stepperConfig={getStepperConfig(wizardId)}
 				onEditTrack={typeof id !== 'undefined'}
 				handleStepClick={handleStepClick}
+				formData={formData}
 			/>
 			<MarkdownView markdown={serverData.markdownToDisplay ?? ''} />
 

--- a/libs/newsletter-workflow/src/lib/newsletter-workflow.ts
+++ b/libs/newsletter-workflow/src/lib/newsletter-workflow.ts
@@ -35,7 +35,7 @@ export const getStepperConfig = (
 ): StepperConfig => {
 	const wizard = newslettersWorkflowStepLayout[wizardId];
 	if (!wizard) {
-		return { steps: [], isNonLinear: false };
+		return { steps: [], isNonLinear: false, indicateStepsComplete: false };
 	}
 
 	return makeStepperConfig(wizard);

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/finishLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/finishLayout.ts
@@ -17,6 +17,7 @@ const staticMarkdown = markdownTemplate.replace(regExPatterns.name, '');
 
 const finishLayout: WizardStepLayout<DraftStorage> = {
 	staticMarkdown: staticMarkdown,
+	indicateStepsCompleteOnThisWizard: true,
 	label: 'Finish',
 	buttons: {},
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/finishLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/finishLayout.ts
@@ -18,6 +18,7 @@ You can see the full details of **{{name}}** on the [details page](drafts/{{list
 const staticMarkdown = markdownTemplate.replace(regExPatterns.name, '');
 
 const finishLayout: WizardStepLayout<DraftStorage> = {
+	indicateStepsCompleteOnThisWizard: true,
 	staticMarkdown: staticMarkdown,
 	label: 'Finish',
 	buttons: {

--- a/libs/newsletters-data-client/src/fixtures/newsletter-fixtures.ts
+++ b/libs/newsletters-data-client/src/fixtures/newsletter-fixtures.ts
@@ -17,7 +17,7 @@ export const TECHSCAPE_IN_NEW_FORMAT: NewsletterData = {
 		"Alex Hern's weekly dive in to how technology is shaping our lives",
 	signUpEmbedDescription:
 		"Alex Hern's weekly dive in to how technology is shaping our lives",
-	regionFocus: '',
+	regionFocus: undefined,
 	frequency: 'Weekly',
 	listIdV1: -1,
 	listId: 6013,
@@ -63,7 +63,7 @@ export const VALID_TECHSCAPE: LegacyNewsletter = {
 	group: 'News in depth',
 	description:
 		"Alex Hern's weekly dive in to how technology is shaping our lives",
-	regionFocus: '',
+	regionFocus: undefined,
 	frequency: 'Weekly',
 	listIdV1: -1,
 	listId: 6013,

--- a/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
@@ -16,7 +16,9 @@ export const themeEnumSchema = z.enum([
 ]);
 export type Theme = z.infer<typeof themeEnumSchema>;
 
-export const regionFocusEnumSchema = z.enum(['UK', 'AU', 'US', 'INTL']);
+export const regionFocusEnumSchema = z
+	.enum(['UK', 'AU', 'US', 'INTL'])
+	.optional();
 export type RegionFocus = z.infer<typeof regionFocusEnumSchema>;
 
 export const onlineArticleSchema = z

--- a/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
@@ -7,7 +7,6 @@ import {
 } from './zod-helpers/schema-helpers';
 
 export const themeEnumSchema = z.enum([
-	'',
 	'news',
 	'opinion',
 	'culture',
@@ -17,16 +16,15 @@ export const themeEnumSchema = z.enum([
 ]);
 export type Theme = z.infer<typeof themeEnumSchema>;
 
-export const regionFocusEnumSchema = z.enum(['', 'UK', 'AU', 'US', 'INTL']);
+export const regionFocusEnumSchema = z.enum(['UK', 'AU', 'US', 'INTL']);
 export type RegionFocus = z.infer<typeof regionFocusEnumSchema>;
 
 export const onlineArticleSchema = z
-	.enum(['', 'Email only', 'Web for first send only', 'Web for all sends'])
+	.enum(['Email only', 'Web for first send only', 'Web for all sends'])
 	.describe('location of article');
 export type OnlineArticle = z.infer<typeof onlineArticleSchema>;
 
 export const singleThrasherLocation = z.enum([
-	'',
 	'Web only',
 	'App only',
 	'Web and App',
@@ -72,7 +70,7 @@ export const thrasherOptionsSchema = z.object({
 export type ThrasherOptions = z.infer<typeof thrasherOptionsSchema>;
 
 export const newsletterCategoriesSchema = z
-	.enum(['', 'article-based', 'fronts-based', 'manual-send', 'other'])
+	.enum(['article-based', 'fronts-based', 'manual-send', 'other'])
 	.describe('production category');
 export type NewsletterCategory = z.infer<typeof newsletterCategoriesSchema>;
 

--- a/libs/newsletters-data-client/src/lib/testQuestionaireSchema.ts
+++ b/libs/newsletters-data-client/src/lib/testQuestionaireSchema.ts
@@ -11,7 +11,7 @@ export type Person = z.infer<typeof personSchema>;
 export const biscuitSchema = z.object({
 	name: z.string(),
 	shape: z.enum(['round', 'finger', 'star', 'rectangle']),
-	filling: z.enum(['none', 'jam', 'chocolate']),
+	filling: z.enum(['jam', 'chocolate', 'cream']).optional(),
 	sugarOnTop: z.boolean(),
 	calories: z.number().optional(),
 });

--- a/libs/newsletters-data-client/src/lib/zod-helpers/getEmptySchemaData.ts
+++ b/libs/newsletters-data-client/src/lib/zod-helpers/getEmptySchemaData.ts
@@ -7,6 +7,10 @@ import { recursiveUnwrap } from './recursiveUnwrap';
  * NOTE - ZodDates are defaulted to 'undefined'
  * not a problem for the current usage of this function
  * but may need to be revised.
+ *
+ * Enums start undefined so the user is forced to choose a value
+ * rather than having the first item pre-selected. Could add and
+ * extra argument to default enum to the first item when required.
  */
 export const getEmptySchemaData = (
 	schema: z.ZodObject<z.ZodRawShape>,
@@ -26,8 +30,7 @@ export const getEmptySchemaData = (
 		if (zod instanceof ZodString) {
 			mod[key] = '';
 		} else if (zod instanceof ZodEnum) {
-			const [firstOption] = zod.options as string[];
-			mod[key] = firstOption;
+			mod[key] = undefined;
 		} else if (zod instanceof ZodNumber) {
 			mod[key] = 0;
 		} else if (zod instanceof ZodBoolean) {

--- a/libs/state-machine/src/lib/getStepList.ts
+++ b/libs/state-machine/src/lib/getStepList.ts
@@ -1,3 +1,4 @@
+import type { ZodObject, ZodRawShape } from 'zod';
 import type { WizardLayout, WizardStepLayout } from './types';
 
 export type StepListing = {
@@ -7,6 +8,7 @@ export type StepListing = {
 	parentStepId?: WizardStepLayout['parentStepId'];
 	canSkipTo?: boolean;
 	canSkipFrom?: boolean;
+	schema?: ZodObject<ZodRawShape>;
 };
 
 export type StepperConfig = {
@@ -26,6 +28,7 @@ export const getStepperConfig = (wizard: WizardLayout): StepperConfig => {
 					parentStepId: step.parentStepId,
 					canSkipTo: step.canSkipTo,
 					canSkipFrom: !!step.executeSkip,
+					schema: step.schema,
 				},
 			];
 		},

--- a/libs/state-machine/src/lib/getStepList.ts
+++ b/libs/state-machine/src/lib/getStepList.ts
@@ -14,6 +14,7 @@ export type StepListing = {
 export type StepperConfig = {
 	steps: StepListing[];
 	isNonLinear: boolean;
+	indicateStepsComplete: boolean;
 };
 
 export const getStepperConfig = (wizard: WizardLayout): StepperConfig => {
@@ -35,10 +36,18 @@ export const getStepperConfig = (wizard: WizardLayout): StepperConfig => {
 		[],
 	);
 
+	// TO DO - these should really be properties of the WizardLayout, rather than
+	// a WizardStepLayout in the WizardLayout.
+	// Since WizardLayout is defined as a record of WizardLayouts, we can't add
+	// any additional "meta" properties to it, without changing that definition.
 	const isNonLinear = Object.values(wizard).some((step) => step.canSkipTo);
+	const indicateStepsComplete = Object.values(wizard).some(
+		(step) => step.indicateStepsCompleteOnThisWizard,
+	);
 
 	return {
 		steps,
 		isNonLinear,
+		indicateStepsComplete,
 	};
 };

--- a/libs/state-machine/src/lib/types.ts
+++ b/libs/state-machine/src/lib/types.ts
@@ -75,6 +75,7 @@ export type WizardStepLayoutButton<
 };
 
 export interface WizardStepLayout<T extends GenericStorageInterface = unknown> {
+	indicateStepsCompleteOnThisWizard?: boolean;
 	label?: string;
 	role?: 'EDIT_START' | 'CREATE_START' | 'EARLY_EXIT';
 	parentStepId?: string;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Removes the empty strings in the enum fields of the `newsletterDataSchema` - these were used so the user was not presented with the first item on the enum "pre-filled". Instead, changed the `SelectInput` components within `SchemaForm` to default the value to `undefined` when rendering a form element for an enum field.

The `StepNav` component now checks if each step is 'complete' based on the `formData` prop and, if the `WizardLayout` is configured to render the indicator, adds captions to the `Step` representing the `WizardStepLayout` to  tell the user if they are complete.

https://trello.com/c/KnjAJC3q/398-change-step-nav-to-give-visual-indication-of-whether-a-step-has-been-completed
https://trello.com/c/knzi0QIW/427-find-a-better-way-to-have-enum-dropdown-start-blank-rather-than-defaulting-to-the-first-item


## How to test

Go through the newsletterData and renderOptions wizards - the step labels will show if the steps are completed or not. The indicators will update as you change steps. Steps without a form (eg 'finish') will not have a caption.

Note that the Launch wizard is configured to have `indicateStepsComplete` false so will look the same.

## How can we measure success?

Easier for users to see which steps need attention.
Schema no longer allows empty strings in the enum fields.

## Images

<img width="1016" alt="Screenshot 2023-05-05 at 15 06 42" src="https://user-images.githubusercontent.com/30567854/236480646-baa097f5-984e-4e59-b40f-0035960066d4.png">


