### PR TITLE
Added new instance running the read only api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
           npm run bundle:ui
           npm run bundle:api
           zip -r dist/newsletters-tool.zip dist
+          cp dist/newsletters-tool.zip dist/newsletters-api.zip
 
         # Build Cloudformation definition from CDK
       - name: Build and synth CDK
@@ -81,3 +82,5 @@ jobs:
               - cdk/cdk.out/NewslettersTool-PROD.template.json
             newsletters-tool:
               - dist/newsletters-tool.zip
+            newsletters-api:
+              - dist/newsletters-api.zip

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -12,16 +12,20 @@ export const sharedProps = {
 
 /** The internal tool for newsletter management */
 const newslettersToolAppName = 'newsletters-tool';
+const newslettersApiName = 'readonly-newsletters';
 
 new NewslettersTool(app, 'NewslettersTool-CODE', {
 	...sharedProps,
 	stage: 'CODE',
 	app: newslettersToolAppName,
-	domainName: `${newslettersToolAppName}.code.dev-gutools.co.uk`,
+	domainNameTool: `${newslettersToolAppName}.code.dev-gutools.co.uk`,
+	domainNameApi: `${newslettersApiName}.code.dev-gutools.co.uk`,
 });
+
 new NewslettersTool(app, 'NewslettersTool-PROD', {
 	...sharedProps,
 	stage: 'PROD',
 	app: newslettersToolAppName,
-	domainName: `${newslettersToolAppName}.gutools.co.uk`,
+	domainNameTool: `${newslettersToolAppName}.gutools.co.uk`,
+	domainNameApi: `${newslettersApiName}.gutools.co.uk`,
 });

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -17,7 +17,6 @@ const newslettersApiName = 'readonly-newsletters';
 new NewslettersTool(app, 'NewslettersTool-CODE', {
 	...sharedProps,
 	stage: 'CODE',
-	app: newslettersToolAppName,
 	domainNameTool: `${newslettersToolAppName}.code.dev-gutools.co.uk`,
 	domainNameApi: `${newslettersApiName}.code.dev-gutools.co.uk`,
 });
@@ -25,7 +24,6 @@ new NewslettersTool(app, 'NewslettersTool-CODE', {
 new NewslettersTool(app, 'NewslettersTool-PROD', {
 	...sharedProps,
 	stage: 'PROD',
-	app: newslettersToolAppName,
 	domainNameTool: `${newslettersToolAppName}.gutools.co.uk`,
 	domainNameApi: `${newslettersApiName}.gutools.co.uk`,
 });

--- a/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
+++ b/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
@@ -47,6 +47,15 @@ exports[`The Newsletters stack matches the snapshot 1`] = `
     "gu:cdk:version": "TEST",
   },
   "Outputs": {
+    "LoadBalancerNewslettersapiDnsName": {
+      "Description": "DNS entry for LoadBalancerNewslettersapi",
+      "Value": {
+        "Fn::GetAtt": [
+          "LoadBalancerNewslettersapi605B1E8A",
+          "DNSName",
+        ],
+      },
+    },
     "LoadBalancerNewsletterstoolDnsName": {
       "Description": "DNS entry for LoadBalancerNewsletterstool",
       "Value": {
@@ -56,23 +65,14 @@ exports[`The Newsletters stack matches the snapshot 1`] = `
         ],
       },
     },
