### PR TITLE
Dblatcher remove unnecessary custom validation hooks

### DIFF
--- a/apps/newsletters-ui/src/main.tsx
+++ b/apps/newsletters-ui/src/main.tsx
@@ -2,11 +2,11 @@ import { ThemeProvider } from '@mui/material';
 import { StrictMode } from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { appTheme } from './app-theme';
 import { DefaultStyles } from './app/components/DefaultStyles';
 import { draftRoute } from './app/routes/drafts';
 import { homeRoute } from './app/routes/home';
 import { newslettersRoute } from './app/routes/newsletters';
-import { appTheme } from './app-theme';
 
 const router = createBrowserRouter([homeRoute, newslettersRoute, draftRoute]);
 

--- a/apps/newsletters-ui/src/main.tsx
+++ b/apps/newsletters-ui/src/main.tsx
@@ -2,11 +2,11 @@ import { ThemeProvider } from '@mui/material';
 import { StrictMode } from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
-import { appTheme } from './app-theme';
 import { DefaultStyles } from './app/components/DefaultStyles';
 import { draftRoute } from './app/routes/drafts';
 import { homeRoute } from './app/routes/home';
 import { newslettersRoute } from './app/routes/newsletters';
+import { appTheme } from './app-theme';
 
 const router = createBrowserRouter([homeRoute, newslettersRoute, draftRoute]);
 

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/categoryLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/categoryLayout.ts
@@ -1,8 +1,5 @@
 import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
-import type {
-	WizardStepData,
-	WizardStepLayout,
-} from '@newsletters-nx/state-machine';
+import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import {
 	getNextStepId,
 	getPreviousOrEditStartStepId,
@@ -55,15 +52,6 @@ export const categoryLayout: WizardStepLayout<DraftStorage> = {
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
-			onBeforeStepChangeValidate: (stepData: WizardStepData) => {
-				const productionCategory = stepData.formData
-					? stepData.formData['category']
-					: undefined;
-				if (!productionCategory || productionCategory === '') {
-					return 'NO PRODUCTION CATEGORY SELECTED';
-				}
-				return undefined;
-			},
 			executeStep: executeModify,
 		},
 	},

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/createDraftNewsletterLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/createDraftNewsletterLayout.ts
@@ -23,10 +23,6 @@ The first step is to enter the name of your newsletter. For example,  **Down to 
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
-			onBeforeStepChangeValidate: (stepData): string | undefined => {
-				const name = stepData.formData ? stepData.formData['name'] : undefined;
-				return name ? undefined : 'NO NAME PROVIDED';
-			},
 			executeStep: executeCreate,
 		},
 	},

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
@@ -6,6 +6,7 @@ import type {
 } from '@newsletters-nx/newsletters-data-client';
 import {
 	newsletterDataSchema,
+	nonEmptyString,
 	renderingOptionsSchema,
 	thrasherOptionsSchema,
 } from '@newsletters-nx/newsletters-data-client';
@@ -82,10 +83,11 @@ export const formSchemas = {
 		})
 		.describe('Choose a theme and a group'),
 
