### PR TITLE
Adding forwarding rule to api listener to block traffic 

### DIFF
--- a/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
+++ b/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
@@ -95,6 +95,10 @@ exports[`The Newsletters stack matches the snapshot 1`] = `
       "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
+    "SsmParameterValueTESTnewslettersnewslettersapireadOnlyEndpointApiKeyC96584B6F00A464EAD1953AFF4B05118Parameter": {
+      "Default": "/TEST/newsletters/newsletters-api/readOnlyEndpointApiKey",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "SsmParameterValueTESTnewslettersnewslettersapis3BucketNameC96584B6F00A464EAD1953AFF4B05118Parameter": {
       "Default": "/TEST/newsletters/newsletters-api/s3BucketName",
       "Type": "AWS::SSM::Parameter::Value<String>",
@@ -1388,6 +1392,36 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "ReadOnlyApiHeaderRule9E380666": {
+      "Properties": {
+        "Actions": [
+          {
+            "TargetGroupArn": {
+              "Ref": "TargetGroupNewslettersapiDF74F995",
+            },
+            "Type": "forward",
+          },
+        ],
+        "Conditions": [
+          {
+            "Field": "http-header",
+            "HttpHeaderConfig": {
+              "HttpHeaderName": "X-Gu-API-Key",
+              "Values": [
+                {
+                  "Ref": "SsmParameterValueTESTnewslettersnewslettersapireadOnlyEndpointApiKeyC96584B6F00A464EAD1953AFF4B05118Parameter",
+                },
+              ],
+            },
+          },
+        ],
+        "ListenerArn": {
+          "Ref": "ListenerNewslettersapi696961C0",
+        },
+        "Priority": 1,
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
     },
     "TargetGroupNewslettersapiDF74F995": {
       "Properties": {


### PR DESCRIPTION
## What does this change?

We should prevent unauthenicated traffic from reaching the Readonly application to protect us from DDoS attacks

This change adds a rule to the listened for the read-only api whcg checks for a header and value. Where these are present, the request is forwarded to the application

We will automatically add these header for requests from Fastly. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test


Try accessing the applications - requests should fail in the absence of the header and value described in the stacks.

This PR is a WIP - We might choose to move the header name in to the Param store too (and change it from its current value)

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Request without header fail, requests with succeed

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

always

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
