### PR TITLE
Add combined validation for Read More configurations

### DIFF
--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/readMoreLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/readMoreLayout.ts
@@ -45,10 +45,35 @@ export const readMoreLayout: WizardStepLayout<DraftStorage> = {
 			stepToMoveTo: getPreviousOrEditStartStepId,
 			executeStep: executeModify,
 		},
-		finish: {
+		next: {
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
+			onBeforeStepChangeValidate: (stepData): string | undefined => {
+				const readMoreDetails = stepData.formData
+					? (stepData.formData[
+							'renderingOptions.readMoreSections'
+					  ] as unknown as Array<{
+							subheading: string;
+							wording: string;
+							url: string;
+					  }>)
+					: undefined;
+				if (readMoreDetails) {
+					if (Array.isArray(readMoreDetails)) {
+						const invalidReadMoreDetails = readMoreDetails.filter(
+							(readMoreEntry) =>
+								!readMoreEntry.subheading ||
+								!readMoreEntry.wording ||
+								!readMoreEntry.url,
+						);
+						if (invalidReadMoreDetails.length > 0) {
+							return 'ALL READ MORE DETAILS MUST BE SPECIFIED FOR A CONFIGURATION';
+						}
+					}
+				}
+				return undefined;
+			},
 			executeStep: executeModify,
 		},
 	},


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Although the “Read More” fields are optional, if the user enters one, they need to enter them all, so this PR adds validation to ensure this

## How to test

Run `npm run dev`
From the list of drafts, click Edit | Article Rendering for an article based newsletter
Navigate to the Read More Sections step and click on ADD NEW ITEM
Ensure that it's not possible to click Next from the step unless all three fields have been populated

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![Screenshot 2023-05-18 at 11 08 08](https://github.com/guardian/newsletters-nx/assets/74301289/8aee3a67-2efb-4f03-8e95-a761a3b6b673)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