-    "LoadBalancerNewsletterstoolapiDnsName": {
-      "Description": "DNS entry for LoadBalancerNewsletterstoolapi",
-      "Value": {
-        "Fn::GetAtt": [
-          "LoadBalancerNewsletterstoolapi72A19492",
-          "DNSName",
-        ],
-      },
-    },
   },
   "Parameters": {
-    "AMINewsletterstool": {
-      "Description": "Amazon Machine Image ID for the app newsletters-tool. Use this in conjunction with AMIgo to keep AMIs up to date.",
+    "AMINewslettersapi": {
+      "Description": "Amazon Machine Image ID for the app newsletters-api. Use this in conjunction with AMIgo to keep AMIs up to date.",
       "Type": "AWS::EC2::Image::Id",
     },
-    "AMINewsletterstoolapi": {
-      "Description": "Amazon Machine Image ID for the app newsletters-tool-api. Use this in conjunction with AMIgo to keep AMIs up to date.",
+    "AMINewsletterstool": {
+      "Description": "Amazon Machine Image ID for the app newsletters-tool. Use this in conjunction with AMIgo to keep AMIs up to date.",
       "Type": "AWS::EC2::Image::Id",
     },
     "AccessLoggingBucket": {
@@ -104,6 +104,16 @@ exports[`The Newsletters stack matches the snapshot 1`] = `
       "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
     },
+    "newslettersapiPrivateSubnets": {
+      "Default": "/account/vpc/primary/subnets/private",
+      "Description": "A list of private subnets",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+    },
+    "newslettersapiPublicSubnets": {
+      "Default": "/account/vpc/primary/subnets/public",
+      "Description": "A list of public subnets",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+    },
     "newsletterstoolPrivateSubnets": {
       "Default": "/account/vpc/primary/subnets/private",
       "Description": "A list of private subnets",
@@ -114,18 +124,141 @@ exports[`The Newsletters stack matches the snapshot 1`] = `
       "Description": "A list of public subnets",
       "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
     },
-    "newsletterstoolapiPrivateSubnets": {
-      "Default": "/account/vpc/primary/subnets/private",
-      "Description": "A list of private subnets",
-      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
-    },
-    "newsletterstoolapiPublicSubnets": {
-      "Default": "/account/vpc/primary/subnets/public",
-      "Description": "A list of public subnets",
-      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
-    },
   },
   "Resources": {
+    "AutoScalingGroupNewslettersapiASG06292ACA": {
+      "Properties": {
+        "HealthCheckGracePeriod": 120,
+        "HealthCheckType": "ELB",
+        "LaunchConfigurationName": {
+          "Ref": "AutoScalingGroupNewslettersapiLaunchConfig6EF45E9F",
+        },
+        "MaxSize": "2",
+        "MinSize": "1",
+        "Tags": [
+          {
+            "Key": "App",
+            "PropagateAtLaunch": true,
+            "Value": "newsletters-api",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "PropagateAtLaunch": true,
+            "Value": "guardian/newsletters-nx",
+          },
+          {
+            "Key": "LogKinesisStreamName",
+            "PropagateAtLaunch": true,
+            "Value": {
+              "Ref": "LoggingStreamName",
+            },
+          },
+          {
+            "Key": "Name",
+            "PropagateAtLaunch": true,
+            "Value": "NewslettersTool-TEST/AutoScalingGroupNewslettersapi",
+          },
+          {
+            "Key": "Stack",
+            "PropagateAtLaunch": true,
+            "Value": "newsletters",
+          },
+          {
+            "Key": "Stage",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
+          },
+        ],
+        "TargetGroupARNs": [
+          {
+            "Ref": "TargetGroupNewslettersapiDF74F995",
+          },
+        ],
+        "VPCZoneIdentifier": {
+          "Ref": "newslettersapiPrivateSubnets",
+        },
+      },
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+    },
+    "AutoScalingGroupNewslettersapiInstanceProfile6DBAC8ED": {
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "InstanceRoleNewslettersapi01755604",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
+    "AutoScalingGroupNewslettersapiLaunchConfig6EF45E9F": {
+      "DependsOn": [
+        "InstanceRoleNewslettersapi01755604",
+      ],
+      "Properties": {
+        "IamInstanceProfile": {
+          "Ref": "AutoScalingGroupNewslettersapiInstanceProfile6DBAC8ED",
+        },
+        "ImageId": {
+          "Ref": "AMINewslettersapi",
+        },
+        "InstanceType": "t4g.small",
+        "MetadataOptions": {
+          "HttpTokens": "required",
+        },
+        "SecurityGroups": [
+          {
+            "Fn::GetAtt": [
+              "GuHttpsEgressSecurityGroupNewslettersapiE3C8E8F2",
+              "GroupId",
+            ],
+          },
+          {
+            "Fn::GetAtt": [
+              "WazuhSecurityGroup",
+              "GroupId",
+            ],
+          },
+        ],
+        "UserData": {
+          "Fn::Base64": {
+            "Fn::Join": [
+              "",
+              [
+                "#!/bin/bash
+set -e
+set +x
+aws s3 cp s3://",
+                {
+                  "Ref": "DistributionBucketName",
+                },
+                "/newsletters/TEST/newsletters-tool/newsletters-tool.zip /tmp
+mkdir -p /opt/newsletters-tool
+unzip /tmp/newsletters-tool.zip -d /opt/newsletters-tool
+chown -R ubuntu /opt/newsletters-tool
+export NEWSLETTERS_API_READ=true
+export NEWSLETTERS_API_READ_WRITE=false
+export NEWSLETTERS_UI_SERVE=false}
+export STAGE=TEST
+export NEWSLETTER_BUCKET_NAME=",
+                {
+                  "Ref": "SsmParameterValueTESTnewslettersnewslettersapis3BucketNameC96584B6F00A464EAD1953AFF4B05118Parameter",
+                },
+                "
+export USE_IN_MEMORY_STORAGE=false
+cd /opt/newsletters-tool
+su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsletters-api/index.cjs'",
+              ],
+            ],
+          },
+        },
+      },
+      "Type": "AWS::AutoScaling::LaunchConfiguration",
+    },
     "AutoScalingGroupNewsletterstoolASGDA0D2177": {
       "Properties": {
         "HealthCheckGracePeriod": 120,
@@ -259,138 +392,40 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
       },
       "Type": "AWS::AutoScaling::LaunchConfiguration",
     },
-    "AutoScalingGroupNewsletterstoolapiASGDC4C7120": {
+    "CertificateNewslettersapi7A81CAC3": {
+      "DeletionPolicy": "Retain",
       "Properties": {
-        "HealthCheckGracePeriod": 120,
-        "HealthCheckType": "ELB",
-        "LaunchConfigurationName": {
-          "Ref": "AutoScalingGroupNewsletterstoolapiLaunchConfig4B05787F",
-        },
-        "MaxSize": "2",
-        "MinSize": "1",
+        "DomainName": "readonly-newsletters.test.dev-gutools.co.uk",
         "Tags": [
           {
             "Key": "App",
-            "PropagateAtLaunch": true,
-            "Value": "newsletters-tool-api",
+            "Value": "newsletters-api",
           },
           {
             "Key": "gu:cdk:version",
-            "PropagateAtLaunch": true,
             "Value": "TEST",
           },
           {
             "Key": "gu:repo",
-            "PropagateAtLaunch": true,
             "Value": "guardian/newsletters-nx",
           },
           {
-            "Key": "LogKinesisStreamName",
-            "PropagateAtLaunch": true,
-            "Value": {
-              "Ref": "LoggingStreamName",
-            },
-          },
-          {
             "Key": "Name",
-            "PropagateAtLaunch": true,
-            "Value": "NewslettersTool-TEST/AutoScalingGroupNewsletterstoolapi",
+            "Value": "NewslettersTool-TEST/CertificateNewslettersapi",
           },
           {
             "Key": "Stack",
-            "PropagateAtLaunch": true,
             "Value": "newsletters",
           },
           {
             "Key": "Stage",
-            "PropagateAtLaunch": true,
             "Value": "TEST",
           },
         ],
-        "TargetGroupARNs": [
-          {
-            "Ref": "TargetGroupNewsletterstoolapi583BDEB1",
-          },
-        ],
-        "VPCZoneIdentifier": {
-          "Ref": "newsletterstoolapiPrivateSubnets",
-        },
+        "ValidationMethod": "DNS",
       },
-      "Type": "AWS::AutoScaling::AutoScalingGroup",
-    },
-    "AutoScalingGroupNewsletterstoolapiInstanceProfile11217FD0": {
-      "Properties": {
-        "Roles": [
-          {
-            "Ref": "InstanceRoleNewsletterstoolapi0896FE93",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::InstanceProfile",
-    },
-    "AutoScalingGroupNewsletterstoolapiLaunchConfig4B05787F": {
-      "DependsOn": [
-        "InstanceRoleNewsletterstoolapi0896FE93",
-      ],
-      "Properties": {
-        "IamInstanceProfile": {
-          "Ref": "AutoScalingGroupNewsletterstoolapiInstanceProfile11217FD0",
-        },
-        "ImageId": {
-          "Ref": "AMINewsletterstoolapi",
-        },
-        "InstanceType": "t4g.small",
-        "MetadataOptions": {
-          "HttpTokens": "required",
-        },
-        "SecurityGroups": [
-          {
-            "Fn::GetAtt": [
-              "GuHttpsEgressSecurityGroupNewsletterstoolapiCF800E6A",
-              "GroupId",
-            ],
-          },
-          {
-            "Fn::GetAtt": [
-              "WazuhSecurityGroup",
-              "GroupId",
-            ],
-          },
-        ],
-        "UserData": {
-          "Fn::Base64": {
-            "Fn::Join": [
-              "",
-              [
-                "#!/bin/bash
-set -e
-set +x
-aws s3 cp s3://",
-                {
-                  "Ref": "DistributionBucketName",
-                },
-                "/newsletters/TEST/newsletters-tool/newsletters-tool.zip /tmp
-mkdir -p /opt/newsletters-tool
-unzip /tmp/newsletters-tool.zip -d /opt/newsletters-tool
-chown -R ubuntu /opt/newsletters-tool
-export NEWSLETTERS_API_READ=true
-export NEWSLETTERS_API_READ_WRITE=false
-export NEWSLETTERS_UI_SERVE=false}
-export STAGE=TEST
-export NEWSLETTER_BUCKET_NAME=",
-                {
-                  "Ref": "SsmParameterValueTESTnewslettersnewslettersapis3BucketNameC96584B6F00A464EAD1953AFF4B05118Parameter",
-                },
-                "
-export USE_IN_MEMORY_STORAGE=false
-cd /opt/newsletters-tool
-su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsletters-api/index.cjs'",
-              ],
-            ],
-          },
-        },
-      },
-      "Type": "AWS::AutoScaling::LaunchConfiguration",
+      "Type": "AWS::CertificateManager::Certificate",
+      "UpdateReplacePolicy": "Retain",
     },
     "CertificateNewsletterstoolAB12580B": {
       "DeletionPolicy": "Retain",
@@ -412,41 +447,6 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
           {
             "Key": "Name",
             "Value": "NewslettersTool-TEST/CertificateNewsletterstool",
-          },
-          {
-            "Key": "Stack",
-            "Value": "newsletters",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "ValidationMethod": "DNS",
-      },
-      "Type": "AWS::CertificateManager::Certificate",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "CertificateNewsletterstoolapi83F10CF4": {
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "DomainName": "readonly-newsletters.test.dev-gutools.co.uk",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "newsletters-tool-api",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/newsletters-nx",
-          },
-          {
-            "Key": "Name",
-            "Value": "NewslettersTool-TEST/CertificateNewsletterstoolapi",
           },
           {
             "Key": "Stack",
@@ -526,7 +526,39 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
             "Ref": "InstanceRoleNewsletterstoolDD0F3665",
           },
           {
-            "Ref": "InstanceRoleNewsletterstoolapi0896FE93",
+            "Ref": "InstanceRoleNewslettersapi01755604",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GetDistributablePolicyNewslettersapi1B9C4AAD": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    {
+                      "Ref": "DistributionBucketName",
+                    },
+                    "/newsletters/TEST/newsletters-api/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GetDistributablePolicyNewslettersapi1B9C4AAD",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleNewslettersapi01755604",
           },
         ],
       },
@@ -564,37 +596,66 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
       },
       "Type": "AWS::IAM::Policy",
     },
-    "GetDistributablePolicyNewsletterstoolapi000AF3BF": {
+    "GuHttpsEgressSecurityGroupNewslettersapiE3C8E8F2": {
       "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "s3:GetObject",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:s3:::",
-                    {
-                      "Ref": "DistributionBucketName",
-                    },
-                    "/newsletters/TEST/newsletters-tool-api/*",
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "GetDistributablePolicyNewsletterstoolapi000AF3BF",
-        "Roles": [
+        "GroupDescription": "Allow all outbound HTTPS traffic",
+        "SecurityGroupEgress": [
           {
-            "Ref": "InstanceRoleNewsletterstoolapi0896FE93",
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound HTTPS traffic",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
           },
         ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newsletters-api",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newsletters-nx",
+          },
+          {
+            "Key": "Stack",
+            "Value": "newsletters",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
       },
-      "Type": "AWS::IAM::Policy",
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "GuHttpsEgressSecurityGroupNewslettersapifromNewslettersToolTESTLoadBalancerNewslettersapiSecurityGroup64654FDD3000DFBFCE9F": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 3000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "GuHttpsEgressSecurityGroupNewslettersapiE3C8E8F2",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerNewslettersapiSecurityGroup874628D3",
+            "GroupId",
+          ],
+        },
+        "ToPort": 3000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
     },
     "GuHttpsEgressSecurityGroupNewsletterstoolA988BFEB": {
       "Properties": {
@@ -635,67 +696,6 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
-    },
-    "GuHttpsEgressSecurityGroupNewsletterstoolapiCF800E6A": {
-      "Properties": {
-        "GroupDescription": "Allow all outbound HTTPS traffic",
-        "SecurityGroupEgress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all outbound HTTPS traffic",
-            "FromPort": 443,
-            "IpProtocol": "tcp",
-            "ToPort": 443,
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "newsletters-tool-api",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/newsletters-nx",
-          },
-          {
-            "Key": "Stack",
-            "Value": "newsletters",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "VpcId": {
-          "Ref": "VpcId",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
-    "GuHttpsEgressSecurityGroupNewsletterstoolapifromNewslettersToolTESTLoadBalancerNewsletterstoolapiSecurityGroupC2034F8D3000733C4055": {
-      "Properties": {
-        "Description": "Load balancer to target",
-        "FromPort": 3000,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "GuHttpsEgressSecurityGroupNewsletterstoolapiCF800E6A",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "SourceSecurityGroupId": {
-          "Fn::GetAtt": [
-            "LoadBalancerNewsletterstoolapiSecurityGroup21F3B3E2",
-            "GroupId",
-          ],
-        },
-        "ToPort": 3000,
-      },
-      "Type": "AWS::EC2::SecurityGroupIngress",
     },
     "GuHttpsEgressSecurityGroupNewsletterstoolfromNewslettersToolTESTIdPAccessNewsletterstoolD34AC715300055F7D2AB": {
       "Properties": {
@@ -774,7 +774,7 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
             "Ref": "InstanceRoleNewsletterstoolDD0F3665",
           },
           {
-            "Ref": "InstanceRoleNewsletterstoolapi0896FE93",
+            "Ref": "InstanceRoleNewslettersapi01755604",
           },
         ],
       },
@@ -841,6 +841,60 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
+    "InstanceRoleNewslettersapi01755604": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ec2.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AmazonSSMManagedInstanceCore",
+              ],
+            ],
+          },
+        ],
+        "Path": "/",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newsletters-api",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newsletters-nx",
+          },
+          {
+            "Key": "Stack",
+            "Value": "newsletters",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
     "InstanceRoleNewsletterstoolDD0F3665": {
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -895,59 +949,30 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
       },
       "Type": "AWS::IAM::Role",
     },
