### PR TITLE
Dblatcher neat stepnav

### DIFF
--- a/apps/newsletters-ui/index.html
+++ b/apps/newsletters-ui/index.html
@@ -18,6 +18,18 @@
 			body {
 				margin: 0;
 			}
+			.left-aligned-step-button b {
+				text-decoration: underline;
+			}
+			.left-aligned-step-button > .MuiStepLabel-horizontal {
+				flex: 1;
+				text-align: left;
+				min-height: 4rem;
+				transition: background-color 0.5s;
+			}
+			.left-aligned-step-button > .MuiStepLabel-horizontal:hover {
+				background-color: #c1d8fc;
+			}
 		</style>
 
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/apps/newsletters-ui/src/app/components/StepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StepNav.tsx
@@ -123,7 +123,11 @@ export const StepNav = ({
 		!isCurrent(step);
 
 	return (
-		<Stepper sx={{ flexWrap: 'wrap' }} nonLinear={stepperConfig.isNonLinear}>
+		<Stepper
+			sx={{ flexWrap: 'wrap' }}
+			nonLinear={stepperConfig.isNonLinear}
+			connector={null}
+		>
 			{filteredStepList.map((step) => {
 				const caption = stepperConfig.indicateStepsComplete ? (
 					<CompletionCaption completeness={completionRecord[step.id]} />
@@ -132,22 +136,22 @@ export const StepNav = ({
 				return (
 					<Step
 						sx={{
-							paddingBottom: '0.75rem',
-							paddingTop: '0.75rem',
+							paddingBottom: '0.5rem',
+							paddingTop: '0.5rem',
+							flexBasis: '11rem',
 						}}
 						key={step.id}
 						active={isCurrent(step)}
 					>
 						{shouldRenderAsButton(step) ? (
 							<StepButton
+								className="left-aligned-step-button"
 								onClick={() => {
 									handleStepClick(step.id);
 								}}
 								optional={caption}
 							>
-								<b css={{ textDecoration: 'underline' }}>
-									{step.label ?? step.id}
-								</b>
+								<b>{step.label ?? step.id}</b>
 							</StepButton>
 						) : (
 							<StepLabel optional={caption}> {step.label ?? step.id}</StepLabel>

--- a/apps/newsletters-ui/src/app/components/StepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StepNav.tsx
@@ -136,8 +136,7 @@ export const StepNav = ({
 				return (
 					<Step
 						sx={{
-							paddingBottom: '0.5rem',
-							paddingTop: '0.5rem',
+							paddingBottom: '0.25rem',
 							flexBasis: '11rem',
 						}}
 						key={step.id}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Uses props and some custom global CSS to override the styling on the `StepButton`s in our the `StepNav` to give each button a uniform width, left alignment and a hover state.

## How to test

Change is purely visual - try some wizards in the UI

## How can we measure success?

Nav looks neater when wrapping onto multiple lines.

## Have we considered potential risks?

Using global css with classname is a bit of a hack - the pattern is suggested as an option in the docs (https://mui.com/material-ui/api/step-button/#css) but isn't ideal. Relying on it too much would not be maintainable.

## Images

|before|after|
|---|---|
| <img width="854" alt="Screenshot 2023-05-10 at 15 28 36" src="https://github.com/guardian/newsletters-nx/assets/30567854/fe825f49-1c10-4ede-80ad-496682c53493">| <img width="854" alt="Screenshot 2023-05-10 at 15 28 23" src="https://github.com/guardian/newsletters-nx/assets/30567854/fd698c29-d609-41e0-8feb-e84fd2ea6440">|




