### PR TITLE
Dblatcher whoami

### DIFF
--- a/apps/newsletters-api/src/apiDeploymentSettings.ts
+++ b/apps/newsletters-api/src/apiDeploymentSettings.ts
@@ -46,3 +46,7 @@ export const isServingReadEndpoints = () => {
 
 export const isUsingInMemoryStorage = () =>
 	process.env.USE_IN_MEMORY_STORAGE === 'true';
+
+export const getTestJwtProfileDataIfUsing = () => {
+	return process.env.USE_FAKE_JWT === 'true' ? process.env.FAKE_JWT : undefined;
+};

--- a/apps/newsletters-api/src/app/routes/user.ts
+++ b/apps/newsletters-api/src/app/routes/user.ts
@@ -1,9 +1,38 @@
 import type { FastifyInstance } from 'fastify';
 
-const fakeCookie = process.env.FAKE_COOKIE;
+const { FAKE_JWT } = process.env;
+
+const USE_FAKE_JWT = true as boolean;
+
+const atob = (a: string) => Buffer.from(a, 'base64').toString('binary');
+
+function parseJwt(token: string): Partial<Record<string, string>> {
+	try {
+		const base64Url = token.split('.')[1] as string;
+		const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+		const jsonPayload = decodeURIComponent(
+			atob(base64)
+				.split('')
+				.map(function (c) {
+					return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+				})
+				.join(''),
+		);
+		return JSON.parse(jsonPayload) as Partial<Record<string, string>>;
+	} catch (err: unknown) {
+		console.warn('failed to parseJwt', err);
+		return {};
+	}
+}
 
 export function registerUserRoute(app: FastifyInstance) {
-	app.get('/api/user/whoami', (req, res) => {
-		return res.send({ message: 'IDK', fakeCookie });
+	app.get('/api/user/whoami', async (req, res) => {
+		const jwtProfile = USE_FAKE_JWT
+			? FAKE_JWT
+			: req.headers['x-amzn-oidc-data'];
+
+		const profile = typeof jwtProfile === 'string' ? parseJwt(jwtProfile) : {};
+
+		return res.send(profile);
 	});
 }

--- a/apps/newsletters-api/src/app/routes/user.ts
+++ b/apps/newsletters-api/src/app/routes/user.ts
@@ -1,8 +1,5 @@
 import type { FastifyInstance } from 'fastify';
-
-const { FAKE_JWT } = process.env;
-
-const USE_FAKE_JWT = true as boolean;
+import { getTestJwtProfileDataIfUsing } from '../../apiDeploymentSettings';
 
 const atob = (a: string) => Buffer.from(a, 'base64').toString('binary');
 
@@ -32,17 +29,11 @@ function parseJwt(
 
 export function registerUserRoute(app: FastifyInstance) {
 	app.get('/api/user/whoami', async (req, res) => {
-		const jwtProfile = USE_FAKE_JWT
-			? FAKE_JWT
-			: req.headers['x-amzn-oidc-data'];
+		const jwtProfile =
+			req.headers['x-amzn-oidc-data'] ?? getTestJwtProfileDataIfUsing();
 
 		const decodedJwtProfile =
-			typeof jwtProfile === 'string'
-				? {
-						body: parseJwt(jwtProfile),
-						headers: parseJwt(jwtProfile, 'headers'),
-				  }
-				: {};
+			typeof jwtProfile === 'string' ? parseJwt(jwtProfile) : {};
 
 		return res.send(decodedJwtProfile);
 	});

--- a/apps/newsletters-api/src/app/routes/user.ts
+++ b/apps/newsletters-api/src/app/routes/user.ts
@@ -1,0 +1,9 @@
+import type { FastifyInstance } from 'fastify';
+
+const fakeCookie = process.env.FAKE_COOKIE;
+
+export function registerUserRoute(app: FastifyInstance) {
+	app.get('/api/user/whoami', (req, res) => {
+		return res.send({ message: 'IDK', fakeCookie });
+	});
+}

--- a/apps/newsletters-api/src/app/routes/user.ts
+++ b/apps/newsletters-api/src/app/routes/user.ts
@@ -6,9 +6,14 @@ const USE_FAKE_JWT = true as boolean;
 
 const atob = (a: string) => Buffer.from(a, 'base64').toString('binary');
 
-function parseJwt(token: string): Partial<Record<string, string>> {
+function parseJwt(
+	token: string,
+	bodyOrHeader: 'body' | 'headers' = 'body',
+): Partial<Record<string, string>> {
 	try {
-		const base64Url = token.split('.')[1] as string;
+		const base64Url = token.split('.')[
+			bodyOrHeader === 'headers' ? 0 : 1
+		] as string;
 		const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
 		const jsonPayload = decodeURIComponent(
 			atob(base64)
@@ -31,7 +36,13 @@ export function registerUserRoute(app: FastifyInstance) {
 			? FAKE_JWT
 			: req.headers['x-amzn-oidc-data'];
 
-		const profile = typeof jwtProfile === 'string' ? parseJwt(jwtProfile) : {};
+		const profile =
+			typeof jwtProfile === 'string'
+				? {
+						body: parseJwt(jwtProfile),
+						headers: parseJwt(jwtProfile, 'headers'),
+				  }
+				: {};
 
 		return res.send(profile);
 	});

--- a/apps/newsletters-api/src/app/routes/user.ts
+++ b/apps/newsletters-api/src/app/routes/user.ts
@@ -1,10 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 
-const {
-	FAKE_JWT,
-	FAKE_ACCESS_TOKEN = '',
-	FAKE_ACCESS_TOKEN_2 = '',
-} = process.env;
+const { FAKE_JWT } = process.env;
 
 const USE_FAKE_JWT = true as boolean;
 
@@ -34,8 +30,6 @@ function parseJwt(
 	}
 }
 
-const userinfoEndpoint = 'https://www.googleapis.com/oauth2/v2/userinfo';
-
 export function registerUserRoute(app: FastifyInstance) {
 	app.get('/api/user/whoami', async (req, res) => {
 		const jwtProfile = USE_FAKE_JWT
@@ -51,18 +45,5 @@ export function registerUserRoute(app: FastifyInstance) {
 				: {};
 
 		return res.send(decodedJwtProfile);
-	});
-
-	app.get('/api/user/profile', async (req, res) => {
-		console.log({ FAKE_ACCESS_TOKEN, FAKE_ACCESS_TOKEN_2 });
-
-		const userInfoResponse = await fetch(userinfoEndpoint, {
-			headers: new Headers({
-				Authorization: `Bearer ${FAKE_ACCESS_TOKEN}`,
-			}),
-		});
-		const userInfoData = (await userInfoResponse.json()) as unknown;
-
-		return res.send(userInfoData);
 	});
 }

--- a/apps/newsletters-api/src/app/routes/user.ts
+++ b/apps/newsletters-api/src/app/routes/user.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance } from 'fastify';
+import type { UserProfile } from '@newsletters-nx/newsletters-data-client';
 import { getTestJwtProfileDataIfUsing } from '../../apiDeploymentSettings';
 import { makeErrorResponse, makeSuccessResponse } from '../responses';
 
@@ -7,7 +8,7 @@ const atob = (a: string) => Buffer.from(a, 'base64').toString('binary');
 function parseJwt(
 	token: string,
 	bodyOrHeader: 'body' | 'headers' = 'body',
-): Partial<Record<string, string>> | undefined {
+): UserProfile | undefined {
 	try {
 		const base64Url = token.split('.')[
 			bodyOrHeader === 'headers' ? 0 : 1
@@ -21,7 +22,7 @@ function parseJwt(
 				})
 				.join(''),
 		);
-		return JSON.parse(jsonPayload) as Partial<Record<string, string>>;
+		return JSON.parse(jsonPayload) as UserProfile;
 	} catch (err: unknown) {
 		console.warn('failed to parseJwt', err);
 		return undefined;

--- a/apps/newsletters-api/src/main.ts
+++ b/apps/newsletters-api/src/main.ts
@@ -9,6 +9,7 @@ import { registerDraftsRoutes } from './app/routes/drafts';
 import { registerHealthRoute } from './app/routes/health';
 import { registerNewsletterRoutes } from './app/routes/newsletters';
 import { registerRenderingTemplatesRoutes } from './app/routes/rendering-templates';
+import { registerUserRoute } from './app/routes/user';
 import { registerUIServer } from './register-ui-server';
 
 const app = Fastify();
@@ -18,6 +19,7 @@ if (isServingUI()) {
 }
 if (isServingReadWriteEndpoints()) {
 	registerCurrentStepRoute(app);
+	registerUserRoute(app);
 }
 if (isServingReadEndpoints()) {
 	registerNewsletterRoutes(app);

--- a/apps/newsletters-ui/src/app/components/MainNav.tsx
+++ b/apps/newsletters-ui/src/app/components/MainNav.tsx
@@ -12,7 +12,10 @@ import Toolbar from '@mui/material/Toolbar';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import * as React from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import type { UserProfile } from '@newsletters-nx/newsletters-data-client';
+import { fetchApiData } from '../api-requests/fetch-api-data';
 
 interface NavLink {
 	path: string;
@@ -31,11 +34,23 @@ const menuItemIsSelected = (path: string): boolean => {
 };
 
 export function MainNav() {
-	const [anchorElNav, setAnchorElNav] = React.useState<null | HTMLElement>(
-		null,
+	const [anchorElNav, setAnchorElNav] = useState<null | HTMLElement>(null);
+
+	const [userProfile, setUserProfile] = useState<UserProfile | undefined>(
+		undefined,
 	);
 
 	const navigate = useNavigate();
+
+	useEffect(() => {
+		const getProfile = async () => {
+			const profile = await fetchApiData<UserProfile>('api/user/whoami');
+			setUserProfile(profile);
+		};
+		void getProfile();
+	}, []);
+
+	const userName = userProfile?.name ?? 'Logged in user';
 
 	const handleOpenNavMenu = (event: React.MouseEvent<HTMLElement>) => {
 		setAnchorElNav(event.currentTarget);
@@ -149,9 +164,9 @@ export function MainNav() {
 					</Box>
 
 					<Box sx={{ flexGrow: 0 }}>
-						<Tooltip title="Logged in user">
+						<Tooltip title={userName}>
 							<IconButton sx={{ p: 0 }}>
-								<Avatar alt="Logged in user" />
+								<Avatar alt={userName} src={userProfile?.picture} />
 							</IconButton>
 						</Tooltip>
 					</Box>

--- a/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
+++ b/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
@@ -1046,7 +1046,7 @@ su ubuntu -c '/usr/local/node/pm2 start --name newsletters-tool dist/apps/newsle
               "ClientSecret": "{{resolve:secretsmanager:/TEST/deploy/newsletters/clientSecret:SecretString:::}}",
               "Issuer": "https://accounts.google.com",
               "OnUnauthenticatedRequest": "authenticate",
-              "Scope": "openid",
+              "Scope": "openid email profile",
               "TokenEndpoint": "https://oauth2.googleapis.com/token",
               "UserInfoEndpoint": "https://openidconnect.googleapis.com/v1/userinfo",
             },

--- a/cdk/lib/newsletters-tool.ts
+++ b/cdk/lib/newsletters-tool.ts
@@ -186,7 +186,7 @@ export class NewslettersTool extends GuStack {
 			action: ListenerAction.authenticateOidc({
 				authorizationEndpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
 				issuer: 'https://accounts.google.com',
-				scope: 'openid',
+				scope: 'openid email profile',
 				authenticationRequestExtraParams: { hd: 'guardian.co.uk' },
 				onUnauthenticatedRequest: UnauthenticatedAction.AUTHENTICATE,
 				tokenEndpoint: 'https://oauth2.googleapis.com/token',

--- a/libs/newsletters-data-client/src/index.ts
+++ b/libs/newsletters-data-client/src/index.ts
@@ -12,3 +12,4 @@ export * from './lib/wizard-button-type';
 export * from './lib/transformWizardData';
 export * from './lib/storage-response-types';
 export * from './lib/zod-helpers';
+export * from './lib/user-profile';

--- a/libs/newsletters-data-client/src/lib/user-profile.ts
+++ b/libs/newsletters-data-client/src/lib/user-profile.ts
@@ -1,0 +1,25 @@
+/**
+ * The fields expected in user data obtained by the Ec2
+ * load balancer when authenticating user via google auth,
+ * based on the scopes requested in ''Google Auth' action
+ * defined the the cdk config.
+ */
+export type UserProfile = Partial<{
+	/** the unique user id used by the auth provider (in our case, google) */
+	sub: string;
+	name: string;
+	given_name: string;
+	family_name: string;
+	/** the url to the profile picture for the user.
+	 * Google provides the url to a generic icon if no profile pic is set */
+	picture: string;
+	/** the user's email address */
+	email: string;
+	email_verified: boolean;
+	locale: string;
+	hd: string;
+	/** the expiry timestamp of the token used to obtain the profile data */
+	exp: number;
+	/** the issuer of the profile data - should be https://accounts.google.com */
+	iss: string;
+}>;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds an api route that decodes the "x-amzn-oidc-data" header (JWT token containing the encoded user profile - see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/listener-authenticate-users.html ) from the user's request to obtain the user's profile data.

Amends the 'scopes' requested at the authorisation step so the JWT token will include the user's profile info (name, email address, avatar pic etc).

Has the main nav component in the UI call the 'whoami' route on the API to get the profile data and user it on the avatar.


## How to test

Can't easily test locally since it doesn't req auth (the api route will return a 'no profile' error response) - so the header isn't present. You can set use environment variables  for FAKE_JWT (copy and paste a x-amzn-oidc-data header from CODE to get your encoded profile) and USE_FAKE_JWT=true to test features relying on a profile locally.

Works when deployed to CODE - you may need to delete the auth cookie for dev-gutools.co.uk in your browser so the app will request a fresh set of permissions, including the user profile.

## How can we measure success?

The app is has access to the user's profile - we can potentially use this to record which users took which actions and restrict access to certain features to certain users.

## Have we considered potential risks?

We are now handling Guardian employee personal data - only the public profile (name, email address, avatar) so there should be low risk, but do need to be wary of this.

## Images

<img width="1111" alt="Screenshot 2023-05-24 at 11 49 51" src="https://github.com/guardian/newsletters-nx/assets/30567854/15d0203a-0de3-4248-b58f-d6fd21a514ed">