-	signUpPage: newsletterDataSchema
-		.pick({
-			signUpHeadline: true,
-			signUpDescription: true,
+	// manually creating the object so both values are required and non-empty
+	signUpPage: z
+		.object({
+			signUpHeadline: nonEmptyString(),
+			signUpDescription: nonEmptyString(),
 		})
 		.describe('Input the Sign Up page copy'),
 
@@ -93,10 +95,12 @@ export const formSchemas = {
 		.pick({ signUpEmbedDescription: true })
 		.describe('Input the Sign Up embed copy'),
 
+	// TO DO - check with editorial if regionFocus should be required for new newsletters
 	regionFocus: newsletterDataSchema
 		.pick({
 			regionFocus: true,
 		})
+		.required() // regionFocus is not required in the newsletterDataSchema, but we want it set for new newsletters
 		.describe('Select from the drop-down list'),
 
 	newsletterDesign: newsletterDataSchema
@@ -130,6 +134,7 @@ export const formSchemas = {
 		.pick({
 			onlineArticle: true,
 		})
+		.required() // onlineArticle is not required in the newsletterDataSchema, but we want it set for new newsletters
 		.describe('Select from the drop-down list'),
 
 	linkList: pickAndPrefixRenderingOption(['linkListSubheading']).describe(

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/frequencyLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/frequencyLayout.ts
@@ -60,12 +60,6 @@ export const frequencyLayout: WizardStepLayout<DraftStorage> = {
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
-			onBeforeStepChangeValidate: (stepData): string | undefined => {
-				const frequency = stepData.formData
-					? stepData.formData['frequency']
-					: undefined;
-				return frequency ? undefined : 'NO FREQUENCY PROVIDED';
-			},
 			executeStep: executeModify,
 		},
 	},

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/onlineArticleLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/onlineArticleLayout.ts
@@ -1,8 +1,5 @@
 import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
-import type {
-	WizardStepData,
-	WizardStepLayout,
-} from '@newsletters-nx/state-machine';
+import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import {
 	getNextStepId,
 	getPreviousOrEditStartStepId,
@@ -50,15 +47,6 @@ export const onlineArticleLayout: WizardStepLayout<DraftStorage> = {
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
-			onBeforeStepChangeValidate: (stepData: WizardStepData) => {
-				const onlineArticle = stepData.formData
-					? stepData.formData['onlineArticle']
-					: undefined;
-				if (!onlineArticle || onlineArticle === '') {
-					return 'NO ONLINE ARTICLE SETUP SELECTED';
-				}
-				return undefined;
-			},
 			executeStep: executeModify,
 		},
 	},

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/regionFocusLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/regionFocusLayout.ts
@@ -3,10 +3,7 @@ import {
 	getNextStepId,
 	getPreviousOrEditStartStepId,
 } from '@newsletters-nx/state-machine';
-import type {
-	WizardStepData,
-	WizardStepLayout,
-} from '@newsletters-nx/state-machine';
+import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeModify } from '../../executeModify';
 import { executeSkip } from '../../executeSkip';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
@@ -46,15 +43,6 @@ export const regionFocusLayout: WizardStepLayout<DraftStorage> = {
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
-			onBeforeStepChangeValidate: (stepData: WizardStepData) => {
-				const regionFocus = stepData.formData
-					? stepData.formData['regionFocus']
-					: undefined;
-				if (!regionFocus || regionFocus === '') {
-					return 'NO REGION FOCUS SELECTED';
-				}
-				return undefined;
-			},
 			executeStep: executeModify,
 		},
 	},

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/signUpEmbedLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/signUpEmbedLayout.ts
@@ -1,8 +1,5 @@
 import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
-import type {
-	WizardStepData,
-	WizardStepLayout,
-} from '@newsletters-nx/state-machine';
+import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import {
 	getNextStepId,
 	getPreviousOrEditStartStepId,
@@ -48,15 +45,6 @@ export const signUpEmbedLayout: WizardStepLayout<DraftStorage> = {
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
-			onBeforeStepChangeValidate: (stepData: WizardStepData) => {
-				const description = stepData.formData
-					? stepData.formData['signUpEmbedDescription']
-					: undefined;
-				if (!description) {
-					return 'NO DESCRIPTION PROVIDED';
-				}
-				return undefined;
-			},
 			executeStep: executeModify,
 		},
 	},

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/signUpPageLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/signUpPageLayout.ts
@@ -1,8 +1,5 @@
 import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
-import type {
-	WizardStepData,
-	WizardStepLayout,
-} from '@newsletters-nx/state-machine';
+import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import {
 	getNextStepId,
 	getPreviousOrEditStartStepId,
@@ -48,21 +45,6 @@ export const signUpPageLayout: WizardStepLayout<DraftStorage> = {
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
-			onBeforeStepChangeValidate: (stepData: WizardStepData) => {
-				const headline = stepData.formData
-					? stepData.formData['signUpHeadline']
-					: undefined;
-				if (!headline) {
-					return 'NO HEADLINE PROVIDED';
-				}
-				const description = stepData.formData
-					? stepData.formData['signUpDescription']
-					: undefined;
-				if (!description) {
-					return 'NO DESCRIPTION PROVIDED';
-				}
-				return undefined;
-			},
 			executeStep: executeModify,
 		},
 	},

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/footerLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/footerLayout.ts
@@ -46,12 +46,6 @@ export const footerLayout: WizardStepLayout<DraftStorage> = {
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
-			onBeforeStepChangeValidate: (stepData): string | undefined => {
-				const email = stepData.formData
-					? stepData.formData['renderingOptions.contactEmail']
-					: undefined;
-				return email ? undefined : 'NO EMAIL ADDRESS PROVIDED';
-			},
 			executeStep: executeModify,
 		},
 	},

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/readMoreLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/readMoreLayout.ts
@@ -49,31 +49,6 @@ export const readMoreLayout: WizardStepLayout<DraftStorage> = {
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
-			onBeforeStepChangeValidate: (stepData): string | undefined => {
-				const readMoreDetails = stepData.formData
-					? (stepData.formData[
-							'renderingOptions.readMoreSections'
-					  ] as unknown as Array<{
-							subheading: string;
-							wording: string;
-							url: string;
-					  }>)
-					: undefined;
-				if (readMoreDetails) {
-					if (Array.isArray(readMoreDetails)) {
-						const invalidReadMoreDetails = readMoreDetails.filter(
-							(readMoreEntry) =>
-								!readMoreEntry.subheading ||
-								!readMoreEntry.wording ||
-								!readMoreEntry.url,
-						);
-						if (invalidReadMoreDetails.length > 0) {
-							return 'ALL READ MORE DETAILS MUST BE SPECIFIED FOR A CONFIGURATION';
-						}
-					}
-				}
-				return undefined;
-			},
 			executeStep: executeModify,
 		},
 	},

