### PR TITLE
Rachel/thrasher validation

### DIFF
--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/multiThrashersLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/multiThrashersLayout.ts
@@ -73,6 +73,12 @@ export const multiThrashersLayout: WizardStepLayout<DraftStorage> = {
 							return 'ALL THREE THRASHERS MUST BE SPECIFIED FOR A CONFIGURATION';
 						}
 					}
+					const thrasherDescription = stepData.formData
+						? stepData.formData['thrasherOptions.thrasherDescription']
+						: undefined;
+					if (!thrasherDescription) {
+						return 'IF MULTI-THRASHERS ARE REQUIRED, MUST ENTER THRASHER DESCRIPTION ON PREVIOUS STEP';
+					}
 				}
 				return undefined;
 			},

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/singleThrasherLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/singleThrasherLayout.ts
@@ -51,17 +51,17 @@ export const singleThrasherLayout: WizardStepLayout<DraftStorage> = {
 			stepToMoveTo: getNextStepId,
 			onBeforeStepChangeValidate: (stepData): string | undefined => {
 				const singleThrasher = stepData.formData
-					? stepData.formData['singleThrasher']
+					? stepData.formData['thrasherOptions.singleThrasher']
 					: undefined;
 				if (singleThrasher) {
 					const singleThrasherLocation = stepData.formData
-						? stepData.formData['singleThrasherLocation']
+						? stepData.formData['thrasherOptions.singleThrasherLocation']
 						: undefined;
 					if (!singleThrasherLocation) {
 						return 'NO SINGLE THRASHER LOCATION SELECTED';
 					}
 					const thrasherDescription = stepData.formData
-						? stepData.formData['thrasherDescription']
+						? stepData.formData['thrasherOptions.thrasherDescription']
 						: undefined;
 					if (!thrasherDescription) {
 						return 'NO THRASHER DESCRIPTION PROVIDED';

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/singleThrasherLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/singleThrasherLayout.ts
@@ -53,6 +53,16 @@ export const singleThrasherLayout: WizardStepLayout<DraftStorage> = {
 				const singleThrasher = stepData.formData
 					? stepData.formData['thrasherOptions.singleThrasher']
 					: undefined;
+				const multiThrashers = stepData.formData
+					? (stepData.formData[
+							'thrasherOptions.multiThrashers'
+					  ] as unknown as Array<{
+							thrasher1: string;
+							thrasher2: string;
+							thrasher3: string;
+					  }>)
+					: undefined;
+
 				if (singleThrasher) {
 					const singleThrasherLocation = stepData.formData
 						? stepData.formData['thrasherOptions.singleThrasherLocation']
@@ -60,6 +70,9 @@ export const singleThrasherLayout: WizardStepLayout<DraftStorage> = {
 					if (!singleThrasherLocation) {
 						return 'NO SINGLE THRASHER LOCATION SELECTED';
 					}
+				}
+
+				if (singleThrasher || multiThrashers) {
 					const thrasherDescription = stepData.formData
 						? stepData.formData['thrasherOptions.thrasherDescription']
 						: undefined;

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/singleThrasherLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/singleThrasherLayout.ts
@@ -72,7 +72,7 @@ export const singleThrasherLayout: WizardStepLayout<DraftStorage> = {
 					}
 				}
 
-				if (singleThrasher || multiThrashers) {
+				if (singleThrasher || (multiThrashers && multiThrashers.length > 0)) {
 					const thrasherDescription = stepData.formData
 						? stepData.formData['thrasherOptions.thrasherDescription']
 						: undefined;

--- a/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
@@ -25,11 +25,9 @@ export const onlineArticleSchema = z
 	.describe('location of article');
 export type OnlineArticle = z.infer<typeof onlineArticleSchema>;
 
-export const singleThrasherLocation = z.enum([
-	'Web only',
-	'App only',
-	'Web and App',
-]);
+export const singleThrasherLocation = z
+	.enum(['Web only', 'App only', 'Web and App'])
+	.optional();
 export type SingleThrasherLocation = z.infer<typeof singleThrasherLocation>;
 
 export const renderingOptionsSchema = z.object({


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Corrects the validation of thrasher data, which had stopped working following the slight restructuring of data:
- single thrasher location is optional if "single thrasher required?" is not checked
- both single thrasher location and thrasher description must be specified if "single thrasher required?" is checked
- thrasher description must be specified if multi-thrashers have been specified (on the following step of the wizard)
- multi-thrasher configuration is not valid unless a thrasher description has been specified (on the previous step of the wizard)

## How to test

Run `npm run dev`
Edit a newsletter in the list of Drafts and navigate through the Newsletter Set-up wizard

## How can we measure success?

User forced to enter correct combinations of data

## Have we considered potential risks?

The user interface of this isn't great if the user attempts to save multi-thrasher information without first specifying a thrasher description on the previous step

## Images

FIELDS MUST BE ENTERED IF SINGLE THRASHER IS REQUIRED
![Screenshot 2023-05-30 at 12 46 33](https://github.com/guardian/newsletters-nx/assets/74301289/78e31690-4522-439a-bef3-1875aef51fae)

DESCRIPTION MUST BE ENTERED IF MULTI-THRASHER INFO ALREADY ENTERED
![Screenshot 2023-05-30 at 12 46 48](https://github.com/guardian/newsletters-nx/assets/74301289/a916b46f-6705-48ab-a154-ea1cfda3bf9e)

CAN'T SAVE MULTI-THRASHER INFO IF NO THRASHER DESCRIPTION
![Screenshot 2023-05-30 at 12 50 25](https://github.com/guardian/newsletters-nx/assets/74301289/3bd67c9b-71b0-4ba2-91cc-5ce452d8a177)


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
