### PR TITLE
Dblatcher theming

### DIFF
--- a/apps/newsletters-ui/index.html
+++ b/apps/newsletters-ui/index.html
@@ -18,18 +18,6 @@
 			body {
 				margin: 0;
 			}
-			.left-aligned-step-button b {
-				text-decoration: underline;
-			}
-			.left-aligned-step-button > .MuiStepLabel-horizontal {
-				flex: 1;
-				text-align: left;
-				min-height: 4rem;
-				transition: background-color 0.5s;
-			}
-			.left-aligned-step-button > .MuiStepLabel-horizontal:hover {
-				background-color: #c1d8fc;
-			}
 		</style>
 
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/apps/newsletters-ui/src/app-theme.ts
+++ b/apps/newsletters-ui/src/app-theme.ts
@@ -1,0 +1,49 @@
+import { palette } from '@guardian/source-foundations';
+import { createTheme } from '@mui/material';
+
+export const appTheme = createTheme({
+	palette: {
+		primary: {
+			light: palette.brand[800],
+			// main: palette.brand[500],
+			main: '#1C5689',
+			dark: palette.brand[400],
+			contrastText: palette.neutral[97],
+		},
+		secondary: {
+			light: palette.news[800],
+			main: palette.news[500],
+			dark: palette.news[400],
+			contrastText: palette.neutral[97],
+		},
+	},
+
+	typography: {
+		allVariants: {
+			fontFamily: 'roboto, arial, sans-serif',
+		},
+		h1: {
+			fontFamily: 'monospace, sans-serif',
+			fontWeight: 700,
+			letterSpacing: '.3rem',
+			fontSize: '1.25rem',
+			lineHeight: '1.6',
+		},
+		h2: {
+			fontFamily: 'monospace, sans-serif',
+			fontSize: '2.25rem',
+		},
+		h3: {
+			fontSize: '1.75rem',
+			fontWeight: 700,
+			marginBottom: '.25rem',
+		},
+	},
+	components: {
+		MuiButton: {
+			defaultProps: {
+				sx: { borderRadius: 0 },
+			},
+		},
+	},
+});

--- a/apps/newsletters-ui/src/app/components/DefaultStyles.tsx
+++ b/apps/newsletters-ui/src/app/components/DefaultStyles.tsx
@@ -1,8 +1,25 @@
 import styled from '@emotion/styled';
 import type { ReactNode } from 'react';
+import { appTheme } from '../../app-theme';
 
 const Styles = styled.div`
 	font-family: 'roboto';
+
+	.left-aligned-step-button {
+		b {
+			text-decoration: underline;
+		}
+
+		& > .MuiStepLabel-horizontal {
+			flex: 1;
+			text-align: left;
+			min-height: 4rem;
+			transition: background-color 0.5s;
+			&:hover {
+				background-color: ${appTheme.palette.primary.light};
+			}
+		}
+	}
 `;
 
 interface DefaultStylesProps {

--- a/apps/newsletters-ui/src/app/components/DraftDetails.tsx
+++ b/apps/newsletters-ui/src/app/components/DraftDetails.tsx
@@ -70,9 +70,7 @@ export const DraftDetails = ({ draft }: Props) => {
 				}}
 			>
 				<CardContent>
-					<Typography sx={{ fontSize: 28, color: palette[100] }}>
-						{draft.name ?? 'UNNAMED DRAFT'}
-					</Typography>
+					<Typography variant="h2">{draft.name ?? 'UNNAMED DRAFT'}</Typography>
 					<Typography sx={{ fontSize: 16 }}>
 						category: {draft.category}
 					</Typography>

