### PR TITLE
Dblatcher optional steps not complete by default

### DIFF
--- a/apps/newsletters-ui/src/app/components/StepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StepNav.tsx
@@ -6,12 +6,12 @@ import {
 	Typography,
 } from '@mui/material';
 import { useState } from 'react';
+import { resolveStepStatus, StepStatus } from '@newsletters-nx/state-machine';
 import type {
 	StepListing,
 	StepperConfig,
 	WizardFormData,
 } from '@newsletters-nx/state-machine';
-import { resolveStepStatus, StepStatus } from '../resolve-step-status';
 
 interface Props {
 	currentStepId?: string;

--- a/apps/newsletters-ui/src/app/components/StepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StepNav.tsx
@@ -6,13 +6,12 @@ import {
 	Typography,
 } from '@mui/material';
 import { useState } from 'react';
-import type { FormDataRecord } from '@newsletters-nx/newsletters-data-client';
-import { getFieldKeyNames } from '@newsletters-nx/newsletters-data-client';
 import type {
 	StepListing,
 	StepperConfig,
 	WizardFormData,
 } from '@newsletters-nx/state-machine';
+import { resolveStepStatus, StepStatus } from '../resolve-step-status';
 
 interface Props {
 	currentStepId?: string;
@@ -22,15 +21,8 @@ interface Props {
 	formData?: WizardFormData;
 }
 
-enum StepStatus {
-	Complete,
-	Incomplete,
-	Optional,
-	NoFields,
-}
-
-const CompletionCaption = (props: { completeness: StepStatus | undefined }) => {
-	switch (props.completeness) {
+const CompletionCaption = (props: { status: StepStatus | undefined }) => {
+	switch (props.status) {
 		case undefined:
 		case StepStatus.NoFields:
 			return null;
@@ -62,47 +54,6 @@ const CompletionCaption = (props: { completeness: StepStatus | undefined }) => {
 				</Typography>
 			);
 	}
-};
-
-function areAllFieldsUnset(
-	step: StepListing,
-	formData: FormDataRecord | undefined,
-) {
-	if (!step.schema || !formData) {
-		return true;
-	}
-	const fieldsInThisStep = getFieldKeyNames(step.schema);
-	if (!fieldsInThisStep) {
-		return true;
-	}
-	const fieldsPopulatedInFormData = Object.keys(formData);
-	return !fieldsInThisStep.some((key) =>
-		fieldsPopulatedInFormData.includes(key),
-	);
-}
-
-const isOptionalStep = (step: StepListing): boolean => {
-	if (!step.schema) {
-		return true;
-	}
-	return step.schema.safeParse({}).success;
-};
-
-const resolveStepStatus = (
-	step: StepListing,
-	formData: FormDataRecord | undefined,
-): StepStatus => {
-	if (!step.schema) {
-		return StepStatus.NoFields;
-	}
-	const parseResult = step.schema.safeParse(formData);
-	if (!parseResult.success) {
-		return StepStatus.Incomplete;
-	}
-	if (isOptionalStep(step) && areAllFieldsUnset(step, formData)) {
-		return StepStatus.Optional;
-	}
-	return StepStatus.Complete;
 };
 
 export const StepNav = ({
@@ -184,7 +135,7 @@ export const StepNav = ({
 		>
 			{filteredStepList.map((step) => {
 				const caption = stepperConfig.indicateStepsComplete ? (
-					<CompletionCaption completeness={completionRecord[step.id]} />
+					<CompletionCaption status={completionRecord[step.id]} />
 				) : undefined;
 
 				return (

--- a/apps/newsletters-ui/src/app/resolve-step-status.ts
+++ b/apps/newsletters-ui/src/app/resolve-step-status.ts
@@ -1,0 +1,51 @@
+import type { FormDataRecord } from '@newsletters-nx/newsletters-data-client';
+import { getFieldKeyNames } from '@newsletters-nx/newsletters-data-client';
+import type { StepListing } from '@newsletters-nx/state-machine';
+
+export enum StepStatus {
+	Complete,
+	Incomplete,
+	Optional,
+	NoFields,
+}
+
+const areAllFieldsUnset = (
+	step: StepListing,
+	formData: FormDataRecord | undefined,
+) => {
+	if (!step.schema || !formData) {
+		return true;
+	}
+	const fieldsInThisStep = getFieldKeyNames(step.schema);
+	if (!fieldsInThisStep) {
+		return true;
+	}
+	const fieldsPopulatedInFormData = Object.keys(formData);
+	return !fieldsInThisStep.some((key) =>
+		fieldsPopulatedInFormData.includes(key),
+	);
+};
+
+const isOptionalStep = (step: StepListing): boolean => {
+	if (!step.schema) {
+		return true;
+	}
+	return step.schema.safeParse({}).success;
+};
+
+export const resolveStepStatus = (
+	step: StepListing,
+	formData: FormDataRecord | undefined,
+): StepStatus => {
+	if (!step.schema) {
+		return StepStatus.NoFields;
+	}
+	const parseResult = step.schema.safeParse(formData);
+	if (!parseResult.success) {
+		return StepStatus.Incomplete;
+	}
+	if (isOptionalStep(step) && areAllFieldsUnset(step, formData)) {
+		return StepStatus.Optional;
+	}
+	return StepStatus.Complete;
+};

--- a/libs/newsletters-data-client/src/lib/zod-helpers/getEmptySchemaData.ts
+++ b/libs/newsletters-data-client/src/lib/zod-helpers/getEmptySchemaData.ts
@@ -1,5 +1,13 @@
 import type { z } from 'zod';
-import { ZodBoolean, ZodDate, ZodEnum, ZodNumber, ZodString } from 'zod';
+import {
+	ZodArray,
+	ZodBoolean,
+	ZodDate,
+	ZodEnum,
+	ZodNumber,
+	ZodOptional,
+	ZodString,
+} from 'zod';
 import type { FormDataRecord } from '../transformWizardData';
 import { recursiveUnwrap } from './recursiveUnwrap';
 
@@ -17,6 +25,8 @@ export const getEmptySchemaData = (
 	unwrapOptionals = false,
 ): FormDataRecord | undefined => {
 	return Object.keys(schema.shape).reduce<FormDataRecord>((formData, key) => {
+		console.log('getEmptySchemaData', key);
+
 		const zodMaybeOptional = schema.shape[key];
 
 		if (!zodMaybeOptional) {
@@ -26,6 +36,8 @@ export const getEmptySchemaData = (
 			? recursiveUnwrap(zodMaybeOptional)
 			: zodMaybeOptional;
 		const mod: FormDataRecord = {};
+
+		console.log(zod);
 
 		if (zod instanceof ZodString) {
 			mod[key] = '';
@@ -37,6 +49,10 @@ export const getEmptySchemaData = (
 			mod[key] = false;
 		} else if (zod instanceof ZodDate) {
 			mod[key] = undefined;
+		} else if (zod instanceof ZodOptional) {
+			if (zod.unwrap() instanceof ZodArray) {
+				mod[key] = [];
+			}
 		}
 
 		return {

--- a/libs/newsletters-data-client/src/lib/zod-helpers/getEmptySchemaData.ts
+++ b/libs/newsletters-data-client/src/lib/zod-helpers/getEmptySchemaData.ts
@@ -25,8 +25,6 @@ export const getEmptySchemaData = (
 	unwrapOptionals = false,
 ): FormDataRecord | undefined => {
 	return Object.keys(schema.shape).reduce<FormDataRecord>((formData, key) => {
-		console.log('getEmptySchemaData', key);
-
 		const zodMaybeOptional = schema.shape[key];
 
 		if (!zodMaybeOptional) {
@@ -36,8 +34,6 @@ export const getEmptySchemaData = (
 			? recursiveUnwrap(zodMaybeOptional)
 			: zodMaybeOptional;
 		const mod: FormDataRecord = {};
-
-		console.log(zod);
 
 		if (zod instanceof ZodString) {
 			mod[key] = '';

--- a/libs/newsletters-data-client/src/lib/zod-helpers/getFieldKeyNames.ts
+++ b/libs/newsletters-data-client/src/lib/zod-helpers/getFieldKeyNames.ts
@@ -1,0 +1,12 @@
+import type { ZodTypeAny } from 'zod';
+import { ZodObject } from 'zod';
+import { recursiveUnwrap } from './recursiveUnwrap';
+
+export const getFieldKeyNames = (schema: ZodTypeAny): undefined | string[] => {
+	const unwrappedSchema = recursiveUnwrap(schema);
+	if (!(unwrappedSchema instanceof ZodObject)) {
+		return undefined;
+	}
+	const shape = unwrappedSchema.shape as Record<string, unknown>;
+	return Object.keys(shape);
+};

--- a/libs/newsletters-data-client/src/lib/zod-helpers/index.ts
+++ b/libs/newsletters-data-client/src/lib/zod-helpers/index.ts
@@ -2,3 +2,4 @@ export * from './getEmptySchemaData';
 export * from './recursiveUnwrap';
 export * from './schema-helpers';
 export * from './validation';
+export * from './getFieldKeyNames';

--- a/libs/state-machine/src/index.ts
+++ b/libs/state-machine/src/index.ts
@@ -5,3 +5,4 @@ export * from './lib/types';
 export * from './lib/utility';
 export * from './lib/getStartStep';
 export * from './lib/step-find-functions';
+export * from './lib/resolve-step-status';

--- a/libs/state-machine/src/lib/getStepList.ts
+++ b/libs/state-machine/src/lib/getStepList.ts
@@ -9,6 +9,7 @@ export type StepListing = {
 	canSkipTo?: boolean;
 	canSkipFrom?: boolean;
 	schema?: ZodObject<ZodRawShape>;
+	isOptional: boolean;
 };
 
 export type StepperConfig = {
@@ -30,6 +31,7 @@ export const getStepperConfig = (wizard: WizardLayout): StepperConfig => {
 					canSkipTo: step.canSkipTo,
 					canSkipFrom: !!step.executeSkip,
 					schema: step.schema,
+					isOptional: !step.schema || step.schema.safeParse({}).success,
 				},
 			];
 		},

--- a/libs/state-machine/src/lib/resolve-step-status.ts
+++ b/libs/state-machine/src/lib/resolve-step-status.ts
@@ -26,13 +26,6 @@ const areAllFieldsUnset = (
 	);
 };
 
-const isOptionalStep = (step: StepListing): boolean => {
-	if (!step.schema) {
-		return true;
-	}
-	return step.schema.safeParse({}).success;
-};
-
 export const resolveStepStatus = (
 	step: StepListing,
 	formData: FormDataRecord | undefined,
@@ -44,7 +37,7 @@ export const resolveStepStatus = (
 	if (!parseResult.success) {
 		return StepStatus.Incomplete;
 	}
-	if (isOptionalStep(step) && areAllFieldsUnset(step, formData)) {
+	if (step.isOptional && areAllFieldsUnset(step, formData)) {
 		return StepStatus.Optional;
 	}
 	return StepStatus.Complete;

--- a/libs/state-machine/src/lib/resolve-step-status.ts
+++ b/libs/state-machine/src/lib/resolve-step-status.ts
@@ -1,6 +1,6 @@
 import type { FormDataRecord } from '@newsletters-nx/newsletters-data-client';
 import { getFieldKeyNames } from '@newsletters-nx/newsletters-data-client';
-import type { StepListing } from '@newsletters-nx/state-machine';
+import type { StepListing } from './getStepList';
 
 export enum StepStatus {
 	Complete,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The `StepNav` can distinguish steps which are actually completed by the user and those which are 'complete by default'  since all the fields are optional. Such steps will be marked as 'optional' unless the user has entered some data (at which point, they are 'complete')


## How to test

Create a new draft - the steps that are will pass with no input are initially marked as 'optional'. If you populate at least one field, the step will be 'complete'.


## How can we measure success?

Better overview of the progress on the wizards

## Have we considered potential risks?

Not sure if users will actually understand the meaning - but can get UX feedback.

## Images
<img width="974" alt="Screenshot 2023-05-25 at 14 44 20" src="https://github.com/guardian/newsletters-nx/assets/30567854/c53c68c0-03b3-4963-9f13-d8c9264a41c6">