### PR TITLE
Dblatcher no nx cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,26 +11,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  main:
-    name: Nx Cloud - Main Job
-    uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.11.3
-    with:
-      number-of-agents: 3
-      init-commands: |
-        npx nx-cloud start-ci-run --stop-agents-after="build" --agent-count=3
-      parallel-commands: |
-        npx nx-cloud record -- npx nx format:check
-      parallel-commands-on-agents: |
-        npx nx affected --target=lint
-        npx nx affected --target=test --ci --code-coverage
-        npx nx affected --target=build --with-deps --configuration=production
-
-  agents:
-    name: Nx Cloud - Agents
-    uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.11.3
-    with:
-      number-of-agents: 3
-
   deploy:
     name: Upload artifacts to riffraff
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ Run `nx graph` to see a diagram of the dependencies of the projects.
 
 Run `npx nx connect-to-nx-cloud` to enable [remote caching](https://nx.app) and make CI faster.
 
+**NOTE** - we decided to not use remote caching to simplify the set-up and to avoid uncertainty on how to best manange the user account needed to 'claim' the Workspace in nx-cloud. See https://nx.dev/core-features/share-your-cache#connecting-your-workspace-to-your-nx-cloud-account
+
+Remote caching had been set up and was working without 'claiming' the workspace, but an unexpected change in nx policy(?) caused [CI errors](https://github.com/guardian/newsletters-nx/actions/runs/5043176034/jobs/9044634561?pr=136) of:
+
+`"NX Error when connecting to Nx Cloud. Code: 401. Error: This workspace is more than a week old and is unclaimed. Workspaces must be claimed within 7 days of creation.."`
+
 ### Further help
 
 Visit the [Nx Documentation](https://nx.dev) to learn more.

--- a/nx.json
+++ b/nx.json
@@ -3,10 +3,10 @@
 	"npmScope": "newsletters-nx",
 	"tasksRunnerOptions": {
 		"default": {
-			"runner": "@nrwl/nx-cloud",
+			"runner": "nx/tasks-runners/default",
 			"options": {
 				"cacheableOperations": ["build", "lint", "test", "e2e"],
-				"accessToken": "ZjJiM2YxYjMtYTBlZi00ZTdiLThiNzUtMTYwY2Q2MDc4Y2M4fHJlYWQtd3JpdGU="
+				"runtimeCacheInputs": ["node -v"]
 			}
 		}
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
 				"@nrwl/jest": "15.9.2",
 				"@nrwl/linter": "15.9.2",
 				"@nrwl/node": "15.9.2",
-				"@nrwl/nx-cloud": "15.3.5",
 				"@nrwl/react": "15.9.2",
 				"@nrwl/vite": "15.9.2",
 				"@nrwl/workspace": "15.9.2",
@@ -7443,109 +7442,6 @@
 				"tslib": "^2.3.0"
 			}
 		},
-		"node_modules/@nrwl/nx-cloud": {
-			"version": "15.3.5",
-			"resolved": "https://registry.npmjs.org/@nrwl/nx-cloud/-/nx-cloud-15.3.5.tgz",
-			"integrity": "sha512-JMKLY0HhdzQ/6jEvfL/EecPPdsdBIM0SyFrWAjikSJAh5MqhpFJWnr6FfTc5P57PJZ+IUNLkJ21VMuoTrA4+4w==",
-			"dev": true,
-			"dependencies": {
-				"axios": "^0.21.2",
-				"chalk": "4.1.0",
-				"dotenv": "~10.0.0",
-				"fs-extra": "^10.1.0",
-				"node-machine-id": "^1.1.12",
-				"strip-json-comments": "^3.1.1",
-				"tar": "6.1.11",
-				"yargs-parser": ">=21.0.1"
-			},
-			"bin": {
-				"nx-cloud": "bin/nx-cloud.js"
-			}
-		},
-		"node_modules/@nrwl/nx-cloud/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@nrwl/nx-cloud/node_modules/chalk": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-			"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/@nrwl/nx-cloud/node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/@nrwl/nx-cloud/node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true
-		},
-		"node_modules/@nrwl/nx-cloud/node_modules/fs-extra": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-			"dev": true,
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@nrwl/nx-cloud/node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@nrwl/nx-cloud/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/@nrwl/nx-darwin-arm64": {
 			"version": "15.9.2",
 			"resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-arm64/-/nx-darwin-arm64-15.9.2.tgz",
@@ -10229,15 +10125,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/axios": {
-			"version": "0.21.4",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-			"integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-			"dev": true,
-			"dependencies": {
-				"follow-redirects": "^1.14.0"
-			}
-		},
 		"node_modules/axobject-query": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -11158,15 +11045,6 @@
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
-			}
-		},
-		"node_modules/chownr": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/chrome-trace-event": {
@@ -14850,18 +14728,6 @@
 			},
 			"engines": {
 				"node": ">=14.14"
-			}
-		},
-		"node_modules/fs-minipass": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-			"dev": true,
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
 			}
 		},
 		"node_modules/fs-monkey": {
@@ -21659,43 +21525,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"dev": true,
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/minipass/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
-		},
-		"node_modules/minizlib": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-			"dev": true,
-			"dependencies": {
-				"minipass": "^3.0.0",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/minizlib/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
-		},
 		"node_modules/mkdirp": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -21846,12 +21675,6 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
 			"integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-			"dev": true
-		},
-		"node_modules/node-machine-id": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.12.tgz",
-			"integrity": "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ==",
 			"dev": true
 		},
 		"node_modules/node-releases": {
@@ -25015,23 +24838,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/tar": {
-			"version": "6.1.11",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-			"integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-			"dev": true,
-			"dependencies": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^3.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">= 10"
-			}
-		},
 		"node_modules/tar-stream": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -25061,12 +24867,6 @@
 			"engines": {
 				"node": ">= 6"
 			}
-		},
-		"node_modules/tar/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
 		},
 		"node_modules/terminal-link": {
 			"version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
 		"@nrwl/jest": "15.9.2",
 		"@nrwl/linter": "15.9.2",
 		"@nrwl/node": "15.9.2",
-		"@nrwl/nx-cloud": "15.3.5",
 		"@nrwl/react": "15.9.2",
 		"@nrwl/vite": "15.9.2",
 		"@nrwl/workspace": "15.9.2",


### PR DESCRIPTION
## What does this change?

Uninstalls the nx-cloud dependency and removes the configuration that uses it. Builds will use local caching, rather than remote caching.

We decided to do this after the [builds stopped working](https://github.com/guardian/newsletters-nx/actions/runs/5043176034/jobs/9044634561?pr=136) because we hadn't signed up for an NX account to claim the cache.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Able to run CI without managing an NX cloud account.

## Have we considered potential risks?

Builds will sometimes be slower locally - we can't use a cached build of a project built by and other developer and pushed to the cloud.

CI builds in github will be slower. Previously, PR's that only changed one project (EG the UI) did not need to build the depended projects (EG the data-client) for testing as they could take the compiled code from the remote cache (I think that was how it worked).
