### PR TITLE
custom markdown elements with external links

### DIFF
--- a/apps/newsletters-ui/src/app-theme.ts
+++ b/apps/newsletters-ui/src/app-theme.ts
@@ -30,12 +30,14 @@ export const appTheme = createTheme({
 			lineHeight: '1.6',
 		},
 		h2: {
-			fontFamily: 'monospace, sans-serif',
-			fontSize: '2.25rem',
+			fontSize: '2rem',
+			marginBottom: '.25rem',
+			borderBottomWidth: 1,
+			borderBottomColor: 'primary.dark',
+			borderBottomStyle: 'solid',
 		},
 		h3: {
-			fontSize: '1.75rem',
-			fontWeight: 700,
+			fontSize: '1.5rem',
 			marginBottom: '.25rem',
 		},
 	},

--- a/apps/newsletters-ui/src/app/components/MarkdownView.tsx
+++ b/apps/newsletters-ui/src/app/components/MarkdownView.tsx
@@ -1,13 +1,52 @@
+import { Typography } from '@mui/material';
+import type { ReactNode } from 'react';
 import ReactMarkdown from 'react-markdown';
 
 interface MarkdownViewProps {
 	markdown: string;
 }
 
+const isExternal = (href?: string) => !href?.startsWith('/');
+
+const LinkWithNewTabIfExternal = (props: {
+	children: ReactNode;
+	href?: string;
+}) => {
+	const extraProps = {
+		target: isExternal(props.href) ? '_blank' : undefined,
+	};
+
+	return (
+		<a href={props.href} {...extraProps}>
+			{props.children}
+		</a>
+	);
+};
+
+const TypographyH2 = (props: { children: ReactNode }) => {
+	return <Typography variant="h2">{props.children}</Typography>;
+};
+const TypographyH3 = (props: { children: ReactNode }) => {
+	return <Typography variant="h3">{props.children}</Typography>;
+};
+const TypographyP = (props: { children: ReactNode }) => {
+	return <Typography marginBottom={1}>{props.children}</Typography>;
+};
+
 export const MarkdownView: React.FC<MarkdownViewProps> = ({ markdown }) => {
 	return (
 		<div className="markdown-block">
-			<ReactMarkdown>{markdown}</ReactMarkdown>
+			<ReactMarkdown
+				components={{
+					a: LinkWithNewTabIfExternal,
+					h1: TypographyH2,
+					h2: TypographyH2,
+					h3: TypographyH3,
+					p: TypographyP,
+				}}
+			>
+				{markdown}
+			</ReactMarkdown>
 		</div>
 	);
 };

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/brazeLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/brazeLayout.ts
@@ -8,7 +8,7 @@ import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 
 const markdownTemplate = `
-# Braze Values
+## Braze Values
 
 These are tracking fields used by Braze.
 

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/cancelLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/cancelLayout.ts
@@ -2,7 +2,7 @@ import type { LaunchService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 
 const markdownToDisplay = `
-# Cancelled
+## Cancelled
 
 Launch of the newsletter was cancelled.
 `.trim();

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/editBrazeLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/editBrazeLayout.ts
@@ -10,7 +10,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
 
 const markdownTemplate = `
-# Modify Braze Values
+## Modify Braze Values
 
 These are tracking fields used by Braze.
 

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/editIdentityNameLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/editIdentityNameLayout.ts
@@ -10,7 +10,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
 
 const markdownTemplate = `
-# Modify Identity Name
+## Modify Identity Name
 
 This is a unique identifier for the newsletter, used internally by the system and not displayed to newsletter readers.
 

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/editOphanLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/editOphanLayout.ts
@@ -10,7 +10,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
 
 const markdownTemplate = `
-# Modify Ophan Campaign Values
+## Modify Ophan Campaign Values
 
 These are tracking fields used by Ophan.
 

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/emailCentralProductionLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/emailCentralProductionLayout.ts
@@ -4,7 +4,7 @@ import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 
 const markdownTemplate = `
-# Emailing Central Production
+## Emailing Central Production
 
 ***DEPENDING ON THE DATA ENTERED ON THE TAGS PAGE OF THE WIZARD, RENDER ONE OF THE FOLLOWING***
 

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/finishLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/finishLayout.ts
@@ -3,7 +3,7 @@ import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 
-const markdownTemplate = `# Finished
+const markdownTemplate = `## Finished
 
 You have reached the end of the wizard. **{{name}}** has been launched!
 

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/identityNameLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/identityNameLayout.ts
@@ -5,7 +5,7 @@ import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 
 const markdownTemplate = `
