### PR TITLE
add floating action button to navigate to new draft wizard

### DIFF
--- a/apps/newsletters-ui/src/app/components/DraftsTable.tsx
+++ b/apps/newsletters-ui/src/app/components/DraftsTable.tsx
@@ -139,7 +139,7 @@ export const DraftsTable = ({ drafts }: Props) => {
 	);
 	return (
 		<>
-			<Table data={data} columns={columns} defaultSortId="name" />;
+			<Table data={data} columns={columns} defaultSortId="name" />
 			<EditDraftDialog
 				draft={draftInDialog}
 				close={() => {

--- a/apps/newsletters-ui/src/app/components/NavigateFab.tsx
+++ b/apps/newsletters-ui/src/app/components/NavigateFab.tsx
@@ -1,0 +1,33 @@
+import type { FabProps } from '@mui/material';
+import { Fab } from '@mui/material';
+import type { MouseEventHandler, ReactNode } from 'react';
+import { useNavigate } from 'react-router';
+
+type Props = FabProps & {
+	href?: string;
+	children: ReactNode;
+};
+
+export const NavigateFab = (props: Props) => {
+	const navigate = useNavigate();
+	const { children, href } = props;
+
+	if (!href) {
+		return (
+			<Fab {...props} disabled>
+				{children}
+			</Fab>
+		);
+	}
+
+	const onClick: MouseEventHandler = (event) => {
+		event.preventDefault();
+		navigate(href);
+	};
+
+	return (
+		<Fab {...props} onClick={onClick}>
+			{children}
+		</Fab>
+	);
+};

--- a/apps/newsletters-ui/src/app/components/views/DraftListView.tsx
+++ b/apps/newsletters-ui/src/app/components/views/DraftListView.tsx
@@ -19,7 +19,7 @@ export const DraftListView = () => {
 				<Box paddingX={1} display={'flex'} justifyContent={'flex-end'}>
 					<NavigateFab
 						href="/newsletters/newsletter-data"
-						color="success"
+						color="primary"
 						variant="extended"
 					>
 						create new draft

--- a/apps/newsletters-ui/src/app/components/views/DraftListView.tsx
+++ b/apps/newsletters-ui/src/app/components/views/DraftListView.tsx
@@ -21,6 +21,7 @@ export const DraftListView = () => {
 						href="/newsletters/newsletter-data"
 						color="primary"
 						variant="extended"
+						aria-label="open create new draft wizard"
 					>
 						create new draft
 						<AddIcon />

--- a/apps/newsletters-ui/src/app/components/views/DraftListView.tsx
+++ b/apps/newsletters-ui/src/app/components/views/DraftListView.tsx
@@ -1,6 +1,9 @@
+import AddIcon from '@mui/icons-material/Add';
+import { Box, Container } from '@mui/material';
 import { useLoaderData } from 'react-router-dom';
 import { isDraft } from '@newsletters-nx/newsletters-data-client';
 import { DraftsTable } from '../DraftsTable';
+import { NavigateFab } from '../NavigateFab';
 
 export const DraftListView = () => {
 	const list = useLoaderData();
@@ -9,5 +12,21 @@ export const DraftListView = () => {
 	}
 
 	const drafts = list.filter(isDraft);
-	return <DraftsTable drafts={drafts} />;
+	return (
+		<>
+			<DraftsTable drafts={drafts} />
+			<Container maxWidth="lg">
+				<Box paddingX={1} display={'flex'} justifyContent={'flex-end'}>
+					<NavigateFab
+						href="/newsletters/newsletter-data"
+						color="success"
+						variant="extended"
+					>
+						create new draft
+						<AddIcon />
+					</NavigateFab>
+				</Box>
+			</Container>
+		</>
+	);
 };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

https://trello.com/c/NC6klp3W/450-list-of-drafts

Adds a "create new draft" button to the the draft list page, below the table


## Images


<img width="1350" alt="Screenshot 2023-05-19 at 13 03 06" src="https://github.com/guardian/newsletters-nx/assets/30567854/908e9708-abe7-4411-8836-a7229513a750">

## Accessibility
Button is keyboard accessible using tab and has an aria label. MUI provides hover/focus effects by default.
