### PR TITLE
Dblatcher access profile in api

### DIFF
--- a/apps/newsletters-api/src/app/get-user-profile.ts
+++ b/apps/newsletters-api/src/app/get-user-profile.ts
@@ -30,19 +30,22 @@ function parseJwt(
 
 export const getUserProfile = (
 	req: FastifyRequest,
-): { ok: true; profile: UserProfile } | { ok: false; errorMessage: string } => {
+): { profile: UserProfile } | { errorMessage: string; profile: undefined } => {
 	const jwtProfile =
 		req.headers['x-amzn-oidc-data'] ?? getTestJwtProfileDataIfUsing();
 
 	if (typeof jwtProfile !== 'string') {
-		return { ok: false, errorMessage: 'No user profile.' };
+		return { errorMessage: 'No user profile.', profile: undefined };
 	}
 
 	const decodedJwtProfile = parseJwt(jwtProfile);
 
 	if (!decodedJwtProfile) {
-		return { ok: false, errorMessage: 'Failed to decode user profile.' };
+		return {
+			errorMessage: 'Failed to decode user profile.',
+			profile: undefined,
+		};
 	}
 
-	return { profile: decodedJwtProfile, ok: true };
+	return { profile: decodedJwtProfile };
 };

--- a/apps/newsletters-api/src/app/get-user-profile.ts
+++ b/apps/newsletters-api/src/app/get-user-profile.ts
@@ -1,0 +1,48 @@
+import type { FastifyRequest } from 'fastify/types/request';
+import type { UserProfile } from '@newsletters-nx/newsletters-data-client';
+import { getTestJwtProfileDataIfUsing } from '../apiDeploymentSettings';
+
+const atob = (a: string) => Buffer.from(a, 'base64').toString('binary');
+
+function parseJwt(
+	token: string,
+	bodyOrHeader: 'body' | 'headers' = 'body',
+): UserProfile | undefined {
+	try {
+		const base64Url = token.split('.')[
+			bodyOrHeader === 'headers' ? 0 : 1
+		] as string;
+		const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+		const jsonPayload = decodeURIComponent(
+			atob(base64)
+				.split('')
+				.map(function (c) {
+					return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+				})
+				.join(''),
+		);
+		return JSON.parse(jsonPayload) as UserProfile;
+	} catch (err: unknown) {
+		console.warn('failed to parseJwt', err);
+		return undefined;
+	}
+}
+
+export const getUserProfile = (
+	req: FastifyRequest,
+): { ok: true; profile: UserProfile } | { ok: false; errorMessage: string } => {
+	const jwtProfile =
+		req.headers['x-amzn-oidc-data'] ?? getTestJwtProfileDataIfUsing();
+
+	if (typeof jwtProfile !== 'string') {
+		return { ok: false, errorMessage: 'No user profile.' };
+	}
+
+	const decodedJwtProfile = parseJwt(jwtProfile);
+
+	if (!decodedJwtProfile) {
+		return { ok: false, errorMessage: 'Failed to decode user profile.' };
+	}
+
+	return { profile: decodedJwtProfile, ok: true };
+};

--- a/apps/newsletters-api/src/app/routes/user.ts
+++ b/apps/newsletters-api/src/app/routes/user.ts
@@ -6,7 +6,7 @@ export function registerUserRoute(app: FastifyInstance) {
 	app.get('/api/user/whoami', async (req, res) => {
 		const maybeUser = getUserProfile(req);
 
-		if (!maybeUser.ok) {
+		if (!maybeUser.profile) {
 			return res.status(500).send(makeErrorResponse(maybeUser.errorMessage));
 		}
 

--- a/apps/newsletters-api/src/app/routes/user.ts
+++ b/apps/newsletters-api/src/app/routes/user.ts
@@ -1,51 +1,15 @@
 import type { FastifyInstance } from 'fastify';
-import type { UserProfile } from '@newsletters-nx/newsletters-data-client';
-import { getTestJwtProfileDataIfUsing } from '../../apiDeploymentSettings';
+import { getUserProfile } from '../get-user-profile';
 import { makeErrorResponse, makeSuccessResponse } from '../responses';
-
-const atob = (a: string) => Buffer.from(a, 'base64').toString('binary');
-
-function parseJwt(
-	token: string,
-	bodyOrHeader: 'body' | 'headers' = 'body',
-): UserProfile | undefined {
-	try {
-		const base64Url = token.split('.')[
-			bodyOrHeader === 'headers' ? 0 : 1
-		] as string;
-		const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
-		const jsonPayload = decodeURIComponent(
-			atob(base64)
-				.split('')
-				.map(function (c) {
-					return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
-				})
-				.join(''),
-		);
-		return JSON.parse(jsonPayload) as UserProfile;
-	} catch (err: unknown) {
-		console.warn('failed to parseJwt', err);
-		return undefined;
-	}
-}
 
 export function registerUserRoute(app: FastifyInstance) {
 	app.get('/api/user/whoami', async (req, res) => {
-		const jwtProfile =
-			req.headers['x-amzn-oidc-data'] ?? getTestJwtProfileDataIfUsing();
+		const maybeUser = getUserProfile(req);
 
-		if (typeof jwtProfile !== 'string') {
-			return res.status(500).send(makeErrorResponse('No user profile.'));
+		if (!maybeUser.ok) {
+			return res.status(500).send(makeErrorResponse(maybeUser.errorMessage));
 		}
 
-		const decodedJwtProfile = parseJwt(jwtProfile);
-
-		if (!decodedJwtProfile) {
-			return res
-				.status(500)
-				.send(makeErrorResponse('Failed to decode user profile.'));
-		}
-
-		return res.send(makeSuccessResponse(decodedJwtProfile));
+		return res.send(makeSuccessResponse(maybeUser.profile));
 	});
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Extracts the code for getting the user profile form the `req.header` out of the `registerUserRoute` module

## How to test

(no changes to behaviour)

## How can we measure success?

By importing the `getUserProfile` function into other parts of the API code, we will be able to use the user profile server-side, as well as client side via the existing  'whoami' end point.

Possible use cases:
 - code can include the user's email in the audit logs
 - we can restrict access to some API calls based on the user's identity (ideally, we will use a google user group to define permissions, but initially a list could be hard coded)
 - A future messaging service can send update/confirmation emails to the user that created a draft newsletter

## Have we considered potential risks?

We will need to be mindful of how we use the profile data.
