### PR TITLE
Added newsletters API build and deploy to riffraff config and add stacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           npm run bundle:ui
           npm run bundle:api
           zip -r dist/newsletters-tool.zip dist
-          zip -r dist/newsletters-api.zip dist
+          cp dist/newsletters-tool.zip dist/newsletters-api.zip
 
         # Build Cloudformation definition from CDK
       - name: Build and synth CDK
@@ -70,11 +70,10 @@ jobs:
           npm run test
           npm run synth
 
-        # Upload artifacts for newsletters internal tool
+        # Upload artifacts for newsletters tool and api
       - name: Upload riff-raff artifacts - newsletters-tool
         uses: guardian/actions-riff-raff@v2
         with:
-          app: newsletters-tool
           configPath: riff-raff.yaml
           contentDirectories: |
             newsletters-tool-cfn:
@@ -82,16 +81,10 @@ jobs:
               - cdk/cdk.out/NewslettersTool-PROD.template.json
             newsletters-tool:
               - dist/newsletters-tool.zip
-
-        # Upload artifacts for newsletters read only API
-      - name: Upload riff-raff artifacts - newsletters-api
-        uses: guardian/actions-riff-raff@v2
-        with:
-          app: newsletters-api
-          configPath: riff-raff.yaml
-          contentDirectories: |
             newsletters-api-cfn:
               - cdk/cdk.out/NewslettersApi-CODE.template.json
               - cdk/cdk.out/NewslettersApi-PROD.template.json
             newsletters-api:
               - dist/newsletters-api.zip
+
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
           npm run bundle:ui
           npm run bundle:api
           zip -r dist/newsletters-tool.zip dist
+          zip -r dist/newsletters-api.zip dist
 
         # Build Cloudformation definition from CDK
       - name: Build and synth CDK
@@ -81,3 +82,16 @@ jobs:
               - cdk/cdk.out/NewslettersTool-PROD.template.json
             newsletters-tool:
               - dist/newsletters-tool.zip
+
+        # Upload artifacts for newsletters read only API
+      - name: Upload riff-raff artifacts - newsletters-api
+        uses: guardian/actions-riff-raff@v2
+        with:
+          app: newsletters-api
+          configPath: riff-raff.yaml
+          contentDirectories: |
+            newsletters-api-cfn:
+              - cdk/cdk.out/NewslettersApi-CODE.template.json
+              - cdk/cdk.out/NewslettersApi-PROD.template.json
+            newsletters-api:
+              - dist/newsletters-api.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,11 @@ jobs:
           npm run test
           npm run synth
 
-        # Upload artifacts for newsletters tool and api
+        # Upload artifacts for newsletters internal tool
       - name: Upload riff-raff artifacts - newsletters-tool
         uses: guardian/actions-riff-raff@v2
         with:
+          app: newsletters-tool
           configPath: riff-raff.yaml
           contentDirectories: |
             newsletters-tool-cfn:
@@ -81,10 +82,16 @@ jobs:
               - cdk/cdk.out/NewslettersTool-PROD.template.json
             newsletters-tool:
               - dist/newsletters-tool.zip
+
+        # Upload artifacts for newsletters read only API
+      - name: Upload riff-raff artifacts - newsletters-api
+        uses: guardian/actions-riff-raff@v2
+        with:
+          app: newsletters-api
+          configPath: riff-raff.yaml
+          contentDirectories: |
             newsletters-api-cfn:
               - cdk/cdk.out/NewslettersApi-CODE.template.json
               - cdk/cdk.out/NewslettersApi-PROD.template.json
             newsletters-api:
               - dist/newsletters-api.zip
-
-

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,6 +1,7 @@
 import 'source-map-support/register';
 import { App } from 'aws-cdk-lib';
 import { NewslettersTool } from '../lib/newsletters-tool';
+import { NewslettersApi } from '../lib/newsletters-api';
 
 const app = new App();
 