-    "InstanceRoleNewsletterstoolapi0896FE93": {
+    "ListenerNewslettersapi696961C0": {
       "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "ec2.amazonaws.com",
-              },
+        "Certificates": [
+          {
+            "CertificateArn": {
+              "Ref": "CertificateNewslettersapi7A81CAC3",
             },
-          ],
-          "Version": "2012-10-17",
+          },
+        ],
+        "DefaultActions": [
+          {
+            "TargetGroupArn": {
+              "Ref": "TargetGroupNewslettersapiDF74F995",
+            },
+            "Type": "forward",
+          },
+        ],
+        "LoadBalancerArn": {
+          "Ref": "LoadBalancerNewslettersapi605B1E8A",
         },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/AmazonSSMManagedInstanceCore",
-              ],
-            ],
-          },
-        ],
-        "Path": "/",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "newsletters-tool-api",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/newsletters-nx",
-          },
-          {
-            "Key": "Stack",
-            "Value": "newsletters",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
+        "Port": 443,
+        "Protocol": "HTTPS",
       },
-      "Type": "AWS::IAM::Role",
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
     },
     "ListenerNewsletterstoolFF7146AA": {
       "Properties": {
@@ -994,30 +1019,112 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
       },
       "Type": "AWS::ElasticLoadBalancingV2::Listener",
     },