--- a/apps/newsletters-ui/src/app/components/MainNav.tsx
+++ b/apps/newsletters-ui/src/app/components/MainNav.tsx
@@ -53,16 +53,13 @@ export function MainNav() {
 						sx={{ display: { xs: 'none', md: 'flex' }, mr: 1 }}
 					/>
 					<Typography
-						variant="h6"
+						variant="h1"
 						noWrap
 						component="a"
 						href="/"
 						sx={{
 							mr: 2,
 							display: { xs: 'none', md: 'flex' },
-							fontFamily: 'monospace',
-							fontWeight: 700,
-							letterSpacing: '.3rem',
 							color: 'inherit',
 							textDecoration: 'none',
 						}}
@@ -117,7 +114,7 @@ export function MainNav() {
 						sx={{ display: { xs: 'flex', md: 'none' }, mr: 1 }}
 					/>
 					<Typography
-						variant="h5"
+						variant="h1"
 						noWrap
 						component="a"
 						href=""
@@ -125,11 +122,10 @@ export function MainNav() {
 							mr: 2,
 							display: { xs: 'flex', md: 'none' },
 							flexGrow: 1,
-							fontFamily: 'monospace',
-							fontWeight: 700,
-							letterSpacing: '.3rem',
 							color: 'inherit',
 							textDecoration: 'none',
+							fontSize: '1.5rem',
+							lineHeight: '1.334',
 						}}
 					>
 						Newsletters

--- a/apps/newsletters-ui/src/app/components/MainNav.tsx
+++ b/apps/newsletters-ui/src/app/components/MainNav.tsx
@@ -46,7 +46,7 @@ export function MainNav() {
 	};
 
 	return (
-		<AppBar position="static" sx={{ bgcolor: '#1C5689' }}>
+		<AppBar position="static">
 			<Container maxWidth="xl">
 				<Toolbar disableGutters>
 					<MailOutlineIcon

--- a/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
+++ b/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
@@ -96,11 +96,7 @@ export const NewsletterDataDetails = ({ newsletter }: Props) => {
 			</DetailAccordian>
 
 			<Stack direction={'row'} justifyContent={'space-between'} marginTop={3}>
-				<NavigateButton
-					href="../"
-					variant="outlined"
-					sx={{ borderRadius: 0, borderColor: '#1C5689', color: '#1C5689' }}
-				>
+				<NavigateButton href="../" variant="outlined" sx={{ borderRadius: 0 }}>
 					Back to List
 				</NavigateButton>
 				<RawDataDialog record={newsletter} title={newsletter.identityName} />

--- a/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
+++ b/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
@@ -96,7 +96,7 @@ export const NewsletterDataDetails = ({ newsletter }: Props) => {
 			</DetailAccordian>
 
 			<Stack direction={'row'} justifyContent={'space-between'} marginTop={3}>
-				<NavigateButton href="../" variant="outlined" sx={{ borderRadius: 0 }}>
+				<NavigateButton href="../" variant="outlined">
 					Back to List
 				</NavigateButton>
 				<RawDataDialog record={newsletter} title={newsletter.identityName} />

--- a/apps/newsletters-ui/src/app/components/RawDataDialog.tsx
+++ b/apps/newsletters-ui/src/app/components/RawDataDialog.tsx
@@ -20,7 +20,7 @@ interface Props {
 	title?: string;
 }
 
-const sxContainedButton = { borderRadius: 0, bgcolor: '#1C5689' };
+const sxContainedButton = { borderRadius: 0 };
 
 export const RawDataDialog = ({ record, title = 'raw data' }: Props) => {
 	const [showRawData, setShowRawData] = useState(false);

--- a/apps/newsletters-ui/src/app/components/RawDataDialog.tsx
+++ b/apps/newsletters-ui/src/app/components/RawDataDialog.tsx
@@ -20,8 +20,6 @@ interface Props {
 	title?: string;
 }
 
-const sxContainedButton = { borderRadius: 0 };
-
 export const RawDataDialog = ({ record, title = 'raw data' }: Props) => {
 	const [showRawData, setShowRawData] = useState(false);
 	const [showClipboardSuccess, setShowClipboardSuccess] = useState(false);
@@ -42,7 +40,6 @@ export const RawDataDialog = ({ record, title = 'raw data' }: Props) => {
 		<>
 			<Button
 				variant="contained"
-				sx={sxContainedButton}
 				onClick={() => {
 					setShowRawData(true);
 				}}
@@ -76,7 +73,6 @@ export const RawDataDialog = ({ record, title = 'raw data' }: Props) => {
 					<Button onClick={copyJson}>copy json</Button>
 					<Button
 						variant="contained"
-						sx={sxContainedButton}
 						onClick={() => {
 							setShowRawData(false);
 						}}

--- a/apps/newsletters-ui/src/app/components/SchemaForm/styling.ts
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/styling.ts
@@ -1,25 +1,8 @@
-import { palette } from '@guardian/source-foundations';
 import { css } from '@mui/material';
-
-const { neutral } = palette;
 
 export const defaultFieldStyle = css`
 	margin-bottom: 0.75rem;
 	max-width: 24rem;
 	display: flex;
 	justify-content: space-between;
-`;
-
-export const defaultFormStyle = css`
-	padding: 0.5rem;
-	margin-bottom: 1rem;
-	max-width: 30rem;
-	background-color: ${neutral[97]};
-
-	legend {
-		display: block;
-		font-weight: bold;
-		border-bottom: 1px solid ${neutral[20]};
-		margin: 0.25rem 0 1rem;
-	}
 `;

--- a/apps/newsletters-ui/src/app/components/SimpleForm.tsx
+++ b/apps/newsletters-ui/src/app/components/SimpleForm.tsx
@@ -1,9 +1,8 @@
-import { Button, Paper } from '@mui/material';
+import { Box, Button, Paper, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
 import type { z } from 'zod';
 import type { FieldDef, FieldValue } from './SchemaForm';
 import { getModification, SchemaForm } from './SchemaForm';
-import { defaultFieldStyle, defaultFormStyle } from './SchemaForm/styling';
 
 type SchemaObjectType<T extends z.ZodRawShape> = {
 	[k in keyof z.objectUtil.addQuestionMarks<{
@@ -113,14 +112,22 @@ export function SimpleForm<T extends z.ZodRawShape>({
 	};
 
 	return (
-		<Paper css={defaultFormStyle} elevation={3}>
-			<legend>{title}</legend>
+		<Box
+			elevation={3}
+			padding={1}
+			component={Paper}
+			maxWidth={'sm'}
+			marginBottom={1.5}
+		>
+			<Typography variant="h3" component={'legend'}>
+				{title}
+			</Typography>
 
-			<div css={defaultFieldStyle}>
+			<Box marginBottom={2}>
 				<Button variant="outlined" onClick={handleReset}>
 					Reset
 				</Button>
-			</div>
+			</Box>
 
 			<SchemaForm
 				schema={schema}
@@ -128,11 +135,11 @@ export function SimpleForm<T extends z.ZodRawShape>({
 				changeValue={manageChange}
 				validationWarnings={warnings}
 			/>
-			<div css={defaultFieldStyle}>
+			<Box marginBottom={2}>
 				<Button variant="contained" onClick={handleSubmit}>
 					{submitButtonText}
 				</Button>
-			</div>
-		</Paper>
+			</Box>
+		</Box>
 	);
 }

--- a/apps/newsletters-ui/src/app/components/StateEditForm.tsx
+++ b/apps/newsletters-ui/src/app/components/StateEditForm.tsx
@@ -1,10 +1,9 @@
-import { Paper } from '@mui/material';
+import { Box, Paper, Typography } from '@mui/material';
 import type { z } from 'zod';
 import { getValidationWarnings } from '@newsletters-nx/newsletters-data-client';
 import type { WizardFormData } from '@newsletters-nx/state-machine';
 import type { FieldDef, FieldValue } from './SchemaForm';
 import { getModification, SchemaForm } from './SchemaForm';
-import { defaultFormStyle } from './SchemaForm/styling';
 
 interface Props {
 	formSchema: z.ZodObject<z.ZodRawShape>;
@@ -24,14 +23,22 @@ export const StateEditForm = ({ formSchema, formData, setFormData }: Props) => {
 	};
 
 	return (
-		<Paper css={defaultFormStyle} elevation={3}>
-			<legend>{formSchema.description}</legend>
+		<Box
+			padding={1}
+			component={Paper}
+			maxWidth={'md'}
+			marginBottom={2.5}
+			elevation={2}
+		>
+			<Typography variant="overline" component={'legend'}>
+				{formSchema.description}
+			</Typography>
 			<SchemaForm
 				schema={formSchema}
 				data={formData}
 				validationWarnings={getValidationWarnings(formData, formSchema)}
 				changeValue={changeFormData}
 			/>
-		</Paper>
+		</Box>
 	);
 };

--- a/apps/newsletters-ui/src/app/components/Wizard.tsx
+++ b/apps/newsletters-ui/src/app/components/Wizard.tsx
@@ -130,19 +130,14 @@ export const Wizard: React.FC<WizardProps> = ({
 		key: string,
 	) => {
 		const primaryActions: WizardButtonType[] = ['NEXT', 'LAUNCH'];
-		const baseStyle = {
-			borderRadius: '0px',
-		};
 
 		const variant = primaryActions.includes(button.buttonType)
 			? 'contained'
 			: 'outlined';
 
-		const styling = baseStyle;
 		return (
 			<Button
 				variant={variant}
-				sx={styling}
 				onClick={() => {
 					onClick(button.id)();
 				}}

--- a/apps/newsletters-ui/src/app/components/Wizard.tsx
+++ b/apps/newsletters-ui/src/app/components/Wizard.tsx
@@ -137,9 +137,8 @@ export const Wizard: React.FC<WizardProps> = ({
 		const variant = primaryActions.includes(button.buttonType)
 			? 'contained'
 			: 'outlined';
-		const styling = primaryActions.includes(button.buttonType)
-			? { ...baseStyle, bgcolor: '#1C5689' }
-			: baseStyle;
+
+		const styling = baseStyle;
 		return (
 			<Button
 				variant={variant}

--- a/apps/newsletters-ui/src/main.tsx
+++ b/apps/newsletters-ui/src/main.tsx
@@ -1,59 +1,12 @@
-import { palette } from '@guardian/source-foundations';
-import { createTheme, ThemeProvider } from '@mui/material';
+import { ThemeProvider } from '@mui/material';
 import { StrictMode } from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { appTheme } from './app-theme';
 import { DefaultStyles } from './app/components/DefaultStyles';
 import { draftRoute } from './app/routes/drafts';
 import { homeRoute } from './app/routes/home';
 import { newslettersRoute } from './app/routes/newsletters';
-
-const theme = createTheme({
-	palette: {
-		primary: {
-			light: palette.brand[800],
-			// main: palette.brand[500],
-			main: '#1C5689',
-			dark: palette.brand[400],
-			contrastText: palette.neutral[97],
-		},
-		secondary: {
-			light: palette.news[800],
-			main: palette.news[500],
-			dark: palette.news[400],
-			contrastText: palette.neutral[97],
-		},
-	},
-
-	typography: {
-		allVariants: {
-			fontFamily: 'roboto, arial, sans-serif',
-		},
-		h1: {
-			fontFamily: 'monospace, sans-serif',
-			fontWeight: 700,
-			letterSpacing: '.3rem',
-			fontSize: '1.25rem',
-			lineHeight: '1.6',
-		},
-		h2: {
-			fontFamily: 'monospace, sans-serif',
-			fontSize: '2.25rem',
-		},
-		h3: {
-			fontSize: '1.75rem',
-			fontWeight: 700,
-			marginBottom: '.25rem',
-		},
-	},
-	components: {
-		MuiButton: {
-			defaultProps: {
-				sx: { borderRadius: 0 },
-			},
-		},
-	},
-});
 
 const router = createBrowserRouter([homeRoute, newslettersRoute, draftRoute]);
 
@@ -63,7 +16,7 @@ const root = ReactDOM.createRoot(
 root.render(
 	<StrictMode>
 		<DefaultStyles>
-			<ThemeProvider theme={theme}>
+			<ThemeProvider theme={appTheme}>
 				<RouterProvider router={router} />
 			</ThemeProvider>
 		</DefaultStyles>

--- a/apps/newsletters-ui/src/main.tsx
+++ b/apps/newsletters-ui/src/main.tsx
@@ -40,6 +40,11 @@ const theme = createTheme({
 			fontFamily: 'monospace, sans-serif',
 			fontSize: '2.25rem',
 		},
+		h3: {
+			fontSize: '1.75rem',
+			fontWeight: 700,
+			marginBottom: '.25rem',
+		},
 	},
 	components: {
 		MuiButton: {

--- a/apps/newsletters-ui/src/main.tsx
+++ b/apps/newsletters-ui/src/main.tsx
@@ -24,6 +24,23 @@ const theme = createTheme({
 			contrastText: palette.neutral[97],
 		},
 	},
+
+	typography: {
+		allVariants: {
+			fontFamily: 'roboto, arial, sans-serif',
+		},
+		h1: {
+			fontFamily: 'monospace, sans-serif',
+			fontWeight: 700,
+			letterSpacing: '.3rem',
+			fontSize: '1.25rem',
+			lineHeight: '1.6',
+		},
+		h2: {
+			fontFamily: 'monospace, sans-serif',
+			fontSize: '2.25rem',
+		},
+	},
 	components: {
 		MuiButton: {
 			defaultProps: {

--- a/apps/newsletters-ui/src/main.tsx
+++ b/apps/newsletters-ui/src/main.tsx
@@ -18,6 +18,13 @@ const theme = createTheme({
 			contrastText: palette.neutral[97],
 		},
 	},
+	components: {
+		MuiButton: {
+			defaultProps: {
+				sx: { borderRadius: 0 },
+			},
+		},
+	},
 });
 
 const router = createBrowserRouter([homeRoute, newslettersRoute, draftRoute]);

--- a/apps/newsletters-ui/src/main.tsx
+++ b/apps/newsletters-ui/src/main.tsx
@@ -1,3 +1,5 @@
+import { palette } from '@guardian/source-foundations';
+import { createTheme, ThemeProvider } from '@mui/material';
 import { StrictMode } from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
@@ -5,6 +7,18 @@ import { DefaultStyles } from './app/components/DefaultStyles';
 import { draftRoute } from './app/routes/drafts';
 import { homeRoute } from './app/routes/home';
 import { newslettersRoute } from './app/routes/newsletters';
+
+const theme = createTheme({
+	palette: {
+		primary: {
+			light: palette.brand[800],
+			// main: palette.brand[500],
+			main: '#1C5689',
+			dark: palette.brand[400],
+			contrastText: palette.neutral[97],
+		},
+	},
+});
 
 const router = createBrowserRouter([homeRoute, newslettersRoute, draftRoute]);
 
@@ -14,7 +28,9 @@ const root = ReactDOM.createRoot(
 root.render(
 	<StrictMode>
 		<DefaultStyles>
-			<RouterProvider router={router} />
+			<ThemeProvider theme={theme}>
+				<RouterProvider router={router} />
+			</ThemeProvider>
 		</DefaultStyles>
 	</StrictMode>,
 );

--- a/apps/newsletters-ui/src/main.tsx
+++ b/apps/newsletters-ui/src/main.tsx
@@ -17,6 +17,12 @@ const theme = createTheme({
 			dark: palette.brand[400],
 			contrastText: palette.neutral[97],
 		},
+		secondary: {
+			light: palette.news[800],
+			main: palette.news[500],
+			dark: palette.news[400],
+			contrastText: palette.neutral[97],
+		},
 	},
 	components: {
 		MuiButton: {


### PR DESCRIPTION
## What does this change?

 - sets up a `ThemeProvider` in the root component applying the following to MUI components:
   - a "primary" color theme based on the source palette "brand" values (and the shade of blue we were manually setting) - not very noticeable as the MUI default primary theme happens to use similar shades of blue
   - a "secondary" color theme based on source  palette "news" values (we don't use secondary colors much)
   - borderRadius:0 for buttons by default
   - typography values, for h1 ("newsletters" in app header nav) , h2 (newsletter and draft summary pages)
 - moves the css for the StepNav buttons out of the html template and into the existing `DefaultStyles` component
 - replaces some of the custom styling for forms using Mui component props. 
 - removes the manual styling on buttons that is not handled by the theme,

## How to test

Adjust the values in apps/newsletters-ui/src/app-theme.ts to see how they impact the appearance of the app.

Note that not every component uses MUI - those that don't will not be effected by the theme (sidenote - changing the font-family in apps/newsletters-ui/src/app/components/DefaultStyles.tsx is a good way to see which components are not usin MUI)

## How can we measure success?

Easier to consistently apply styling throughout the app. Should make design feedback easier to implement

## Have we considered potential risks?

Does tie use closer to MUI.

## Images
<img width="475" alt="Screenshot 2023-05-15 at 17 21 06" src="https://github.com/guardian/newsletters-nx/assets/30567854/3d9102b8-f9b9-49af-9699-8a1f672bb6df">