-# Identity Name
+## Identity Name
 
 This is a unique identifier for the newsletter, used internally by the system and not displayed to newsletter readers.
 

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/noItem.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/noItem.ts
@@ -2,7 +2,7 @@ import type { LaunchService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 
 export const noItemLayout: WizardStepLayout<LaunchService> = {
-	staticMarkdown: `# Launch a newsletter
+	staticMarkdown: `## Launch a newsletter
 
 This wizard will guide you through the process of launching a new newsletter using email-rendering.
 

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/ophanLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/ophanLayout.ts
@@ -8,7 +8,7 @@ import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 
 const markdownTemplate = `
-# Ophan Campaign Values
+## Ophan Campaign Values
 
 These are tracking fields used by Ophan.
 

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/cancelLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/cancelLayout.ts
@@ -2,7 +2,7 @@ import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 
 const markdownToDisplay = `
-# Cancelled
+## Cancelled
 
 Collection of newsletter data was cancelled.
 `.trim();

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/categoryLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/categoryLayout.ts
@@ -13,7 +13,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from './formSchemas';
 
 const markdownTemplate = `
-# How will {{name}} be produced?
+## How will {{name}} be produced?
 
 Editorial newsletters can be produced in three ways:
 

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/dateLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/dateLayout.ts
@@ -11,15 +11,15 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from './formSchemas';
 
 const markdownTemplate = `
-# Tell us about your launch date and promotion plans for {{name}}
+## Tell us about your launch date and promotion plans for {{name}}
 
-## Launch
+### Launch
 
 When will the first send of **{{name}}** be?  Please specify the time and date.
 
 This needs to be added in the UK timezone so the system can process this information correctly.
 
-## Promotion
+### Promotion
 
 Will **{{name}}** be promoted (e.g. on thrashers) ahead of the launch day?  If so:
 
@@ -27,7 +27,7 @@ Will **{{name}}** be promoted (e.g. on thrashers) ahead of the launch day?  If s
 
 - What date will the thrashers go live?
 
-## Testing
+### Testing
 
 Please note that we will automatically add a testing period for the newsletter of 1 week before the first send.
 

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/editDraftNewsletterLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/editDraftNewsletterLayout.ts
@@ -7,7 +7,7 @@ import { getDraftFromStorage } from '../../getDraftFromStorage';
 import { formSchemas } from './formSchemas';
 
 export const editDraftNewsletterLayout: WizardStepLayout<DraftStorage> = {
-	staticMarkdown: `# Name Your Newsletter
+	staticMarkdown: `## Name Your Newsletter
 
 The first step is to enter the name for your newsletter, for example **Down to Earth**.
 

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/frequencyLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/frequencyLayout.ts
@@ -8,7 +8,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from './formSchemas';
 
 const markdownTemplate = `
-# Specify the send frequency of {{name}}
+## Specify the send frequency of {{name}}
 
 Specify how regularly the newsletter will be sent e.g.
 - Every day

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/multiThrashersLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/multiThrashersLayout.ts
@@ -10,7 +10,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
 
 const markdownTemplate = `
-# Multi-Thrashers for {{name}}
+## Multi-Thrashers for {{name}}
 
 A multi-thrasher comprises three or more newsletter thrashers.
 

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/newsletterDesignLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/newsletterDesignLayout.ts
@@ -11,7 +11,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from './formSchemas';
 
 const markdownTemplate = `
-# Add the design brief and Figma design link for {{name}}
+## Add the design brief and Figma design link for {{name}}
 
 Please share the following for **{{name}}**:
 - The design brief Google document URL

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/onlineArticleLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/onlineArticleLayout.ts
@@ -14,7 +14,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from './formSchemas';
 
 const markdownTemplate = `
-# Will {{name}} be an online article?
+## Will {{name}} be an online article?
 
 Tell us if the newsletter will appear as a web article.
 

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/pillarAndGroupLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/pillarAndGroupLayout.ts
@@ -11,7 +11,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from './formSchemas';
 
 const markdownTemplate = `
-# Choose the Pillar and Group for {{name}}
+## Choose the Pillar and Group for {{name}}
 
 Select a pillar for the newsletter e.g. **Football Daily** sits under the **Sport** pillar.
 

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/regionFocusLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/regionFocusLayout.ts
@@ -14,7 +14,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from './formSchemas';
 
 const markdownTemplate = `
-# Choose the Geo Focus for {{name}}
+## Choose the Geo Focus for {{name}}
 
 What’s the geo focus of **{{name}}**? UK, US, Australia or International??
 

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/signUpEmbedLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/signUpEmbedLayout.ts
@@ -14,7 +14,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from './formSchemas';
 
 const markdownTemplate = `
-# Specify the sign up embed copy
+## Specify the sign up embed copy
 
 Please enter the description for the sign up embed for **{{name}}**
 

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/signUpPageLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/signUpPageLayout.ts
@@ -14,7 +14,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from './formSchemas';
 
 const markdownTemplate = `
-# Specify the sign up page copy
+## Specify the sign up page copy
 
 Please enter the headline and description for the sign up page for **{{name}}**
 

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/singleThrasherLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/singleThrasherLayout.ts
@@ -11,7 +11,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from './formSchemas';
 
 const markdownTemplate = `
-# Specify the single thrasher setup for {{name}}
+## Specify the single thrasher setup for {{name}}
 
 Do you need a single thrasher?
 

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/tagsLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/tagsLayout.ts
@@ -11,9 +11,9 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from './formSchemas';
 
 const markdownTemplate = `
-# Specify the tag setup for {{name}}
+## Specify the tag setup for {{name}}
 
-## Series Tag
+### Series Tag
 
 Please share the series tag URL for the newsletter.
 
@@ -21,7 +21,7 @@ For example: [tv-and-radio/series/what-s-on-tv](https://www.theguardian.com/tv-a
 
 *If the tag does not already exist, an email will automatically be sent to Central Production to request its production.*
 
-## Composer tag relationship for newsletter embeds
+### Composer tag relationship for newsletter embeds
 
 In Composer, we now have a feature where a newsletter signup embed is proposed to the user once a tag is added to the article - find out more [here](https://docs.google.com/document/d/1HC_Y6kOStrBNwQR322N8NdiCuhyIjlUke5RWmsRUcpM/edit).
 

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/cancelLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/cancelLayout.ts
@@ -2,7 +2,7 @@ import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 
 const markdownToDisplay = `
-# Cancelled
+## Cancelled
 
 Setting the render options was cancelled.
 `.trim();

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/finishLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/finishLayout.ts
@@ -5,7 +5,7 @@ import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 
-const markdownTemplate = `# Finished
+const markdownTemplate = `## Finished
 
 You have reached the end of the wizard.
 

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/footerLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/footerLayout.ts
@@ -10,7 +10,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
 
 const markdownTemplate = `
-# Specify the footer setup for {{name}}
+## Specify the footer setup for {{name}}
 
 What email address would you like to display in the footer of **{{name}}**?
 

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/imageLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/imageLayout.ts
@@ -10,7 +10,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
 
 const markdownTemplate = `
-# Specify the image caption setup for {{name}}
+## Specify the image caption setup for {{name}}
 
 Would you like captions to be displayed within the newsletter?
 

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/linkListLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/linkListLayout.ts
@@ -10,7 +10,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
 
 const markdownTemplate = `
-# Rendering 'Link List' sections in {{name}}
+## Rendering 'Link List' sections in {{name}}
 
 You may want to display some sections in **{{name}}** with LinkList styling.
 

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/newsletterHeaderLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/newsletterHeaderLayout.ts
@@ -10,9 +10,9 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
 
 const markdownTemplate = `
-# Specify the header setup for {{name}}
+## Specify the header setup for {{name}}
 
-## Date
+### Date
 
 Should the publication date display in each edition?
 
@@ -20,7 +20,7 @@ This is typically shown for daily emails, but not for weekly ones.
 
 ![Date](https://i.guim.co.uk/img/uploads/2023/03/15/Date.png?quality=85&dpr=2&width=300&s=815d857cb40089e47f501bf6d5838c2a)
 
-## Standfirst
+### Standfirst
 
 Would you like this to be displayed?
 

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/podcastLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/podcastLayout.ts
@@ -10,7 +10,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
 
 const markdownTemplate = `
-# Rendering Podcast sections in {{name}}
+## Rendering Podcast sections in {{name}}
 
 You may want to display some sections in **{{name}}** as Podcast sections.
 

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/readMoreLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/readMoreLayout.ts
@@ -10,7 +10,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
 
 const markdownTemplate = `
-# Rendering 'Read More' sections in {{name}}
+## Rendering 'Read More' sections in {{name}}
 
 At the end of some sections in **{{name}}** you may wish to have a link encouraging the reader to 'Read more on the Guardian'.
 

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/startLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/startLayout.ts
@@ -5,7 +5,7 @@ import { executeModify } from '../../executeModify';
 import { getDraftFromStorage } from '../../getDraftFromStorage';
 
 export const startLayout: WizardStepLayout<DraftStorage> = {
-	staticMarkdown: `# Set Rendering Template Options
+	staticMarkdown: `## Set Rendering Template Options
 
 This wizard is to choose the options for how an article-based newsletter will appear in Email-rendering.
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Uses custom elements for the Markdown view so that:
 - external links (absolute urls) will open a new tab - see: https://trello.com/c/Neyrd3wr/448-pillar-and-group-step
 - headings and paragraphs in Markdown use the `Typography` component and therefore pick up the appTheme styling

Adjusts the theming for h2 and h3 so they look nice on wizard / markdown pages

## How to test

the link to the allnewsletter page in the pillar-and-group step will open a new tab. internal links to other UI pages will stay in the same tab.

## How can we measure success?

Happier users. Markdown can be made consistent with the rest of the app.

NOTE - if we wanted any markdown text to look distinct, we could make a different MUI theme for it and wrap the `MarkdownView` in another `ThemeProvider`.

## Images
<img width="1350" alt="Screenshot 2023-05-19 at 15 16 52" src="https://github.com/guardian/newsletters-nx/assets/30567854/8f5b29e5-c225-4f9f-8c88-d95c05dbb71f">
