### PR TITLE
Add space before h3

### DIFF
--- a/apps/newsletters-ui/src/app-theme.ts
+++ b/apps/newsletters-ui/src/app-theme.ts
@@ -39,6 +39,7 @@ export const appTheme = createTheme({
 		h3: {
 			fontSize: '1.5rem',
 			marginBottom: '.25rem',
+			marginTop: '1.5rem',
 		},
 	},
 	components: {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds spacing before h3 headings to make the markdown more readable

## How to test

`npm run dev`
Edit a draft newsletter, and navigate through the wizard to a page including an h3 heading e.g. Tag Setup

## How can we measure success?

Users happy

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Before
![Screenshot 2023-05-24 at 15 14 41](https://github.com/guardian/newsletters-nx/assets/74301289/2acc1068-1a48-4423-bc48-4a323d70f7cb)

After
![Screenshot 2023-05-24 at 15 17 05](https://github.com/guardian/newsletters-nx/assets/74301289/a75a4dd7-2551-4200-b502-6f8d4fc1b90b)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