@@ -12,6 +13,7 @@ export const sharedProps = {
 
 /** The internal tool for newsletter management */
 const newslettersToolAppName = 'newsletters-tool';
+const readOnlyNewslettersApiName = 'read-only-newsletters';
 
 new NewslettersTool(app, 'NewslettersTool-CODE', {
 	...sharedProps,
@@ -24,4 +26,11 @@ new NewslettersTool(app, 'NewslettersTool-PROD', {
 	stage: 'PROD',
 	app: newslettersToolAppName,
 	domainName: `${newslettersToolAppName}.gutools.co.uk`,
+});
+
+new NewslettersApi(app, 'NewslettersApi-CODE', {
+	...sharedProps,
+	stage: 'CODE',
+	app: readOnlyNewslettersApiName,
+	domainName: `${readOnlyNewslettersApiName}.code.dev-gutools.co.uk`,
 });

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -34,3 +34,10 @@ new NewslettersApi(app, 'NewslettersApi-CODE', {
 	app: readOnlyNewslettersApiName,
 	domainName: `${readOnlyNewslettersApiName}.code.dev-gutools.co.uk`,
 });
+
+new NewslettersApi(app, 'NewslettersApi-PROD', {
+	...sharedProps,
+	stage: 'PROD',
+	app: readOnlyNewslettersApiName,
+	domainName: `${readOnlyNewslettersApiName}.gutools.co.uk`,
+});

--- a/cdk/lib/__snapshots__/newsletters-api.test.ts.snap
+++ b/cdk/lib/__snapshots__/newsletters-api.test.ts.snap
@@ -4,7 +4,7 @@ exports[`The NewslettersApi stack matches the snapshot 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [
-      "GuS3Bucket",
+      "GuPolicy",
       "GuDistributionBucketParameter",
       "GuVpcParameter",
       "GuSubnetListParameter",
@@ -187,6 +187,16 @@ aws s3 cp s3://",
                 },
                 "/newsletters/TEST/newsletters-api /tmp --recursive
 chown -R ubuntu /tmp
+export NEWSLETTERS_API_READ=true
+export NEWSLETTERS_API_READ_WRITE=false
+export NEWSLETTERS_UI_SERVE=false
+export STAGE=TEST
+export NEWSLETTER_BUCKET_NAME=",
+                {
+                  "Ref": "SsmParameterValueTESTnewslettersnewslettersapis3BucketNameC96584B6F00A464EAD1953AFF4B05118Parameter",
+                },
+                "
+export USE_IN_MEMORY_STORAGE=false
 su ubuntu -c '/usr/local/node/pm2 start --name newsletters-api /tmp/apps/newsletters-api/main.cjs'",
               ],
             ],
@@ -228,47 +238,6 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-api /tmp/apps/newslet
         "ValidationMethod": "DNS",
       },
       "Type": "AWS::CertificateManager::Certificate",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "DataBucketNewslettersapi96EED09B": {
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "BucketName": {
-          "Ref": "SsmParameterValueTESTnewslettersnewslettersapis3BucketNameC96584B6F00A464EAD1953AFF4B05118Parameter",
-        },
-        "PublicAccessBlockConfiguration": {
-          "BlockPublicAcls": true,
-          "BlockPublicPolicy": true,
-          "IgnorePublicAcls": true,
-          "RestrictPublicBuckets": true,
-        },
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "newsletters-api",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/newsletters-nx",
-          },
-          {
-            "Key": "Stack",
-            "Value": "newsletters",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "VersioningConfiguration": {
-          "Status": "Enabled",
-        },
-      },
-      "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
     },
     "DescribeEC2PolicyFF5F9295": {
@@ -773,6 +742,67 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-api /tmp/apps/newslet
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
+    },
+    "newslettersapiInstancePolicy45E0A5E0": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:PutObject",
+                "s3:GetObject",
+                "s3:GetObjectVersion",
+                "s3:DeleteObject",
+                "s3:ListBucket",
+                "s3:DeleteObjectVersion",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "SsmParameterValueTESTnewslettersnewslettersapis3BucketNameC96584B6F00A464EAD1953AFF4B05118Parameter",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "SsmParameterValueTESTnewslettersnewslettersapis3BucketNameC96584B6F00A464EAD1953AFF4B05118Parameter",
+                      },
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "writeToDataStorageBucketPolicy",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "readWriteAccessToDataBucket",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleNewslettersapi01755604",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
   },
 }

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -27,7 +27,23 @@ deployments:
         CODE: NewslettersTool-CODE.template.json
         PROD: NewslettersTool-PROD.template.json
 
+        # Newsletters internal tool cloudformation deployment
+  newsletters-api-cfn:
+    template: cloudformation-template
+    app: newsletters-api
+    parameters:
+      cloudFormationStackName: newsletters-api
+      amiParameter: AMINewsletterstool # please don't change this unless you know what you're doing
+      templateStagePaths:
+        CODE: NewslettersApi-CODE.template.json
+        PROD: NewslettersApi-PROD.template.json
+
   # Newsletters internal tool autoscaling deployment
   newsletters-tool:
     template: autoscaling-template
     dependencies: [newsletters-tool-cfn]
+
+  # Newsletters external API autoscaling deployment
+  newsletters-api:
+    template: autoscaling-template
+    dependencies: [newsletters-api-cfn]

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -3,8 +3,19 @@ stacks: [newsletters]
 regions: [eu-west-1]
 allowedStages: [CODE, PROD]
 templates:
-  cloudformation-template:
+  cloudformation-template-tool:
     type: cloud-formation
+    app: newsletters-tool
+    parameters:
+      cloudFormationStackByTags: false
+      prependStackToCloudFormationStackName: false
+      amiTags:
+        Recipe: newsletters-node
+        AmigoStage: PROD
+
+  cloudformation-template-api:
+    type: cloud-formation
+    app: newsletters-api
     parameters:
       cloudFormationStackByTags: false
       prependStackToCloudFormationStackName: false
@@ -18,7 +29,7 @@ templates:
 deployments:
   # Newsletters internal tool cloudformation deployment
   newsletters-tool-cfn:
-    template: cloudformation-template
+    template: cloudformation-template-tool
     app: newsletters-tool
     parameters:
       cloudFormationStackName: newsletters-tool
@@ -29,7 +40,7 @@ deployments:
 
         # Newsletters internal tool cloudformation deployment
   newsletters-api-cfn:
-    template: cloudformation-template
+    template: cloudformation-template-api
     app: newsletters-api
     parameters:
       cloudFormationStackName: newsletters-api


### PR DESCRIPTION

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds Newsletters API as a  separate stack in readonly mode without UI. This instance will server external requests and can scale for that use case. We are also able to heavily cache external requests which permists running on modest hardware

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