--- a/libs/newsletters-data-client/src/lib/deriveNewsletterFields.ts
+++ b/libs/newsletters-data-client/src/lib/deriveNewsletterFields.ts
@@ -47,9 +47,6 @@ export const addSuffixToMakeTokenUnique = (
 	delimiter = '-',
 ): string => {
 	// no duplicates, so can use the token name
-
-	console.log('dedupe', { originalToken, existingTokens });
-
 	if (!existingTokens.includes(originalToken)) {
 		return originalToken;
 	}

--- a/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
@@ -49,9 +49,9 @@ export const renderingOptionsSchema = z.object({
 		.array(
 			z
 				.object({
-					subheading: z.string().optional().describe('read more subheading'),
-					wording: z.string().optional().describe('read more wording'),
-					url: z.string().url().optional().describe('read more url'),
+					subheading: nonEmptyString().describe('read more subheading'),
+					wording: nonEmptyString().describe('read more wording'),
+					url: z.string().url().describe('read more url'),
 				})
 				.describe('read more section configuration'),
 		)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Removes custom validation hooks (`onBeforeStepChangeValidate`) which were only testing for missing values that the schema check now handle.

Makes the form schemas for the create draft wizard more restrictive than the `newsletterDataSchema` it is based on so that:
 - [to do]

and removes the custom validation for the related steps as the schema will now handle the validation.

## How to test

Wizards will work as before except:
-  the form elements will display validation warning (eg 'can't be empty') where previously, the error would only be flagged after submitting the form.
- we don't get custom validation errors, just the somewhat clunky ones parsed from the zod issues.
- The 'completion' status shown in the StepNav (based on the form schemas) will be more accurate

## How can we measure success?

Less custom code to maintain!
Users get more feedback on editing rather than when they submit the step

## Have we considered potential risks?

It was nicer to be able to derive the form schemas by just 'picking' the fields - but the trade-off in complexity with the custom hooks is probably a benefit.

The error messages generated from the zod schema (eg 'Please try again: VALIDATION ERRORS: signUpDescription: "Must not be empty"') are not as clear as the custom error messages (eg "Please try again: NO HEADLINE PROVIDED").  We could address this with some better validation error handling in the state machine code (at present, validation messages are returned as strings rather than data see https://trello.com/c/eNRynPNu/418-change-return-type-for-executemodify).

