### PR TITLE
Dblatcher remove emailembed schema

### DIFF
--- a/apps/newsletters-api/src/services/storage/inMemoryStorageInstance.ts
+++ b/apps/newsletters-api/src/services/storage/inMemoryStorageInstance.ts
@@ -19,20 +19,10 @@ export const makeInMemoryStorageInstance = () =>
 			theme: 'culture',
 			group: 'Work',
 			regionFocus: 'UK',
-			// listIdV1: 3703,
 			listId: 5770,
 			exampleUrl: '/world/series/series-avon-recumbent/latest/email',
 			signupPage:
 				'/global/sign-up-for-the-avon-recumbent-newsletter-our-free-email',
-			emailEmbed: {
-				name: 'Avon Recumbent',
-				title: 'Sign up for Avon Recumbent',
-				description:
-					'Numquam ipsam culpa velit suscipit ratione corrupti. recusandae aliquam repudiandae eaque. error corporis deserunt suscipit dolor consequuntur dolor quaerat dolor. possimus cupiditate in nam. itaque quaerat illum sint quos blanditiis.',
-				successHeadline: 'Subscription confirmed',
-				successDescription: "We'll send you Avon Recumbent weekly",
-				hexCode: '#DCDCDC',
-			},
 			campaignName: 'AvonRecumbentUs',
 			campaignCode: 'avonrecumbentUS_email',
 			brazeSubscribeAttributeNameAlternate: [

--- a/apps/newsletters-api/static/newsletters.local.json
+++ b/apps/newsletters-api/static/newsletters.local.json
@@ -19,14 +19,6 @@
 		"exampleUrl": "/world/series/series-blue-empowering/latest/email",
 		"signupPage": "/global/sign-up-for-the-blue-empowering-newsletter-our-free-email",
 		"signUpEmbedDescription": "We'll send you Blue Empowering fortnightly",
-		"emailEmbed": {
-			"name": "Blue Empowering",
-			"title": "Sign up for Blue Empowering",
-			"description": "Exercitationem ducimus quas enim dolorem.",
-			"successHeadline": "Subscription confirmed",
-			"successDescription": "We'll send you Blue Empowering fortnightly",
-			"hexCode": "#DCDCDC"
-		},
 		"campaignName": "BlueEmpowering",
 		"campaignCode": "blueempowering_email",
 		"brazeSubscribeAttributeNameAlternate": ["email_subscribe_blue_empowering"],
@@ -58,14 +50,6 @@
 		"exampleUrl": "/world/series/series-sint-denigrate/latest/email",
 		"signupPage": "/global/sign-up-for-the-sint-denigrate-newsletter-our-free-email",
 		"signUpEmbedDescription": "We'll send you Sint Denigrate monthly",
-		"emailEmbed": {
-			"name": "Sint Denigrate",
-			"title": "Sign up for Sint Denigrate",
-			"description": "Voluptatem facilis similique",
-			"successHeadline": "Subscription confirmed",
-			"successDescription": "We'll send you Sint Denigrate monthly",
-			"hexCode": "#DCDCDC"
-		},
 		"campaignName": "SintDenigrateUk",
 		"campaignCode": "sintdenigrateUK_email",
 		"brazeSubscribeAttributeNameAlternate": [
@@ -99,14 +83,6 @@
 		"exampleUrl": "/world/series/series-systems-northeast/latest/email",
 		"signupPage": "/global/sign-up-for-the-systems-northeast-newsletter-our-free-email",
 		"signUpEmbedDescription": "We'll send you Systems Northeast weekly",
-		"emailEmbed": {
-			"name": "Systems Northeast",
-			"title": "Sign up for Systems Northeast",
-			"description": "At totam autem velit numquam saepe alias odit.",
-			"successHeadline": "Subscription confirmed",
-			"successDescription": "We'll send you Systems Northeast weekly",
-			"hexCode": "#DCDCDC"
-		},
 		"campaignName": "SystemsNortheast",
 		"campaignCode": "systemsnortheast_email",
 		"brazeSubscribeAttributeNameAlternate": [
@@ -140,14 +116,6 @@
 		"exampleUrl": "/world/series/series-cambridgeshire-support/latest/email",
 		"signupPage": "/global/sign-up-for-the-cambridgeshire-support-newsletter-our-free-email",
 		"signUpEmbedDescription": "We'll send you Cambridgeshire Support fortnightly",
-		"emailEmbed": {
-			"name": "Cambridgeshire Support",
-			"title": "Sign up for Cambridgeshire Support",
-			"description": "Praesentium cumque ad accusamus deserunt incidunt.",
-			"successHeadline": "Subscription confirmed",
-			"successDescription": "We'll send you Cambridgeshire Support fortnightly",
-			"hexCode": "#DCDCDC"
-		},
 		"campaignName": "CambridgeshireSupport",
 		"campaignCode": "cambridgeshiresupport_email",
 		"brazeSubscribeAttributeNameAlternate": [

--- a/libs/newsletters-data-client/src/fixtures/newsletter-fixtures.ts
+++ b/libs/newsletters-data-client/src/fixtures/newsletter-fixtures.ts
@@ -17,21 +17,13 @@ export const TECHSCAPE_IN_NEW_FORMAT: NewsletterData = {
 		"Alex Hern's weekly dive in to how technology is shaping our lives",
 	signUpEmbedDescription:
 		"Alex Hern's weekly dive in to how technology is shaping our lives",
+	mailSuccessDescription: "We'll send you TechScape every week",
 	regionFocus: undefined,
 	frequency: 'Weekly',
 	listIdV1: -1,
 	listId: 6013,
 	signupPage:
 		'/info/2022/sep/20/sign-up-for-the-techscape-newsletter-our-free-technology-email',
-	emailEmbed: {
-		name: 'TechScape',
-		title: 'Sign up for TechScape',
-		description:
-			"Alex Hern's weekly dive in to how technology is shaping our lives",
-		successHeadline: 'Subscription confirmed',
-		successDescription: "We'll send you TechScape every week",
-		hexCode: '#DCDCDC',
-	},
 	campaignName: 'TechScape',
 	campaignCode: 'techscape_email',
 	brazeSubscribeAttributeNameAlternate: [
@@ -71,7 +63,7 @@ export const VALID_TECHSCAPE: LegacyNewsletter = {
 		'/info/2022/sep/20/sign-up-for-the-techscape-newsletter-our-free-technology-email',
 	emailEmbed: {
 		name: 'TechScape',
-		title: 'Sign up for TechScape',
+		title: 'Sign up for TechScape',
 		description:
 			"Alex Hern's weekly dive in to how technology is shaping our lives",
 		successHeadline: 'Subscription confirmed',

--- a/libs/newsletters-data-client/src/lib/draft-to-newsletter.ts
+++ b/libs/newsletters-data-client/src/lib/draft-to-newsletter.ts
@@ -1,4 +1,3 @@
-import type { EmailEmbed } from './emailEmbedSchema';
 import type { DraftNewsletterData } from './newsletter-data-type';
 import {
 	newsletterDataSchema,
@@ -14,44 +13,12 @@ const defaultNewsletterValues: DraftNewsletterData = {
 	figmaIncludesThrashers: false,
 } as const;
 
-// TODO - the NewsletterData should not have these structure - it's a legacy
-// feature. This should happen in deriveLegacyNewsletter
-const buildEmailEmbedObject = (draft: DraftNewsletterData): EmailEmbed => {
-	const {
-		name = 'newsletter',
-		emailConfirmation = false,
-		frequency,
-		mailSuccessDescription,
-	} = draft;
-
-	const successHeadline = emailConfirmation
-		? 'Check your email inbox and confirm your subscription'
-		: 'Subscription confirmed';
-
-	const successDescription =
-		mailSuccessDescription ??
-		(frequency
-			? `We'll send you ${name} every ${frequency.toLowerCase()}`
-			: `We'll send you ${name} every time it comes out`);
-
-	return {
-		description: draft.signUpEmbedDescription ?? ' ',
-		name: name,
-		title: `Sign up to ${name}`,
-		successHeadline,
-		successDescription: successDescription,
-		hexCode: '#DCDCDC',
-		...draft.emailEmbed,
-	};
-};
-
 export const withDefaultNewsletterValues = (
 	draft: DraftNewsletterData,
 ): DraftNewsletterData => {
 	return {
 		...defaultNewsletterValues,
 		...draft,
-		emailEmbed: buildEmailEmbedObject(draft),
 	};
 };
 

--- a/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { emailEmbedSchema } from './emailEmbedSchema';
 import {
 	kebabCasedString,
 	nonEmptyString,
@@ -108,10 +107,6 @@ export const newsletterDataSchema = z.object({
 	frequency: nonEmptyString(),
 	listId: z.number(),
 	listIdV1: z.number(),
-	// TODO - remove emailEmbed from this schema and derive it as part of in deriveLegacyNewsletter
-	emailEmbed: emailEmbedSchema.extend({
-		description: z.string(),
-	}),
 	campaignName: z.string().optional(),
 	campaignCode: z.string().optional(),
 	brazeSubscribeAttributeNameAlternate: z

--- a/libs/newsletters-data-client/src/lib/transformDataToLegacyNewsletter.ts
+++ b/libs/newsletters-data-client/src/lib/transformDataToLegacyNewsletter.ts
@@ -1,6 +1,9 @@
 import type { LegacyNewsletter } from './legacy-newsletter-type';
 import { isLegacyNewsletter } from './legacy-newsletter-type';
-import type { NewsletterData } from './newsletter-data-type';
+import type {
+	DraftNewsletterData,
+	NewsletterData,
+} from './newsletter-data-type';
 import { isNewsletterData } from './newsletter-data-type';
 
 export const TRANSFORM_ERROR_MESSAGE = {
@@ -16,6 +19,36 @@ const deriveBooleansFromStatus = (
 	return {
 		cancelled: status === 'cancelled',
 		paused: status === 'paused',
+	};
+};
+
+const deriveEmailEmbedObject = (
+	draft: DraftNewsletterData,
+): LegacyNewsletter['emailEmbed'] => {
+	const {
+		name = 'newsletter',
+		emailConfirmation = false,
+		frequency,
+		mailSuccessDescription,
+	} = draft;
+
+	const successHeadline = emailConfirmation
+		? 'Check your email inbox and confirm your subscription'
+		: 'Subscription confirmed';
+
+	const successDescription =
+		mailSuccessDescription ??
+		(frequency
+			? `We'll send you ${name} ${frequency.toLowerCase()}`
+			: `We'll send you ${name} every time it comes out`);
+
+	return {
+		description: draft.signUpEmbedDescription ?? ' ',
+		name: name,
+		title: `Sign up for ${name}`,
+		successHeadline,
+		successDescription: successDescription,
+		hexCode: '#DCDCDC',
 	};
 };
 
@@ -53,7 +86,7 @@ const deriveLegacyNewsletter = (
 			illustration: newsletterData.illustrationCircle
 				? { circle: newsletterData.illustrationCircle }
 				: undefined,
-			emailEmbed: newsletterData.emailEmbed,
+			emailEmbed: deriveEmailEmbedObject(newsletterData),
 			campaignName: newsletterData.campaignName,
 			campaignCode: newsletterData.campaignCode,
 			brazeSubscribeAttributeNameAlternate:

--- a/libs/newsletters-data-client/src/lib/transformWizardData.spec.ts
+++ b/libs/newsletters-data-client/src/lib/transformWizardData.spec.ts
@@ -23,23 +23,15 @@ const SIMPLE_VALID_DRAFT: DraftNewsletterData = {
 
 const VALID_FORM_DATA_WITH_NESTED_OBJECT: FormDataRecord = {
 	name: 'test name',
-	'emailEmbed.name': 'embed name',
-	'emailEmbed.title': 'embed title',
-	'emailEmbed.description': 'embed description',
-	'emailEmbed.successHeadline': 'embed successHeadline',
-	'emailEmbed.successDescription': 'embed successDescription',
-	'emailEmbed.hexCode': 'embed hexCode',
+	'renderingOptions.linkListSubheading': ['frog', 'bird', 'snake'],
+	'renderingOptions.displayStandfirst': true,
 };
 
 const VALID_DRAFT_WITH_NESTED_OBJECT: DraftNewsletterData = {
 	name: 'test name',
-	emailEmbed: {
-		name: 'embed name',
-		title: 'embed title',
-		description: 'embed description',
-		successHeadline: 'embed successHeadline',
-		successDescription: 'embed successDescription',
-		hexCode: 'embed hexCode',
+	renderingOptions: {
+		linkListSubheading: ['frog', 'bird', 'snake'],
+		displayStandfirst: true,
 	},
 };
 

--- a/tools/scripts/deno/generate-newsletters.js
+++ b/tools/scripts/deno/generate-newsletters.js
@@ -101,14 +101,6 @@ const generateNewsletter = () => {
 		exampleUrl: `/world/series/series-${newsletterId}/latest/email`,
 		signupPage: `/global/sign-up-for-the-${newsletterId}-newsletter-our-free-email`,
 		signUpEmbedDescription: `We'll send you ${name} ${frequency.toLowerCase()}`,
-		emailEmbed: {
-			name,
-			title: `Sign up for ${name}`,
-			description: initCap(faker.lorem.text()),
-			successHeadline: 'Subscription confirmed',
-			successDescription: `We'll send you ${name} ${frequency.toLowerCase()}`,
-			hexCode: '#DCDCDC',
-		},
 		campaignName: slugConverter(idWithRegion, 'pascal'),
 		campaignCode: `${idWithRegion.replaceAll('-', '')}_email`,
 		brazeSubscribeAttributeNameAlternate: [


### PR DESCRIPTION
## What does this change?

Removes the `emailEmbed` structure from the `NewsletterDataSchema` and derives it from the other fields when converting to a `LegacyNewsletter`.

Updates fixtures and generators to match.

See corresponding change in migration tool:
https://github.com/guardian/newsletters-migration-tool/pull/11/files

## How to test

features work as before in the UI.
The legacy data is still correctly populated.

## How can we measure success?

The data model is simpler and no longer required to hold redundant legacy fields, which make it hard to determine what data is relevant.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
