### PR TITLE
re-adding lint and test steps to PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
   deploy:
-    name: Upload artifacts to riffraff
+    name: Build, test and deploy to riff-raff
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -33,6 +34,9 @@ jobs:
       - name: Install deps
         run: |
           npm ci
+          npm run lint
+          npm run test
+
 
       - name: Bundle and zip
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
       - name: Install deps
         run: |
           npm ci
+      - name: lint and test
+        run: |
           npm run lint
           npm run test
 


### PR DESCRIPTION
## What does this change?

An earlier PR removed the NX cloud cache enabled PR checks - this inadvertently also removed the linting and testing steps from PRs. This PR re-adds those.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Check that the lint and test steps are present in the checks for this PR


## Have we considered potential risks?

Always


![Screenshot 2023-05-23 at 08 07 28](https://github.com/guardian/newsletters-nx/assets/3277259/f6b8de2c-2df0-49b7-b24a-d8879818ba63)