-    "ListenerNewsletterstoolapiAED5F562": {
+    "LoadBalancerNewslettersapi605B1E8A": {
       "Properties": {
-        "Certificates": [
+        "LoadBalancerAttributes": [
           {
-            "CertificateArn": {
-              "Ref": "CertificateNewsletterstoolapi83F10CF4",
-            },
+            "Key": "deletion_protection.enabled",
+            "Value": "true",
           },
         ],
-        "DefaultActions": [
+        "Scheme": "internet-facing",
+        "SecurityGroups": [
           {
-            "TargetGroupArn": {
-              "Ref": "TargetGroupNewsletterstoolapi583BDEB1",
-            },
-            "Type": "forward",
+            "Fn::GetAtt": [
+              "LoadBalancerNewslettersapiSecurityGroup874628D3",
+              "GroupId",
+            ],
           },
         ],
-        "LoadBalancerArn": {
-          "Ref": "LoadBalancerNewsletterstoolapi72A19492",
+        "Subnets": {
+          "Ref": "newslettersapiPublicSubnets",
         },
-        "Port": 443,
-        "Protocol": "HTTPS",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newsletters-api",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newsletters-nx",
+          },
+          {
+            "Key": "Stack",
+            "Value": "newsletters",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Type": "application",
       },
-      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    },
+    "LoadBalancerNewslettersapiSecurityGroup874628D3": {
+      "Properties": {
+        "GroupDescription": "Automatically created Security Group for ELB NewslettersToolTESTLoadBalancerNewslettersapiE2FEAA80",
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 443",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newsletters-api",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newsletters-nx",
+          },
+          {
+            "Key": "Stack",
+            "Value": "newsletters",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "LoadBalancerNewslettersapiSecurityGrouptoNewslettersToolTESTGuHttpsEgressSecurityGroupNewslettersapi4921DD22300030C48175": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "GuHttpsEgressSecurityGroupNewslettersapiE3C8E8F2",
+            "GroupId",
+          ],
+        },
+        "FromPort": 3000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerNewslettersapiSecurityGroup874628D3",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 3000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
     },
     "LoadBalancerNewsletterstoolE9AB350F": {
       "Properties": {
@@ -1146,113 +1253,6 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
-    "LoadBalancerNewsletterstoolapi72A19492": {
-      "Properties": {
-        "LoadBalancerAttributes": [
-          {
-            "Key": "deletion_protection.enabled",
-            "Value": "true",
-          },
-        ],
-        "Scheme": "internet-facing",
-        "SecurityGroups": [
-          {
-            "Fn::GetAtt": [
-              "LoadBalancerNewsletterstoolapiSecurityGroup21F3B3E2",
-              "GroupId",
-            ],
-          },
-        ],
-        "Subnets": {
-          "Ref": "newsletterstoolapiPublicSubnets",
-        },
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "newsletters-tool-api",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/newsletters-nx",
-          },
-          {
-            "Key": "Stack",
-            "Value": "newsletters",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "Type": "application",
-      },
-      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
-    },
-    "LoadBalancerNewsletterstoolapiSecurityGroup21F3B3E2": {
-      "Properties": {
-        "GroupDescription": "Automatically created Security Group for ELB NewslettersToolTESTLoadBalancerNewsletterstoolapi135BAFC5",
-        "SecurityGroupIngress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow from anyone on port 443",
-            "FromPort": 443,
-            "IpProtocol": "tcp",
-            "ToPort": 443,
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "newsletters-tool-api",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/newsletters-nx",
-          },
-          {
-            "Key": "Stack",
-            "Value": "newsletters",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "VpcId": {
-          "Ref": "VpcId",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
-    "LoadBalancerNewsletterstoolapiSecurityGrouptoNewslettersToolTESTGuHttpsEgressSecurityGroupNewsletterstoolapi167097B0300059D218F6": {
-      "Properties": {
-        "Description": "Load balancer to target",
-        "DestinationSecurityGroupId": {
-          "Fn::GetAtt": [
-            "GuHttpsEgressSecurityGroupNewsletterstoolapiCF800E6A",
-            "GroupId",
-          ],
-        },
-        "FromPort": 3000,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "LoadBalancerNewsletterstoolapiSecurityGroup21F3B3E2",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "ToPort": 3000,
-      },
-      "Type": "AWS::EC2::SecurityGroupEgress",
-    },
     "NewslettersAPICname": {
       "Properties": {
         "Name": "readonly-newsletters.test.dev-gutools.co.uk",
@@ -1260,7 +1260,7 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
         "ResourceRecords": [
           {
             "Fn::GetAtt": [
-              "LoadBalancerNewsletterstoolapi72A19492",
+              "LoadBalancerNewslettersapi605B1E8A",
               "DNSName",
             ],
           },
@@ -1286,6 +1286,57 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
         "TTL": 3600,
       },
       "Type": "Guardian::DNS::RecordSet",
+    },
+    "ParameterStoreReadNewslettersapi37E83AD5": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/newsletters/newsletters-api",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/newsletters/newsletters-api/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "parameter-store-read-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleNewslettersapi01755604",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "ParameterStoreReadNewsletterstoolC810365C": {
       "Properties": {
@@ -1338,58 +1389,7 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
       },
       "Type": "AWS::IAM::Policy",
     },
-    "ParameterStoreReadNewsletterstoolapi38EC6DE9": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "ssm:GetParametersByPath",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:eu-west-1:",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/TEST/newsletters/newsletters-tool-api",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "ssm:GetParameters",
-                "ssm:GetParameter",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:eu-west-1:",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/TEST/newsletters/newsletters-tool-api/*",
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "parameter-store-read-policy",
-        "Roles": [
-          {
-            "Ref": "InstanceRoleNewsletterstoolapi0896FE93",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "TargetGroupNewsletterstool43BAC68D": {
+    "TargetGroupNewslettersapiDF74F995": {
       "Properties": {
         "HealthCheckIntervalSeconds": 10,
         "HealthCheckPath": "/healthcheck",
@@ -1401,7 +1401,7 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
         "Tags": [
           {
             "Key": "App",
-            "Value": "newsletters-tool",
+            "Value": "newsletters-api",
           },
           {
             "Key": "gu:cdk:version",
@@ -1438,7 +1438,7 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
-    "TargetGroupNewsletterstoolapi583BDEB1": {
+    "TargetGroupNewsletterstool43BAC68D": {
       "Properties": {
         "HealthCheckIntervalSeconds": 10,
         "HealthCheckPath": "/healthcheck",
@@ -1450,7 +1450,7 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
         "Tags": [
           {
             "Key": "App",
-            "Value": "newsletters-tool-api",
+            "Value": "newsletters-tool",
           },
           {
             "Key": "gu:cdk:version",
@@ -1577,7 +1577,7 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
             "Ref": "InstanceRoleNewsletterstoolDD0F3665",
           },
           {
-            "Ref": "InstanceRoleNewsletterstoolapi0896FE93",
+            "Ref": "InstanceRoleNewslettersapi01755604",
           },
         ],
       },

--- a/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
+++ b/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
@@ -392,6 +392,23 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
       },
       "Type": "AWS::AutoScaling::LaunchConfiguration",
     },
+    "CNAME": {
+      "Properties": {
+        "Name": "newsletters-tool.test.dev-gutools.co.uk",
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "LoadBalancerNewsletterstoolE9AB350F",
+              "DNSName",
+            ],
+          },
+        ],
+        "Stage": "TEST",
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
     "CertificateNewslettersapi7A81CAC3": {
       "DeletionPolicy": "Retain",
       "Properties": {
@@ -1261,23 +1278,6 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
           {
             "Fn::GetAtt": [
               "LoadBalancerNewslettersapi605B1E8A",
-              "DNSName",
-            ],
-          },
-        ],
-        "Stage": "TEST",
-        "TTL": 3600,
-      },
-      "Type": "Guardian::DNS::RecordSet",
-    },
-    "NewslettersToolCname": {
-      "Properties": {
-        "Name": "newsletters-tool.test.dev-gutools.co.uk",
-        "RecordType": "CNAME",
-        "ResourceRecords": [
-          {
-            "Fn::GetAtt": [
-              "LoadBalancerNewsletterstoolE9AB350F",
               "DNSName",
             ],
           },

--- a/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
+++ b/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
@@ -242,7 +242,7 @@ unzip /tmp/newsletters-api.zip -d /opt/newsletters-api
 chown -R ubuntu /opt/newsletters-api
 export NEWSLETTERS_API_READ=true
 export NEWSLETTERS_API_READ_WRITE=false
-export NEWSLETTERS_UI_SERVE=false}
+export NEWSLETTERS_UI_SERVE=false
 export STAGE=TEST
 export NEWSLETTER_BUCKET_NAME=",
                 {
@@ -375,7 +375,7 @@ unzip /tmp/newsletters-tool.zip -d /opt/newsletters-tool
 chown -R ubuntu /opt/newsletters-tool
 export NEWSLETTERS_API_READ=false
 export NEWSLETTERS_API_READ_WRITE=true
-export NEWSLETTERS_UI_SERVE=true}
+export NEWSLETTERS_UI_SERVE=true
 export STAGE=TEST
 export NEWSLETTER_BUCKET_NAME=",
                 {

--- a/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
+++ b/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
@@ -236,10 +236,10 @@ aws s3 cp s3://",
                 {
                   "Ref": "DistributionBucketName",
                 },
-                "/newsletters/TEST/newsletters-tool/newsletters-tool.zip /tmp
-mkdir -p /opt/newsletters-tool
-unzip /tmp/newsletters-tool.zip -d /opt/newsletters-tool
-chown -R ubuntu /opt/newsletters-tool
+                "/newsletters/TEST/newsletters-api/newsletters-api.zip /tmp
+mkdir -p /opt/newsletters-api
+unzip /tmp/newsletters-api.zip -d /opt/newsletters-api
+chown -R ubuntu /opt/newsletters-api
 export NEWSLETTERS_API_READ=true
 export NEWSLETTERS_API_READ_WRITE=false
 export NEWSLETTERS_UI_SERVE=false}
@@ -250,8 +250,8 @@ export NEWSLETTER_BUCKET_NAME=",
                 },
                 "
 export USE_IN_MEMORY_STORAGE=false
-cd /opt/newsletters-tool
-su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsletters-api/index.cjs'",
+cd /opt/newsletters-api
+su ubuntu -c '/usr/local/node/pm2 start --name newsletters-api dist/apps/newsletters-api/index.cjs'",
               ],
             ],
           },
@@ -1530,7 +1530,7 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "newsletterstoolInstancePolicy214EAC72": {
+    "s3accesspolicy28B12BB3": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [

--- a/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
+++ b/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
@@ -26,8 +26,22 @@ exports[`The Newsletters stack matches the snapshot 1`] = `
       "GuStringParameter",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
+      "GuSubnetListParameter",
+      "GuSubnetListParameter",
+      "GuNodeApp",
+      "GuCertificate",
+      "GuInstanceRole",
+      "GuGetDistributablePolicy",
+      "GuParameterStoreReadPolicy",
+      "GuAmiParameter",
+      "GuHttpsEgressSecurityGroup",
+      "GuAutoScalingGroup",
+      "GuApplicationLoadBalancer",
+      "GuApplicationTargetGroup",
+      "GuHttpsApplicationListener",
       "GuHttpsEgressSecurityGroup",
       "GuStringParameter",
+      "GuCname",
       "GuCname",
     ],
     "gu:cdk:version": "TEST",
@@ -42,10 +56,23 @@ exports[`The Newsletters stack matches the snapshot 1`] = `
         ],
       },
     },
+    "LoadBalancerNewsletterstoolapiDnsName": {
+      "Description": "DNS entry for LoadBalancerNewsletterstoolapi",
+      "Value": {
+        "Fn::GetAtt": [
+          "LoadBalancerNewsletterstoolapi72A19492",
+          "DNSName",
+        ],
+      },
+    },
   },
   "Parameters": {
     "AMINewsletterstool": {
       "Description": "Amazon Machine Image ID for the app newsletters-tool. Use this in conjunction with AMIgo to keep AMIs up to date.",
+      "Type": "AWS::EC2::Image::Id",
+    },
+    "AMINewsletterstoolapi": {
+      "Description": "Amazon Machine Image ID for the app newsletters-tool-api. Use this in conjunction with AMIgo to keep AMIs up to date.",
       "Type": "AWS::EC2::Image::Id",
     },
     "AccessLoggingBucket": {
@@ -83,6 +110,16 @@ exports[`The Newsletters stack matches the snapshot 1`] = `
       "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
     },
     "newsletterstoolPublicSubnets": {
+      "Default": "/account/vpc/primary/subnets/public",
+      "Description": "A list of public subnets",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+    },
+    "newsletterstoolapiPrivateSubnets": {
+      "Default": "/account/vpc/primary/subnets/private",
+      "Description": "A list of private subnets",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+    },
+    "newsletterstoolapiPublicSubnets": {
       "Default": "/account/vpc/primary/subnets/public",
       "Description": "A list of public subnets",
       "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
@@ -203,9 +240,9 @@ aws s3 cp s3://",
 mkdir -p /opt/newsletters-tool
 unzip /tmp/newsletters-tool.zip -d /opt/newsletters-tool
 chown -R ubuntu /opt/newsletters-tool
-export NEWSLETTERS_API_READ=true
+export NEWSLETTERS_API_READ=false
 export NEWSLETTERS_API_READ_WRITE=true
-export NEWSLETTERS_UI_SERVE=true
+export NEWSLETTERS_UI_SERVE=true}
 export STAGE=TEST
 export NEWSLETTER_BUCKET_NAME=",
                 {
@@ -222,22 +259,138 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
       },
       "Type": "AWS::AutoScaling::LaunchConfiguration",
     },
-    "CNAME": {
+    "AutoScalingGroupNewsletterstoolapiASGDC4C7120": {
       "Properties": {
-        "Name": "newsletters-tool.test.dev-gutools.co.uk",
-        "RecordType": "CNAME",
-        "ResourceRecords": [
+        "HealthCheckGracePeriod": 120,
+        "HealthCheckType": "ELB",
+        "LaunchConfigurationName": {
+          "Ref": "AutoScalingGroupNewsletterstoolapiLaunchConfig4B05787F",
+        },
+        "MaxSize": "2",
+        "MinSize": "1",
+        "Tags": [
+          {
+            "Key": "App",
+            "PropagateAtLaunch": true,
+            "Value": "newsletters-tool-api",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "PropagateAtLaunch": true,
+            "Value": "guardian/newsletters-nx",
+          },
+          {
+            "Key": "LogKinesisStreamName",
+            "PropagateAtLaunch": true,
+            "Value": {
+              "Ref": "LoggingStreamName",
+            },
+          },
+          {
+            "Key": "Name",
+            "PropagateAtLaunch": true,
+            "Value": "NewslettersTool-TEST/AutoScalingGroupNewsletterstoolapi",
+          },
+          {
+            "Key": "Stack",
+            "PropagateAtLaunch": true,
+            "Value": "newsletters",
+          },
+          {
+            "Key": "Stage",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
+          },
+        ],
+        "TargetGroupARNs": [
+          {
+            "Ref": "TargetGroupNewsletterstoolapi583BDEB1",
+          },
+        ],
+        "VPCZoneIdentifier": {
+          "Ref": "newsletterstoolapiPrivateSubnets",
+        },
+      },
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+    },
+    "AutoScalingGroupNewsletterstoolapiInstanceProfile11217FD0": {
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "InstanceRoleNewsletterstoolapi0896FE93",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
+    "AutoScalingGroupNewsletterstoolapiLaunchConfig4B05787F": {
+      "DependsOn": [
+        "InstanceRoleNewsletterstoolapi0896FE93",
+      ],
+      "Properties": {
+        "IamInstanceProfile": {
+          "Ref": "AutoScalingGroupNewsletterstoolapiInstanceProfile11217FD0",
+        },
+        "ImageId": {
+          "Ref": "AMINewsletterstoolapi",
+        },
+        "InstanceType": "t4g.small",
+        "MetadataOptions": {
+          "HttpTokens": "required",
+        },
+        "SecurityGroups": [
           {
             "Fn::GetAtt": [
-              "LoadBalancerNewsletterstoolE9AB350F",
-              "DNSName",
+              "GuHttpsEgressSecurityGroupNewsletterstoolapiCF800E6A",
+              "GroupId",
+            ],
+          },
+          {
+            "Fn::GetAtt": [
+              "WazuhSecurityGroup",
+              "GroupId",
             ],
           },
         ],
-        "Stage": "TEST",
-        "TTL": 3600,
+        "UserData": {
+          "Fn::Base64": {
+            "Fn::Join": [
+              "",
+              [
+                "#!/bin/bash
+set -e
+set +x
+aws s3 cp s3://",
+                {
+                  "Ref": "DistributionBucketName",
+                },
+                "/newsletters/TEST/newsletters-tool/newsletters-tool.zip /tmp
+mkdir -p /opt/newsletters-tool
+unzip /tmp/newsletters-tool.zip -d /opt/newsletters-tool
+chown -R ubuntu /opt/newsletters-tool
+export NEWSLETTERS_API_READ=true
+export NEWSLETTERS_API_READ_WRITE=false
+export NEWSLETTERS_UI_SERVE=false}
+export STAGE=TEST
+export NEWSLETTER_BUCKET_NAME=",
+                {
+                  "Ref": "SsmParameterValueTESTnewslettersnewslettersapis3BucketNameC96584B6F00A464EAD1953AFF4B05118Parameter",
+                },
+                "
+export USE_IN_MEMORY_STORAGE=false
+cd /opt/newsletters-tool
+su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsletters-api/index.cjs'",
+              ],
+            ],
+          },
+        },
       },
-      "Type": "Guardian::DNS::RecordSet",
+      "Type": "AWS::AutoScaling::LaunchConfiguration",
     },
     "CertificateNewsletterstoolAB12580B": {
       "DeletionPolicy": "Retain",
@@ -259,6 +412,41 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
           {
             "Key": "Name",
             "Value": "NewslettersTool-TEST/CertificateNewsletterstool",
+          },
+          {
+            "Key": "Stack",
+            "Value": "newsletters",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "ValidationMethod": "DNS",
+      },
+      "Type": "AWS::CertificateManager::Certificate",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "CertificateNewsletterstoolapi83F10CF4": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "DomainName": "readonly-newsletters.test.dev-gutools.co.uk",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newsletters-tool-api",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newsletters-nx",
+          },
+          {
+            "Key": "Name",
+            "Value": "NewslettersTool-TEST/CertificateNewsletterstoolapi",
           },
           {
             "Key": "Stack",
@@ -337,6 +525,9 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
           {
             "Ref": "InstanceRoleNewsletterstoolDD0F3665",
           },
+          {
+            "Ref": "InstanceRoleNewsletterstoolapi0896FE93",
+          },
         ],
       },
       "Type": "AWS::IAM::Policy",
@@ -368,6 +559,38 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
         "Roles": [
           {
             "Ref": "InstanceRoleNewsletterstoolDD0F3665",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GetDistributablePolicyNewsletterstoolapi000AF3BF": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    {
+                      "Ref": "DistributionBucketName",
+                    },
+                    "/newsletters/TEST/newsletters-tool-api/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GetDistributablePolicyNewsletterstoolapi000AF3BF",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleNewsletterstoolapi0896FE93",
           },
         ],
       },
@@ -412,6 +635,67 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
+    },
+    "GuHttpsEgressSecurityGroupNewsletterstoolapiCF800E6A": {
+      "Properties": {
+        "GroupDescription": "Allow all outbound HTTPS traffic",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound HTTPS traffic",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newsletters-tool-api",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newsletters-nx",
+          },
+          {
+            "Key": "Stack",
+            "Value": "newsletters",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "GuHttpsEgressSecurityGroupNewsletterstoolapifromNewslettersToolTESTLoadBalancerNewsletterstoolapiSecurityGroupC2034F8D3000733C4055": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 3000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "GuHttpsEgressSecurityGroupNewsletterstoolapiCF800E6A",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerNewsletterstoolapiSecurityGroup21F3B3E2",
+            "GroupId",
+          ],
+        },
+        "ToPort": 3000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
     },
     "GuHttpsEgressSecurityGroupNewsletterstoolfromNewslettersToolTESTIdPAccessNewsletterstoolD34AC715300055F7D2AB": {
       "Properties": {
@@ -488,6 +772,9 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
         "Roles": [
           {
             "Ref": "InstanceRoleNewsletterstoolDD0F3665",
+          },
+          {
+            "Ref": "InstanceRoleNewsletterstoolapi0896FE93",
           },
         ],
       },
@@ -608,6 +895,60 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
       },
       "Type": "AWS::IAM::Role",
     },
+    "InstanceRoleNewsletterstoolapi0896FE93": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ec2.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AmazonSSMManagedInstanceCore",
+              ],
+            ],
+          },
+        ],
+        "Path": "/",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newsletters-tool-api",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newsletters-nx",
+          },
+          {
+            "Key": "Stack",
+            "Value": "newsletters",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
     "ListenerNewsletterstoolFF7146AA": {
       "Properties": {
         "Certificates": [
@@ -647,6 +988,31 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
         ],
         "LoadBalancerArn": {
           "Ref": "LoadBalancerNewsletterstoolE9AB350F",
+        },
+        "Port": 443,
+        "Protocol": "HTTPS",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+    },
+    "ListenerNewsletterstoolapiAED5F562": {
+      "Properties": {
+        "Certificates": [
+          {
+            "CertificateArn": {
+              "Ref": "CertificateNewsletterstoolapi83F10CF4",
+            },
+          },
+        ],
+        "DefaultActions": [
+          {
+            "TargetGroupArn": {
+              "Ref": "TargetGroupNewsletterstoolapi583BDEB1",
+            },
+            "Type": "forward",
+          },
+        ],
+        "LoadBalancerArn": {
+          "Ref": "LoadBalancerNewsletterstoolapi72A19492",
         },
         "Port": 443,
         "Protocol": "HTTPS",
@@ -780,6 +1146,147 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
+    "LoadBalancerNewsletterstoolapi72A19492": {
+      "Properties": {
+        "LoadBalancerAttributes": [
+          {
+            "Key": "deletion_protection.enabled",
+            "Value": "true",
+          },
+        ],
+        "Scheme": "internet-facing",
+        "SecurityGroups": [
+          {
+            "Fn::GetAtt": [
+              "LoadBalancerNewsletterstoolapiSecurityGroup21F3B3E2",
+              "GroupId",
+            ],
+          },
+        ],
+        "Subnets": {
+          "Ref": "newsletterstoolapiPublicSubnets",
+        },
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newsletters-tool-api",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newsletters-nx",
+          },
+          {
+            "Key": "Stack",
+            "Value": "newsletters",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Type": "application",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    },
+    "LoadBalancerNewsletterstoolapiSecurityGroup21F3B3E2": {
+      "Properties": {
+        "GroupDescription": "Automatically created Security Group for ELB NewslettersToolTESTLoadBalancerNewsletterstoolapi135BAFC5",
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 443",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newsletters-tool-api",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newsletters-nx",
+          },
+          {
+            "Key": "Stack",
+            "Value": "newsletters",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "LoadBalancerNewsletterstoolapiSecurityGrouptoNewslettersToolTESTGuHttpsEgressSecurityGroupNewsletterstoolapi167097B0300059D218F6": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "GuHttpsEgressSecurityGroupNewsletterstoolapiCF800E6A",
+            "GroupId",
+          ],
+        },
+        "FromPort": 3000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerNewsletterstoolapiSecurityGroup21F3B3E2",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 3000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "NewslettersAPICname": {
+      "Properties": {
+        "Name": "readonly-newsletters.test.dev-gutools.co.uk",
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "LoadBalancerNewsletterstoolapi72A19492",
+              "DNSName",
+            ],
+          },
+        ],
+        "Stage": "TEST",
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
+    "NewslettersToolCname": {
+      "Properties": {
+        "Name": "newsletters-tool.test.dev-gutools.co.uk",
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "LoadBalancerNewsletterstoolE9AB350F",
+              "DNSName",
+            ],
+          },
+        ],
+        "Stage": "TEST",
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
     "ParameterStoreReadNewsletterstoolC810365C": {
       "Properties": {
         "PolicyDocument": {
@@ -831,6 +1338,57 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
       },
       "Type": "AWS::IAM::Policy",
     },
+    "ParameterStoreReadNewsletterstoolapi38EC6DE9": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/newsletters/newsletters-tool-api",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/newsletters/newsletters-tool-api/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "parameter-store-read-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleNewsletterstoolapi0896FE93",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "TargetGroupNewsletterstool43BAC68D": {
       "Properties": {
         "HealthCheckIntervalSeconds": 10,
@@ -844,6 +1402,55 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
           {
             "Key": "App",
             "Value": "newsletters-tool",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newsletters-nx",
+          },
+          {
+            "Key": "Stack",
+            "Value": "newsletters",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "TargetGroupAttributes": [
+          {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "30",
+          },
+          {
+            "Key": "stickiness.enabled",
+            "Value": "false",
+          },
+        ],
+        "TargetType": "instance",
+        "UnhealthyThresholdCount": 2,
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+    "TargetGroupNewsletterstoolapi583BDEB1": {
+      "Properties": {
+        "HealthCheckIntervalSeconds": 10,
+        "HealthCheckPath": "/healthcheck",
+        "HealthCheckProtocol": "HTTP",
+        "HealthCheckTimeoutSeconds": 5,
+        "HealthyThresholdCount": 5,
+        "Port": 3000,
+        "Protocol": "HTTP",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newsletters-tool-api",
           },
           {
             "Key": "gu:cdk:version",
@@ -968,6 +1575,9 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
         "Roles": [
           {
             "Ref": "InstanceRoleNewsletterstoolDD0F3665",
+          },
+          {
+            "Ref": "InstanceRoleNewsletterstoolapi0896FE93",
           },
         ],
       },

--- a/cdk/lib/newsletters-tool.test.ts
+++ b/cdk/lib/newsletters-tool.test.ts
@@ -10,7 +10,8 @@ describe('The Newsletters stack', () => {
 			...sharedProps,
 			stage: 'TEST',
 			app: 'newsletters-tool',
-			domainName: 'newsletters-tool.test.dev-gutools.co.uk',
+			domainNameTool: 'newsletters-tool.test.dev-gutools.co.uk',
+			domainNameApi: 'readonly-newsletters.test.dev-gutools.co.uk',
 		});
 		const template = Template.fromStack(stack);
 		expect(template.toJSON()).toMatchSnapshot();

--- a/cdk/lib/newsletters-tool.ts
+++ b/cdk/lib/newsletters-tool.ts
@@ -21,7 +21,8 @@ import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
 
 export interface NewslettersToolProps extends GuStackProps {
 	app: string; // Force app to be a required prop
-	domainName: string;
+	domainNameTool: string;
+	domainNameApi: string;
 }
 
 export class NewslettersTool extends GuStack {
@@ -39,6 +40,7 @@ export class NewslettersTool extends GuStack {
 	private getUserData = (
 		app: NewslettersToolProps['app'],
 		bucketName: string,
+		readOnly: boolean,
 	) => {
 		// Fetches distribution S3 bucket name from account
 		const distributionBucketParameter =
@@ -52,9 +54,9 @@ export class NewslettersTool extends GuStack {
 			`mkdir -p /opt/${app}`, // make more permanent directory for app to be unzipped into
 			`unzip /tmp/${app}.zip -d /opt/${app}`, // unzip the downloaded zip from /tmp into directory in /opt instead
 			`chown -R ubuntu /opt/${app}`, // change ownership of the copied files to ubuntu user
-			`export NEWSLETTERS_API_READ=true`,
-			`export NEWSLETTERS_API_READ_WRITE=true`,
-			`export NEWSLETTERS_UI_SERVE=true`,
+			`export NEWSLETTERS_API_READ=${readOnly}`,
+			`export NEWSLETTERS_API_READ_WRITE=${!readOnly}`,
+			`export NEWSLETTERS_UI_SERVE=${!readOnly}}`,
 			`export STAGE=${this.stage}`, // sets the stage environment variable
 			`export NEWSLETTER_BUCKET_NAME=${bucketName}`, // sets the bucket name environment variable
 			`export USE_IN_MEMORY_STORAGE=false`, // use s3 when running on cloud
@@ -64,7 +66,7 @@ export class NewslettersTool extends GuStack {
 	};
 
 	private setUpNodeEc2 = (props: NewslettersToolProps) => {
-		const { app, domainName } = props;
+		const { app, domainNameTool, domainNameApi } = props;
 
 		// To avoid exposing the bucket name publicly, fetches the bucket name from SSM (parameter store).
 		const bucketSSMParameterName = `/${this.stage}/${this.stack}/newsletters-api/s3BucketName`;
@@ -102,15 +104,15 @@ export class NewslettersTool extends GuStack {
 		});
 
 		/** Sets up Node app to be run in EC2 */
-		const ec2App = new GuNodeApp(this, {
+		const ec2AppTool = new GuNodeApp(this, {
 			access: { scope: AccessScope.PUBLIC },
-			certificateProps: { domainName },
+			certificateProps: { domainName: domainNameTool },
 			monitoringConfiguration: { noMonitoring: true },
 			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
 			// Minimum of 1 EC2 instance running at a time. If one fails, scales up to 2 before dropping back to 1 again
 			scaling: { minimumInstances: 1, maximumInstances: 2 },
 			// Instructions to set up the environment in the instance
-			userData: this.getUserData(app, bucketName),
+			userData: this.getUserData(app, bucketName, false),
 			roleConfiguration: {
 				additionalPolicies: [s3AccessPolicy],
 			},
@@ -121,15 +123,28 @@ export class NewslettersTool extends GuStack {
 			},
 		});
 
+		const ec2AppApi = new GuNodeApp(this, {
+			access: { scope: AccessScope.PUBLIC },
+			certificateProps: { domainName: domainNameApi },
+			monitoringConfiguration: { noMonitoring: true },
+			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
+			scaling: { minimumInstances: 1, maximumInstances: 2 },
+			userData: this.getUserData(app, bucketName, true),
+			roleConfiguration: {
+				additionalPolicies: [s3AccessPolicy],
+			},
+			app: `${app}-api`,
+		});
+
 		/** Security group to allow load balancer to egress to 443 for OIDC flow using Google auth */
 		const lbEgressSecurityGroup = new GuHttpsEgressSecurityGroup(
 			this,
 			'IdP Access',
-			{ app, vpc: ec2App.vpc },
+			{ app, vpc: ec2AppTool.vpc },
 		);
 
 		/** Add security group to EC2 load balancer */
-		ec2App.loadBalancer.addSecurityGroup(lbEgressSecurityGroup);
+		ec2AppTool.loadBalancer.addSecurityGroup(lbEgressSecurityGroup);
 
 		/** Fetch Google clientId param from SSM */
 		const clientId = new GuStringParameter(this, 'Google Client ID', {
@@ -139,7 +154,7 @@ export class NewslettersTool extends GuStack {
 		});
 
 		/** Add Google authentication layer to the EC2 load balancer */
-		ec2App.listener.addAction('Google Auth', {
+		ec2AppTool.listener.addAction('Google Auth', {
 			action: ListenerAction.authenticateOidc({
 				authorizationEndpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
 				issuer: 'https://accounts.google.com',
@@ -152,7 +167,7 @@ export class NewslettersTool extends GuStack {
 				clientSecret: SecretValue.secretsManager(
 					`/${this.stage}/deploy/newsletters/clientSecret`,
 				),
-				next: ListenerAction.forward([ec2App.targetGroup]),
+				next: ListenerAction.forward([ec2AppTool.targetGroup]),
 			}),
 		});
 
@@ -160,11 +175,17 @@ export class NewslettersTool extends GuStack {
 		 * Sets up CNAME record for domainName specified
 		 * @see https://en.wikipedia.org/wiki/CNAME_record
 		 */
-		new GuCname(this, 'CNAME', {
+		new GuCname(this, 'NewslettersToolCname', {
 			app,
-			domainName,
+			domainName: domainNameTool,
 			ttl: Duration.hours(1),
-			resourceRecord: ec2App.loadBalancer.loadBalancerDnsName,
+			resourceRecord: ec2AppTool.loadBalancer.loadBalancerDnsName,
+		});
+		new GuCname(this, 'NewslettersAPICname', {
+			app,
+			domainName: domainNameApi,
+			ttl: Duration.hours(1),
+			resourceRecord: ec2AppApi.loadBalancer.loadBalancerDnsName,
 		});
 	};
 }

--- a/cdk/lib/newsletters-tool.ts
+++ b/cdk/lib/newsletters-tool.ts
@@ -53,9 +53,9 @@ export class NewslettersTool extends GuStack {
 			`mkdir -p /opt/${app}`, // make more permanent directory for app to be unzipped into
 			`unzip /tmp/${app}.zip -d /opt/${app}`, // unzip the downloaded zip from /tmp into directory in /opt instead
 			`chown -R ubuntu /opt/${app}`, // change ownership of the copied files to ubuntu user
-			`export NEWSLETTERS_API_READ=${readOnly}`,
-			`export NEWSLETTERS_API_READ_WRITE=${!readOnly}`,
-			`export NEWSLETTERS_UI_SERVE=${!readOnly}}`,
+			`export NEWSLETTERS_API_READ=${readOnly ? 'true' : 'false'}`,
+			`export NEWSLETTERS_API_READ_WRITE=${readOnly ? 'false' : 'true'}`,
+			`export NEWSLETTERS_UI_SERVE=${readOnly ? 'false' : 'true'}`,
 			`export STAGE=${this.stage}`, // sets the stage environment variable
 			`export NEWSLETTER_BUCKET_NAME=${bucketName}`, // sets the bucket name environment variable
 			`export USE_IN_MEMORY_STORAGE=false`, // use s3 when running on cloud

--- a/cdk/lib/newsletters-tool.ts
+++ b/cdk/lib/newsletters-tool.ts
@@ -176,7 +176,7 @@ export class NewslettersTool extends GuStack {
 		 * Sets up CNAME record for domainName specified
 		 * @see https://en.wikipedia.org/wiki/CNAME_record
 		 */
-		new GuCname(this, 'NewslettersToolCname', {
+		new GuCname(this, 'CNAME', {
 			app: toolAppName,
 			domainName: domainNameTool,
 			ttl: Duration.hours(1),

--- a/cdk/lib/newsletters-tool.ts
+++ b/cdk/lib/newsletters-tool.ts
@@ -133,7 +133,7 @@ export class NewslettersTool extends GuStack {
 			roleConfiguration: {
 				additionalPolicies: [s3AccessPolicy],
 			},
-			app: `${app}-api`,
+			app: `newsletters-api`,
 		});
 
 		/** Security group to allow load balancer to egress to 443 for OIDC flow using Google auth */

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -26,7 +26,7 @@ deployments:
         AMINewsletterstool:
           BuiltBy: amigo
           Recipe: newsletters-node
-        AMINewsletterstoolapi:
+        AMINewslettersapi:
           BuiltBy: amigo
           Recipe: newsletters-node
       templateStagePaths:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -22,12 +22,22 @@ deployments:
     app: newsletters-tool
     parameters:
       cloudFormationStackName: newsletters-tool
-      amiParameter: AMINewsletterstool # please don't change this unless you know what you're doing
+      amiParametersToTags:
+        AMINewsletterstool:
+            BuiltBy: amigo
+            Recipe: newsletters-node
+        AMINewsletterstoolapi:
+          BuiltBy: amigo
+          Recipe: newsletters-node
       templateStagePaths:
         CODE: NewslettersTool-CODE.template.json
         PROD: NewslettersTool-PROD.template.json
 
   # Newsletters internal tool autoscaling deployment
   newsletters-tool:
+    template: autoscaling-template
+    dependencies: [newsletters-tool-cfn]
+
+  newsletters-api:
     template: autoscaling-template
     dependencies: [newsletters-tool-cfn]

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -24,8 +24,8 @@ deployments:
       cloudFormationStackName: newsletters-tool
       amiParametersToTags:
         AMINewsletterstool:
-            BuiltBy: amigo
-            Recipe: newsletters-node
+          BuiltBy: amigo
+          Recipe: newsletters-node
         AMINewsletterstoolapi:
           BuiltBy: amigo
           Recipe: newsletters-node


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This adds a new EC2 instance running as a separate app configured not to serve the UI and to provide read-only access to the API.

This will be used to serve external clients (Braze, Identity & Frontend). A future PR will add a Fastly deployment to cache these responses.

<img width="1169" alt="Screenshot 2023-05-11 at 14 12 02" src="https://github.com/guardian/newsletters-nx/assets/3277259/68595a3e-e9d9-47d6-8cf4-ec3df1337aeb">


## How to test

Deploy and ensure the existing app is running and that the  [read-only API](https://readonly-newsletters.code.dev-gutools.co.uk/) is available and that is is not possible to write to it

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->


## Have we considered potential risks?

This offers unauthenticated access to the Newsletters API. This is the same as the existing newsletters api and we are not exposing sensitive data




