### PR TITLE
Rachel/tag setup validation

### DIFF
--- a/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
+++ b/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
@@ -99,7 +99,7 @@ export const NewsletterDataDetails = ({ newsletter }: Props) => {
 				<NavigateButton href="../" variant="outlined">
 					Back to List
 				</NavigateButton>
-				{/* TO DO - restrict the access to the JSON editter based on user role? */}
+				{/* TO DO - restrict the access to the JSON editor based on user role? */}
 				<RawDataDialog
 					record={newsletter}
 					title={newsletter.identityName}

--- a/libs/newsletter-workflow/src/lib/getInitialStateForLaunch.ts
+++ b/libs/newsletter-workflow/src/lib/getInitialStateForLaunch.ts
@@ -35,7 +35,7 @@ export const getInitialStateForLaunch = async (
 		};
 	}
 	const storageResponse = await launchService.draftStorage.read(id);
-	const allLauchedResponse = await launchService.newsletterStorage.list();
+	const allLaunchedResponse = await launchService.newsletterStorage.list();
 
 	const draft: DraftNewsletterData = storageResponse.ok
 		? storageResponse.data
@@ -64,8 +64,8 @@ export const getInitialStateForLaunch = async (
 	const derivedFieldValuesOrActualIfSet =
 		withDefaultNewsletterValuesAndDerivedFields(draft);
 
-	const existingNewsletters = allLauchedResponse.ok
-		? allLauchedResponse.data
+	const existingNewsletters = allLaunchedResponse.ok
+		? allLaunchedResponse.data
 		: [];
 
 	suffixDervivedValues(derivedFieldValuesOrActualIfSet, existingNewsletters);

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
@@ -1,12 +1,10 @@
 import type { ZodObject, ZodRawShape } from 'zod';
 import { z } from 'zod';
 import type {
-	ComposerTagRelationship,
 	RenderingOptions,
 	ThrasherOptions,
 } from '@newsletters-nx/newsletters-data-client';
 import {
-	composerTagRelationshipSchema,
 	newsletterDataSchema,
 	renderingOptionsSchema,
 	thrasherOptionsSchema,
@@ -28,19 +26,6 @@ const pickAndPrefixThrasherOption = (
 	const shape: ZodRawShape = {};
 	fieldKeys.forEach((key) => {
 		shape[`thrasherOptions.${key}`] = thrasherOptionsSchema.shape[key];
-	});
-	return z.object(shape);
-};
-
-const pickAndPrefixTagRelationshipOption = (
-	fieldKeys: Array<keyof ComposerTagRelationship>,
-): ZodObject<ZodRawShape> => {
-	const shape: ZodRawShape = {
-		seriesTag: newsletterDataSchema.shape.seriesTag,
-	};
-	fieldKeys.forEach((key) => {
-		shape[`composerTagRelationship.${key}`] =
-			composerTagRelationshipSchema.shape[key];
 	});
 	return z.object(shape);
 };
@@ -159,11 +144,12 @@ export const formSchemas = {
 		'Input the Read More setup',
 	),
 
-	tags: pickAndPrefixTagRelationshipOption([
-		'composerTag',
-		'composerCampaignTag',
-	])
-		.extend({ seriesTag: newsletterDataSchema.shape.seriesTag })
+	tags: newsletterDataSchema
+		.pick({
+			seriesTag: true,
+			composerTag: true,
+			composerCampaignTag: true,
+		})
 		.describe('Input the tag setup'),
 
 	singleThrasher: pickAndPrefixThrasherOption([

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
@@ -1,10 +1,12 @@
 import type { ZodObject, ZodRawShape } from 'zod';
 import { z } from 'zod';
 import type {
+	ComposerTagRelationship,
 	RenderingOptions,
 	ThrasherOptions,
 } from '@newsletters-nx/newsletters-data-client';
 import {
+	composerTagRelationshipSchema,
 	newsletterDataSchema,
 	renderingOptionsSchema,
 	thrasherOptionsSchema,
@@ -26,6 +28,19 @@ const pickAndPrefixThrasherOption = (
 	const shape: ZodRawShape = {};
 	fieldKeys.forEach((key) => {
 		shape[`thrasherOptions.${key}`] = thrasherOptionsSchema.shape[key];
+	});
+	return z.object(shape);
+};
+
+const pickAndPrefixTagRelationshipOption = (
+	fieldKeys: Array<keyof ComposerTagRelationship>,
+): ZodObject<ZodRawShape> => {
+	const shape: ZodRawShape = {
+		seriesTag: newsletterDataSchema.shape.seriesTag,
+	};
+	fieldKeys.forEach((key) => {
+		shape[`composerTagRelationship.${key}`] =
+			composerTagRelationshipSchema.shape[key];
 	});
 	return z.object(shape);
 };
@@ -144,12 +159,11 @@ export const formSchemas = {
 		'Input the Read More setup',
 	),
 
-	tags: newsletterDataSchema
-		.pick({
-			seriesTag: true,
-			composerTag: true,
-			composerCampaignTag: true,
-		})
+	tags: pickAndPrefixTagRelationshipOption([
+		'composerTag',
+		'composerCampaignTag',
+	])
+		.extend({ seriesTag: newsletterDataSchema.shape.seriesTag })
 		.describe('Input the tag setup'),
 
 	singleThrasher: pickAndPrefixThrasherOption([

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/tagsLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/tagsLayout.ts
@@ -59,23 +59,6 @@ export const tagsLayout: WizardStepLayout<DraftStorage> = {
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
-			onBeforeStepChangeValidate: (stepData): string | undefined => {
-				const composerTag = stepData.formData
-					? stepData.formData['composerTag']
-					: undefined;
-				const composerCampaignTag = stepData.formData
-					? stepData.formData['composerCampaignTag']
-					: undefined;
-				if (composerTag || composerCampaignTag) {
-					if (!composerTag) {
-						return 'ENTER AT LEAST ONE COMPOSER TAG IF SPECIFYING COMPOSER CAMPAIGN TAG';
-					}
-					if (!composerCampaignTag) {
-						return 'ENTER COMPOSER CAMPAIGN TAG IF SPECIFYING COMPOSER TAG';
-					}
-				}
-				return undefined;
-			},
 			executeStep: executeModify,
 		},
 	},

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/tagsLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/tagsLayout.ts
@@ -59,6 +59,23 @@ export const tagsLayout: WizardStepLayout<DraftStorage> = {
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
+			onBeforeStepChangeValidate: (stepData): string | undefined => {
+				const composerTag = stepData.formData
+					? stepData.formData['composerTag']
+					: undefined;
+				const composerCampaignTag = stepData.formData
+					? stepData.formData['composerCampaignTag']
+					: undefined;
+				if (composerTag || composerCampaignTag) {
+					if (!composerTag) {
+						return 'ENTER AT LEAST ONE COMPOSER TAG IF SPECIFYING COMPOSER CAMPAIGN TAG';
+					}
+					if (!composerCampaignTag) {
+						return 'ENTER COMPOSER CAMPAIGN TAG IF SPECIFYING COMPOSER TAG';
+					}
+				}
+				return undefined;
+			},
 			executeStep: executeModify,
 		},
 	},

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/tagsLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/tagsLayout.ts
@@ -29,8 +29,6 @@ For example, the **Games (video games only)** tag recommends the user adds the *
 
 Which tag(s) would you like to propose the sign up embed for **{{name}}**?
 
-*If you would like to enable this feature, your request will automatically be emailed to Central Production.*
-
 `.trim();
 
 const staticMarkdown = markdownTemplate.replace(

--- a/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
@@ -141,7 +141,7 @@ export const newsletterDataSchema = z.object({
 	cancellationTimeStamp: z.number().optional(),
 
 	seriesTag: z.string().optional().describe('series tag'),
-	composerTag: z.string().optional().describe('composer tag'),
+	composerTag: z.string().optional().describe('composer tag(s)'),
 	composerCampaignTag: z.string().optional().describe('composer campaign tag'),
 
 	launchDate: z.coerce.date().describe('launch date'),

--- a/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
@@ -97,6 +97,14 @@ export const newsletterCategoriesSchema = z
 	.describe('production category');
 export type NewsletterCategory = z.infer<typeof newsletterCategoriesSchema>;
 
+export const composerTagRelationshipSchema = z.object({
+	composerTag: z.string().describe('composer tag'),
+	composerCampaignTag: z.string().describe('composer campaign tag'),
+});
+export type ComposerTagRelationship = z.infer<
+	typeof composerTagRelationshipSchema
+>;
+
 /**
  * NOT FINAL - this schema a placeholder to test the data transformation structure.
  * Edits to this schema would need to be reflected in the transform function.
@@ -141,8 +149,7 @@ export const newsletterDataSchema = z.object({
 	cancellationTimeStamp: z.number().optional(),
 
 	seriesTag: z.string().optional().describe('series tag'),
-	composerTag: z.string().optional().describe('composer tag'),
-	composerCampaignTag: z.string().optional().describe('composer campaign tag'),
+	composerTagRelationship: composerTagRelationshipSchema.optional(),
 
 	launchDate: z.coerce.date().describe('launch date'),
 	signUpPageDate: z.coerce.date().describe('sign up page date'),

--- a/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
@@ -97,14 +97,6 @@ export const newsletterCategoriesSchema = z
 	.describe('production category');
 export type NewsletterCategory = z.infer<typeof newsletterCategoriesSchema>;
 
-export const composerTagRelationshipSchema = z.object({
-	composerTag: z.string().describe('composer tag'),
-	composerCampaignTag: z.string().describe('composer campaign tag'),
-});
-export type ComposerTagRelationship = z.infer<
-	typeof composerTagRelationshipSchema
->;
-
 /**
  * NOT FINAL - this schema a placeholder to test the data transformation structure.
  * Edits to this schema would need to be reflected in the transform function.
@@ -149,7 +141,8 @@ export const newsletterDataSchema = z.object({
 	cancellationTimeStamp: z.number().optional(),
 
 	seriesTag: z.string().optional().describe('series tag'),
-	composerTagRelationship: composerTagRelationshipSchema.optional(),
+	composerTag: z.string().optional().describe('composer tag'),
+	composerCampaignTag: z.string().optional().describe('composer campaign tag'),
 
 	launchDate: z.coerce.date().describe('launch date'),
 	signUpPageDate: z.coerce.date().describe('sign up page date'),


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

https://github.com/guardian/newsletters-nx/pull/142  removed validation from the Tag Setup step.  In the case of the series tag it was correct to remove the validation (it should be done on the formSchema object if required).  However, the validation for the combination of composerTag and composerCampaignTag should remain i.e. if the user enters either one, then we need both

## How to test

`npm run dev`
Edit one of the draft newsletters and navigate to the Tag Setup step of the wizard
It's possible to press Next if neither the composer tag or composer campaign tag have been entered
However, if one or the other is entered, validation ensures that both have been entered

## How can we measure success?

Field entries are correctly validated

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![Screenshot 2023-05-30 at 12 03 00](https://github.com/guardian/newsletters-nx/assets/74301289/4c3e1a96-1a3e-4975-9b07-482efefe68a8)

![Screenshot 2023-05-30 at 12 03 26](https://github.com/guardian/newsletters-nx/assets/74301289/f8807eaa-a614-44fe-b247-da4c6065d39b)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
