### PR TITLE
Update link to launch wizard

### DIFF
--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/finishLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/finishLayout.ts
@@ -10,7 +10,7 @@ Congratulations, you have reached the end of the wizard for newsletter **{{name}
 
 You can see your draft on the [details page](drafts/{{listId}}), which includes the options to edit the data you have provided and provide additional details.
 
-Once all the data required to create **{{name}}** has been specified, the newsletter [can be launched](/demo/launch-newsletter/{{listId}}).
+Once all the data required to create **{{name}}** has been specified, the newsletter [can be launched](/newsletters/launch-newsletter/{{listId}}).
 `;
 
 const staticMarkdown = markdownTemplate.replace(regExPatterns.name, '');


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Fixes the bug on the Finish page of the data collection wizard where the "can be launched" hyperlink led to a "Not Found" page

## How to test

Run `npm run dev`
Navigate to the Finish page of the data collection wizard for a draft newsletter and click the hyperlink

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

David has suggested that there is a better way of handling the routing so that it would not need to be changed in multiple places when updated.  This PR merely fixes the existing bug: improvements will be addressed separately.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
