### PR TITLE
remove custom validation for tag layout

### DIFF
--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/tagsLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/tagsLayout.ts
@@ -59,27 +59,6 @@ export const tagsLayout: WizardStepLayout<DraftStorage> = {
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
-			onBeforeStepChangeValidate: (stepData): string | undefined => {
-				const seriesTag = stepData.formData
-					? stepData.formData['seriesTag']
-					: undefined;
-				if (!seriesTag) return 'NO SERIES TAG PROVIDED';
-				const composerTag = stepData.formData
-					? stepData.formData['composerTag']
-					: undefined;
-				const composerCampaignTag = stepData.formData
-					? stepData.formData['composerCampaignTag']
-					: undefined;
-				if (composerTag || composerCampaignTag) {
-					if (!composerTag) {
-						return 'ENTER AT LEAST ONE COMPOSER TAG IF SPECIFYING COMPOSER CAMPAIGN TAG';
-					}
-					if (!composerCampaignTag) {
-						return 'ENTER COMPOSER CAMPAIGN TAG IF SPECIFYING COMPOSER TAG';
-					}
-				}
-				return undefined;
-			},
 			executeStep: executeModify,
 		},
 	},


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

ticket: https://trello.com/c/5LkKLvmj/446-error-in-breadcrumb-completeness
**issue:**
The breadcrumbs claim that Tag Setup is complete, but I can’t move off the step because series tag has not been entered

This is because the custom onBeforeStepChangeValidate hook in the tagLayout required all the fields to be populated, even though they are optional on the schema (which is what drives the breadcrumbs).

We don’t actually need the validate hook here - if we did want to require the field to be filled in, we can do it on the formSchema object.

**resolution**:
remove the hook


## How to test

clicking next on the Tag step with all the fields empty(the values are optional strings) will be accepted.
