### PR TITLE
Dblatcher wizard failure objects

### DIFF
--- a/apps/newsletters-ui/src/app/components/Wizard.tsx
+++ b/apps/newsletters-ui/src/app/components/Wizard.tsx
@@ -17,6 +17,7 @@ import { MarkdownView } from './MarkdownView';
 import { StateEditForm } from './StateEditForm';
 import { StepNav } from './StepNav';
 import { WizardActionButton } from './WizardActionButton';
+import { ZodIssuesReport } from './ZodIssuesReport';
 
 /**
  * Interface for the props passed to the `Wizard` component.
@@ -28,9 +29,11 @@ export interface WizardProps {
 
 const FailureAlert = (props: {
 	errorMessage: string;
+	errorDetails?: CurrentStepRouteResponse['errorDetails'];
 	isPersistent?: boolean;
 }) => {
-	const { errorMessage, isPersistent } = props;
+	const { errorMessage, isPersistent, errorDetails } = props;
+
 	if (isPersistent) {
 		return (
 			<Alert severity="error">
@@ -38,7 +41,15 @@ const FailureAlert = (props: {
 			</Alert>
 		);
 	}
-	return <Alert severity="warning">Please try again: {errorMessage}</Alert>;
+	return (
+		<Alert severity="warning">
+			{' '}
+			Please try again: {errorMessage}
+			{errorDetails?.zodIssues && (
+				<ZodIssuesReport issues={errorDetails.zodIssues} />
+			)}
+		</Alert>
+	);
 };
 
 /**
@@ -109,6 +120,7 @@ export const Wizard: React.FC<WizardProps> = ({
 		return (
 			<FailureAlert
 				errorMessage={serverErrorMessage}
+				errorDetails={serverData.errorDetails}
 				isPersistent={serverData.hasPersistentError}
 			/>
 		);
@@ -159,6 +171,7 @@ export const Wizard: React.FC<WizardProps> = ({
 				<Box paddingBottom={2}>
 					<FailureAlert
 						errorMessage={serverData.errorMessage}
+						errorDetails={serverData.errorDetails}
 						isPersistent={serverData.hasPersistentError}
 					/>
 				</Box>

--- a/apps/newsletters-ui/src/app/components/Wizard.tsx
+++ b/apps/newsletters-ui/src/app/components/Wizard.tsx
@@ -1,4 +1,4 @@
-import { Alert, Box, Stack } from '@mui/material';
+import { Alert, Box, Stack, Typography } from '@mui/material';
 import { useCallback, useEffect, useState } from 'react';
 import type { WizardId } from '@newsletters-nx/newsletter-workflow';
 import {
@@ -47,6 +47,15 @@ const FailureAlert = (props: {
 			Please try again: {errorMessage}
 			{errorDetails?.zodIssues && (
 				<ZodIssuesReport issues={errorDetails.zodIssues} />
+			)}
+			{errorDetails?.problemList && (
+				<Stack spacing={1} component={'ul'}>
+					{errorDetails.problemList.map((problem, index) => (
+						<Typography key={index} component={'li'}>
+							{problem}
+						</Typography>
+					))}
+				</Stack>
 			)}
 		</Alert>
 	);

--- a/libs/newsletter-workflow/src/lib/executeCreate.ts
+++ b/libs/newsletter-workflow/src/lib/executeCreate.ts
@@ -7,19 +7,17 @@ import {
 	formDataToDraftNewsletterData,
 } from '@newsletters-nx/newsletters-data-client';
 import {
+	makeWizardExecutionFailure,
 	StateMachineError,
 	StateMachineErrorCode,
 } from '@newsletters-nx/state-machine';
-import type {
-	AsyncExecution,
-	WizardFormData,
-} from '@newsletters-nx/state-machine';
+import type { AsyncExecution } from '@newsletters-nx/state-machine';
 
 export const executeCreate: AsyncExecution<DraftStorage> = async (
 	stepData,
 	stepLayout,
 	storageInstance,
-): Promise<WizardFormData | string> => {
+) => {
 	if (!storageInstance) {
 		throw new StateMachineError(
 			'no storageInstance',
@@ -39,9 +37,11 @@ export const executeCreate: AsyncExecution<DraftStorage> = async (
 
 	const parseResult = schema.safeParse(stepData.formData);
 	if (!parseResult.success) {
-		return `Form data is invalid for schema: ${
-			schema.description ?? '[no description]'
-		}`;
+		return makeWizardExecutionFailure(
+			`Form data is invalid for schema: ${
+				schema.description ?? '[no description]'
+			}`,
+		);
 	}
 
 	const draft: DraftNewsletterData = formDataToDraftNewsletterData({
@@ -55,5 +55,5 @@ export const executeCreate: AsyncExecution<DraftStorage> = async (
 		return draftNewsletterDataToFormData(storageResponse.data);
 	}
 
-	return storageResponse.message;
+	return makeWizardExecutionFailure(storageResponse.message);
 };

--- a/libs/newsletter-workflow/src/lib/executeCreate.ts
+++ b/libs/newsletter-workflow/src/lib/executeCreate.ts
@@ -8,6 +8,7 @@ import {
 } from '@newsletters-nx/newsletters-data-client';
 import {
 	makeWizardExecutionFailure,
+	makeWizardExecutionSuccess,
 	StateMachineError,
 	StateMachineErrorCode,
 } from '@newsletters-nx/state-machine';
@@ -52,7 +53,9 @@ export const executeCreate: AsyncExecution<DraftStorage> = async (
 		listId: undefined,
 	});
 	if (storageResponse.ok) {
-		return draftNewsletterDataToFormData(storageResponse.data);
+		return makeWizardExecutionSuccess(
+			draftNewsletterDataToFormData(storageResponse.data),
+		);
 	}
 
 	return makeWizardExecutionFailure(storageResponse.message);

--- a/libs/newsletter-workflow/src/lib/executeCreate.ts
+++ b/libs/newsletter-workflow/src/lib/executeCreate.ts
@@ -42,6 +42,7 @@ export const executeCreate: AsyncExecution<DraftStorage> = async (
 			`Form data is invalid for schema: ${
 				schema.description ?? '[no description]'
 			}`,
+			{ zodIssues: parseResult.error.issues },
 		);
 	}
 

--- a/libs/newsletter-workflow/src/lib/executeCreate.ts
+++ b/libs/newsletter-workflow/src/lib/executeCreate.ts
@@ -7,8 +7,6 @@ import {
 	formDataToDraftNewsletterData,
 } from '@newsletters-nx/newsletters-data-client';
 import {
-	makeWizardExecutionFailure,
-	makeWizardExecutionSuccess,
 	StateMachineError,
 	StateMachineErrorCode,
 } from '@newsletters-nx/state-machine';
@@ -38,12 +36,13 @@ export const executeCreate: AsyncExecution<DraftStorage> = async (
 
 	const parseResult = schema.safeParse(stepData.formData);
 	if (!parseResult.success) {
-		return makeWizardExecutionFailure(
-			`Form data is invalid for schema: ${
+		return {
+			isFailure: true,
+			message: `Form data is invalid for schema: ${
 				schema.description ?? '[no description]'
 			}`,
-			{ zodIssues: parseResult.error.issues },
-		);
+			details: { zodIssues: parseResult.error.issues },
+		};
 	}
 
 	const draft: DraftNewsletterData = formDataToDraftNewsletterData({
@@ -54,10 +53,13 @@ export const executeCreate: AsyncExecution<DraftStorage> = async (
 		listId: undefined,
 	});
 	if (storageResponse.ok) {
-		return makeWizardExecutionSuccess(
-			draftNewsletterDataToFormData(storageResponse.data),
-		);
+		return {
+			data: draftNewsletterDataToFormData(storageResponse.data),
+		};
 	}
 
-	return makeWizardExecutionFailure(storageResponse.message);
+	return {
+		isFailure: true,
+		message: storageResponse.message,
+	};
 };

--- a/libs/newsletter-workflow/src/lib/executeLaunch.ts
+++ b/libs/newsletter-workflow/src/lib/executeLaunch.ts
@@ -4,10 +4,6 @@ import type {
 	NewsletterData,
 } from '@newsletters-nx/newsletters-data-client';
 import type { AsyncExecution } from '@newsletters-nx/state-machine';
-import {
-	makeWizardExecutionFailure,
-	makeWizardExecutionSuccess,
-} from '@newsletters-nx/state-machine';
 import { parseToNumber } from './util';
 
 const DERIVED_FIELD_KEYS: Array<keyof NewsletterData> = [
@@ -45,11 +41,11 @@ export const executeLaunch: AsyncExecution<LaunchService> = async (
 ) => {
 	const draftId = parseToNumber(stepData['id']);
 	if (draftId === undefined) {
-		return makeWizardExecutionFailure('ERROR: invalid id.');
+		return { isFailure: true, message: 'ERROR: invalid id.' };
 	}
 
 	if (!launchService) {
-		return makeWizardExecutionFailure('ERROR: no launch service available');
+		return { isFailure: true, message: 'ERROR: no launch service available' };
 	}
 
 	const response = await launchService.launchDraft(
@@ -57,12 +53,14 @@ export const executeLaunch: AsyncExecution<LaunchService> = async (
 		getExtraValuesFromFormData(stepData.formData),
 	);
 	if (!response.ok) {
-		return makeWizardExecutionFailure(response.message);
+		return { isFailure: true, message: response.message };
 	}
 
-	return makeWizardExecutionSuccess({
-		newNewsletterListId: response.data.listId,
-		newNewsletterName: response.data.name,
-		newNewsletterIdentityName: response.data.identityName,
-	});
+	return {
+		data: {
+			newNewsletterListId: response.data.listId,
+			newNewsletterName: response.data.name,
+			newNewsletterIdentityName: response.data.identityName,
+		},
+	};
 };

--- a/libs/newsletter-workflow/src/lib/executeLaunch.ts
+++ b/libs/newsletter-workflow/src/lib/executeLaunch.ts
@@ -4,6 +4,7 @@ import type {
 	NewsletterData,
 } from '@newsletters-nx/newsletters-data-client';
 import type { AsyncExecution } from '@newsletters-nx/state-machine';
+import { makeWizardExecutionFailure } from '@newsletters-nx/state-machine';
 import { parseToNumber } from './util';
 
 const DERIVED_FIELD_KEYS: Array<keyof NewsletterData> = [
@@ -41,11 +42,11 @@ export const executeLaunch: AsyncExecution<LaunchService> = async (
 ) => {
 	const draftId = parseToNumber(stepData['id']);
 	if (draftId === undefined) {
-		return `ERROR: invalid id.`;
+		return makeWizardExecutionFailure('ERROR: invalid id.');
 	}
 
 	if (!launchService) {
-		return 'ERROR: no launch service available';
+		return makeWizardExecutionFailure('ERROR: no launch service available');
 	}
 
 	const response = await launchService.launchDraft(
@@ -53,7 +54,7 @@ export const executeLaunch: AsyncExecution<LaunchService> = async (
 		getExtraValuesFromFormData(stepData.formData),
 	);
 	if (!response.ok) {
-		return response.message;
+		return makeWizardExecutionFailure(response.message);
 	}
 
 	return {

--- a/libs/newsletter-workflow/src/lib/executeLaunch.ts
+++ b/libs/newsletter-workflow/src/lib/executeLaunch.ts
@@ -4,7 +4,10 @@ import type {
 	NewsletterData,
 } from '@newsletters-nx/newsletters-data-client';
 import type { AsyncExecution } from '@newsletters-nx/state-machine';
-import { makeWizardExecutionFailure } from '@newsletters-nx/state-machine';
+import {
+	makeWizardExecutionFailure,
+	makeWizardExecutionSuccess,
+} from '@newsletters-nx/state-machine';
 import { parseToNumber } from './util';
 
 const DERIVED_FIELD_KEYS: Array<keyof NewsletterData> = [
@@ -57,9 +60,9 @@ export const executeLaunch: AsyncExecution<LaunchService> = async (
 		return makeWizardExecutionFailure(response.message);
 	}
 
-	return {
+	return makeWizardExecutionSuccess({
 		newNewsletterListId: response.data.listId,
 		newNewsletterName: response.data.name,
 		newNewsletterIdentityName: response.data.identityName,
-	};
+	});
 };

--- a/libs/newsletter-workflow/src/lib/executeModify.ts
+++ b/libs/newsletter-workflow/src/lib/executeModify.ts
@@ -10,12 +10,13 @@ import {
 import type {
 	AsyncExecution,
 	WizardExecutionFailure,
-	WizardFormData,
+	WizardExecutionSuccess,
 	WizardStepData,
 	WizardStepLayout,
 } from '@newsletters-nx/state-machine';
 import {
 	makeWizardExecutionFailure,
+	makeWizardExecutionSuccess,
 	validateIncomingFormData,
 } from '@newsletters-nx/state-machine';
 
@@ -29,7 +30,7 @@ const doModify = async (
 	stepData: WizardStepData,
 	stepLayout?: WizardStepLayout,
 	service?: LaunchService | DraftStorage,
-): Promise<WizardFormData | WizardExecutionFailure> => {
+): Promise<WizardExecutionSuccess | WizardExecutionFailure> => {
 	if (!service) {
 		return makeWizardExecutionFailure('no draft storage instance');
 	}
@@ -67,7 +68,9 @@ const doModify = async (
 			};
 			const storageResponse = await ourDraftService.update(draftNewsletter);
 			if (storageResponse.ok) {
-				return draftNewsletterDataToFormData(storageResponse.data);
+				return makeWizardExecutionSuccess(
+					draftNewsletterDataToFormData(storageResponse.data),
+				);
 			}
 			return makeWizardExecutionFailure(storageResponse.message);
 		}

--- a/libs/newsletter-workflow/src/lib/executeModify.ts
+++ b/libs/newsletter-workflow/src/lib/executeModify.ts
@@ -54,7 +54,9 @@ const doModify = async (
 		);
 
 		if (formValidationError) {
-			return makeWizardExecutionFailure(formValidationError);
+			return makeWizardExecutionFailure(formValidationError.message, {
+				zodIssues: formValidationError.issues,
+			});
 		}
 
 		// listId specifically added to draftNewsletter to ensure correct typing

--- a/libs/newsletter-workflow/src/lib/executeSkip.ts
+++ b/libs/newsletter-workflow/src/lib/executeSkip.ts
@@ -5,7 +5,10 @@ import type {
 	WizardStepData,
 	WizardStepLayout,
 } from '@newsletters-nx/state-machine';
-import { makeWizardExecutionFailure } from '@newsletters-nx/state-machine';
+import {
+	makeWizardExecutionFailure,
+	makeWizardExecutionSuccess,
+} from '@newsletters-nx/state-machine';
 
 export const executeSkip: AsyncExecution<DraftStorage> = async (
 	stepData: WizardStepData,
@@ -19,6 +22,6 @@ export const executeSkip: AsyncExecution<DraftStorage> = async (
 		if (!stepData.formData) {
 			reject('missing form data');
 		}
-		resolve(stepData.formData as WizardFormData);
+		resolve(makeWizardExecutionSuccess(stepData.formData as WizardFormData));
 	});
 };

--- a/libs/newsletter-workflow/src/lib/executeSkip.ts
+++ b/libs/newsletter-workflow/src/lib/executeSkip.ts
@@ -5,10 +5,6 @@ import type {
 	WizardStepData,
 	WizardStepLayout,
 } from '@newsletters-nx/state-machine';
-import {
-	makeWizardExecutionFailure,
-	makeWizardExecutionSuccess,
-} from '@newsletters-nx/state-machine';
 
 export const executeSkip: AsyncExecution<DraftStorage> = async (
 	stepData: WizardStepData,
@@ -16,12 +12,12 @@ export const executeSkip: AsyncExecution<DraftStorage> = async (
 	storageInstance?: DraftStorage,
 ) => {
 	if (!storageInstance) {
-		return makeWizardExecutionFailure('no storage instance');
+		return { isFailure: true, message: 'no storage instance' };
 	}
 	return new Promise((resolve, reject) => {
 		if (!stepData.formData) {
 			reject('missing form data');
 		}
-		resolve(makeWizardExecutionSuccess(stepData.formData as WizardFormData));
+		resolve({ data: stepData.formData as WizardFormData });
 	});
 };

--- a/libs/newsletter-workflow/src/lib/executeSkip.ts
+++ b/libs/newsletter-workflow/src/lib/executeSkip.ts
@@ -5,14 +5,15 @@ import type {
 	WizardStepData,
 	WizardStepLayout,
 } from '@newsletters-nx/state-machine';
+import { makeWizardExecutionFailure } from '@newsletters-nx/state-machine';
 
 export const executeSkip: AsyncExecution<DraftStorage> = async (
 	stepData: WizardStepData,
 	stepLayout?: WizardStepLayout<DraftStorage>,
 	storageInstance?: DraftStorage,
-): Promise<WizardFormData | string> => {
+) => {
 	if (!storageInstance) {
-		return 'no storage instance';
+		return makeWizardExecutionFailure('no storage instance');
 	}
 	return new Promise((resolve, reject) => {
 		if (!stepData.formData) {

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/isDataCompleteLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/isDataCompleteLayout.ts
@@ -83,10 +83,13 @@ export const isDataCompleteLayout: WizardStepLayout<LaunchService> = {
 					| undefined;
 
 				if (launchInitialState?.hasAllStandardData !== true) {
-					return 'The draft is not ready to launch';
+					return { message: 'The draft is not ready to launch' };
 				}
 				if (!launchInitialState.hasRenderingOptionsIfNeeded) {
-					return 'The draft is not ready to launch because it needs rendering options set';
+					return {
+						message:
+							'The draft is not ready to launch because it needs rendering options set',
+					};
 				}
 				return undefined;
 			},

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/multiThrashersLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/multiThrashersLayout.ts
@@ -51,7 +51,7 @@ export const multiThrashersLayout: WizardStepLayout<DraftStorage> = {
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
-			onBeforeStepChangeValidate: (stepData): string | undefined => {
+			onBeforeStepChangeValidate: (stepData) => {
 				const multiThrashers = stepData.formData
 					? (stepData.formData[
 							'thrasherOptions.multiThrashers'
@@ -70,14 +70,20 @@ export const multiThrashersLayout: WizardStepLayout<DraftStorage> = {
 								!multiThrasher.thrasher3,
 						);
 						if (invalidThrashers.length > 0) {
-							return 'ALL THREE THRASHERS MUST BE SPECIFIED FOR A CONFIGURATION';
+							return {
+								message:
+									'ALL THREE THRASHERS MUST BE SPECIFIED FOR A CONFIGURATION',
+							};
 						}
 					}
 					const thrasherDescription = stepData.formData
 						? stepData.formData['thrasherOptions.thrasherDescription']
 						: undefined;
 					if (!thrasherDescription) {
-						return 'IF MULTI-THRASHERS ARE REQUIRED, MUST ENTER THRASHER DESCRIPTION ON PREVIOUS STEP';
+						return {
+							message:
+								'IF MULTI-THRASHERS ARE REQUIRED, MUST ENTER THRASHER DESCRIPTION ON PREVIOUS STEP',
+						};
 					}
 				}
 				return undefined;

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/newsletterDesignLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/newsletterDesignLayout.ts
@@ -44,15 +44,19 @@ export const newsletterDesignLayout: WizardStepLayout<DraftStorage> = {
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
-			onBeforeStepChangeValidate: (stepData): string | undefined => {
+			onBeforeStepChangeValidate: (stepData) => {
 				const newsletterDesignDoc = stepData.formData
 					? stepData.formData['designBriefDoc']
 					: undefined;
-				if (!newsletterDesignDoc) return 'NO DESIGN BRIEF DOC PROVIDED';
+				if (!newsletterDesignDoc) {
+					return { message: 'NO DESIGN BRIEF DOC PROVIDED' };
+				}
 				const figmaDesignUrl = stepData.formData
 					? stepData.formData['figmaDesignUrl']
 					: undefined;
-				if (!figmaDesignUrl) return 'NO FIGMA DESIGN URL PROVIDED';
+				if (!figmaDesignUrl) {
+					return { message: 'NO FIGMA DESIGN URL PROVIDED' };
+				}
 				const singleThrasher = stepData.formData
 					? stepData.formData['thrasherOptions.singleThrasher']
 					: undefined;
@@ -64,7 +68,10 @@ export const newsletterDesignLayout: WizardStepLayout<DraftStorage> = {
 						? stepData.formData['figmaIncludesThrashers']
 						: undefined;
 					if (!figmaIncludesThrashers) {
-						return 'FIGMA DESIGN MUST INCLUDE THRASHERS IF SINGLE/MULTI THRASHERS ARE REQUIRED';
+						return {
+							message:
+								'FIGMA DESIGN MUST INCLUDE THRASHERS IF SINGLE/MULTI THRASHERS ARE REQUIRED',
+						};
 					}
 				}
 				return undefined;

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/singleThrasherLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/singleThrasherLayout.ts
@@ -49,7 +49,7 @@ export const singleThrasherLayout: WizardStepLayout<DraftStorage> = {
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
-			onBeforeStepChangeValidate: (stepData): string | undefined => {
+			onBeforeStepChangeValidate: (stepData) => {
 				const singleThrasher = stepData.formData
 					? stepData.formData['thrasherOptions.singleThrasher']
 					: undefined;
@@ -68,7 +68,7 @@ export const singleThrasherLayout: WizardStepLayout<DraftStorage> = {
 						? stepData.formData['thrasherOptions.singleThrasherLocation']
 						: undefined;
 					if (!singleThrasherLocation) {
-						return 'NO SINGLE THRASHER LOCATION SELECTED';
+						return { message: 'NO SINGLE THRASHER LOCATION SELECTED' };
 					}
 				}
 
@@ -77,7 +77,7 @@ export const singleThrasherLayout: WizardStepLayout<DraftStorage> = {
 						? stepData.formData['thrasherOptions.thrasherDescription']
 						: undefined;
 					if (!thrasherDescription) {
-						return 'NO THRASHER DESCRIPTION PROVIDED';
+						return { message: 'NO THRASHER DESCRIPTION PROVIDED' };
 					}
 				}
 				return undefined;

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/tagsLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/tagsLayout.ts
@@ -57,7 +57,7 @@ export const tagsLayout: WizardStepLayout<DraftStorage> = {
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
-			onBeforeStepChangeValidate: (stepData): string | undefined => {
+			onBeforeStepChangeValidate: (stepData) => {
 				const composerTag = stepData.formData
 					? stepData.formData['composerTag']
 					: undefined;
@@ -66,10 +66,15 @@ export const tagsLayout: WizardStepLayout<DraftStorage> = {
 					: undefined;
 				if (composerTag || composerCampaignTag) {
 					if (!composerTag) {
-						return 'ENTER AT LEAST ONE COMPOSER TAG IF SPECIFYING COMPOSER CAMPAIGN TAG';
+						return {
+							message:
+								'ENTER AT LEAST ONE COMPOSER TAG IF SPECIFYING COMPOSER CAMPAIGN TAG',
+						};
 					}
 					if (!composerCampaignTag) {
-						return 'ENTER COMPOSER CAMPAIGN TAG IF SPECIFYING COMPOSER TAG';
+						return {
+							message: 'ENTER COMPOSER CAMPAIGN TAG IF SPECIFYING COMPOSER TAG',
+						};
 					}
 				}
 				return undefined;

--- a/libs/state-machine/src/lib/makeResponse.ts
+++ b/libs/state-machine/src/lib/makeResponse.ts
@@ -56,6 +56,7 @@ export const makeResponse = (
 			nextWizardStepLayout.buttons,
 		),
 		errorMessage: state.errorMessage,
+		errorDetails: state.errorDetails,
 		formData: state.formData,
 	};
 

--- a/libs/state-machine/src/lib/stateMachineButtonPressed.spec.ts
+++ b/libs/state-machine/src/lib/stateMachineButtonPressed.spec.ts
@@ -1,5 +1,9 @@
 import { stateMachineButtonPressed } from './stateMachineButtonPressed';
-import type { WizardLayout, WizardStepData } from './types';
+import type {
+	WizardExecutionSuccess,
+	WizardLayout,
+	WizardStepData,
+} from './types';
 
 const initialStep: WizardStepData = {
 	currentStepId: 'step1',
@@ -9,6 +13,11 @@ let mockStepData: WizardStepData;
 beforeEach(() => {
 	mockStepData = Object.assign({}, initialStep);
 });
+
+const mockExecutionSuccess: WizardExecutionSuccess = {
+	isFailure: false,
+	data: {},
+};
 
 const mockWizardLayout: WizardLayout = {
 	step1: {
@@ -76,7 +85,7 @@ describe('stateMachineButtonPressed', () => {
 });
 
 it('should execute step and move to next step if next button is pressed', async () => {
-	const executeStepMock = jest.fn().mockResolvedValue(undefined);
+	const executeStepMock = jest.fn().mockResolvedValue(mockExecutionSuccess);
 	const nextButton = mockWizardLayout['step1']?.buttons['next'];
 	const executeStep = nextButton?.executeStep;
 	if (nextButton && executeStep) {

--- a/libs/state-machine/src/lib/stateMachineButtonPressed.spec.ts
+++ b/libs/state-machine/src/lib/stateMachineButtonPressed.spec.ts
@@ -1,8 +1,11 @@
 import { stateMachineButtonPressed } from './stateMachineButtonPressed';
 import type {
+	ValidationFailure,
+	WizardExecutionFailure,
 	WizardExecutionSuccess,
 	WizardLayout,
 	WizardStepData,
+	WizardStepLayoutButton,
 } from './types';
 
 const initialStep: WizardStepData = {
@@ -15,8 +18,16 @@ beforeEach(() => {
 });
 
 const mockExecutionSuccess: WizardExecutionSuccess = {
-	isFailure: false,
 	data: {},
+};
+const mockExecutionFailure: WizardExecutionFailure = {
+	isFailure: true,
+	message: 'execution failed',
+	details: {},
+};
+const mockValidationFailure: ValidationFailure = {
+	message: 'validation failed',
+	details: {},
 };
 
 const mockWizardLayout: WizardLayout = {
@@ -68,6 +79,12 @@ const mockWizardLayout: WizardLayout = {
 	},
 };
 
+const resetMockHooksOnButton = (button: WizardStepLayoutButton) => {
+	button.onAfterStepStartValidate = jest.fn();
+	button.onBeforeStepChangeValidate = jest.fn();
+	button.executeStep = jest.fn();
+};
+
 const mockStorage = {};
 
 describe('stateMachineButtonPressed', () => {
@@ -82,117 +99,120 @@ describe('stateMachineButtonPressed', () => {
 			),
 		).rejects.toThrowError('Button poop not found in step step1');
 	});
-});
 
-it('should execute step and move to next step if next button is pressed', async () => {
-	const executeStepMock = jest.fn().mockResolvedValue(mockExecutionSuccess);
-	const nextButton = mockWizardLayout['step1']?.buttons['next'];
-	const executeStep = nextButton?.executeStep;
-	if (nextButton && executeStep) {
-		nextButton.executeStep = executeStepMock;
-		const newState = await stateMachineButtonPressed(
-			'next',
-			mockStepData,
-			mockWizardLayout,
-			false,
-			mockStorage,
-		);
-		expect(executeStepMock).toHaveBeenCalledWith(
-			mockStepData,
-			mockWizardLayout['step1'],
-			mockStorage,
-		);
-		expect(newState.currentStepId).toEqual('step2');
-	}
-});
+	it('should execute step and move to next step if next button is pressed', async () => {
+		const executeStepMock = jest.fn(() => mockExecutionSuccess);
+		const nextButton = mockWizardLayout['step1']?.buttons['next'];
+		const executeStep = nextButton?.executeStep;
+		if (nextButton && executeStep) {
+			nextButton.executeStep = executeStepMock;
+			const newState = await stateMachineButtonPressed(
+				'next',
+				mockStepData,
+				mockWizardLayout,
+				false,
+				mockStorage,
+			);
+			expect(executeStepMock).toHaveBeenCalledWith(
+				mockStepData,
+				mockWizardLayout['step1'],
+				mockStorage,
+			);
+			expect(newState.currentStepId).toEqual('step2');
+			resetMockHooksOnButton(nextButton);
+		}
+	});
 
-it('should validate before step change and return error message if there is validation error', async () => {
-	const onBeforeStepChangeValidateMock = jest
-		.fn()
-		.mockReturnValue('Validation error');
-	const nextButton = mockWizardLayout['step1']?.buttons['next'];
-	const onBeforeStepChangeValidate = nextButton?.onBeforeStepChangeValidate;
-	if (nextButton && onBeforeStepChangeValidate) {
-		nextButton.onBeforeStepChangeValidate = onBeforeStepChangeValidateMock;
-		const result = await stateMachineButtonPressed(
-			'next',
-			mockStepData,
-			mockWizardLayout,
-			false,
-			mockStorage,
-		);
-		expect(onBeforeStepChangeValidateMock).toHaveBeenCalledWith(
-			mockStepData,
-			mockWizardLayout['step1'],
-			mockStorage,
-		);
-		expect(result.currentStepId).toEqual('step1');
-		expect(result.errorMessage).toEqual('Validation error');
-	}
-});
+	it('should validate before step change and return error message if there is validation error', async () => {
+		const onBeforeStepChangeValidateMock = jest.fn(() => mockValidationFailure);
 
-it('should validate after step start and return error message if there is validation error', async () => {
-	const onAfterStepStartValidateMock = jest
-		.fn()
-		.mockReturnValue('Validation error');
-	const nextButton = mockWizardLayout['step1']?.buttons['next'];
-	const onAfterStepStartValidate = nextButton?.onAfterStepStartValidate;
-	if (nextButton && onAfterStepStartValidate) {
-		nextButton.onAfterStepStartValidate = onAfterStepStartValidateMock;
-		const result = await stateMachineButtonPressed(
-			'next',
-			mockStepData,
-			mockWizardLayout,
-			false,
-			mockStorage,
-		);
-		expect(onAfterStepStartValidateMock).toHaveBeenCalledWith(
-			mockStepData,
-			undefined,
-			mockStorage,
-		);
-		expect(result.currentStepId).toEqual('step1');
-		expect(result.errorMessage).toEqual('Validation error');
-	}
-});
+		const nextButton = mockWizardLayout['step1']?.buttons['next'];
+		const onBeforeStepChangeValidate = nextButton?.onBeforeStepChangeValidate;
+		if (nextButton && onBeforeStepChangeValidate) {
+			nextButton.onBeforeStepChangeValidate = onBeforeStepChangeValidateMock;
+			const result = await stateMachineButtonPressed(
+				'next',
+				mockStepData,
+				mockWizardLayout,
+				false,
+				mockStorage,
+			);
+			expect(onBeforeStepChangeValidateMock).toHaveBeenCalledWith(
+				mockStepData,
+				mockWizardLayout['step1'],
+				mockStorage,
+			);
+			expect(result.currentStepId).toEqual('step1');
+			expect(result.errorMessage).toEqual(mockValidationFailure.message);
+			resetMockHooksOnButton(nextButton);
+		}
+	});
 
-it('should fail to execute step and return error message if there is validation error', async () => {
-	const executeStepMock = jest.fn().mockReturnValue('Validation error');
-	const nextButton = mockWizardLayout['step1']?.buttons['next'];
-	const executeStep = nextButton?.executeStep;
-	if (nextButton && executeStep) {
-		nextButton.executeStep = executeStepMock;
-		const result = await stateMachineButtonPressed(
-			'next',
-			mockStepData,
-			mockWizardLayout,
-			false,
-			mockStorage,
-		);
-		expect(executeStepMock).toHaveBeenCalled;
-		expect(result.currentStepId).toEqual('step1');
-		expect(result.errorMessage).toEqual('Validation error');
-	}
-});
+	it('should validate after step start and return error message if there is validation error', async () => {
+		const onAfterStepStartValidateMock = jest.fn(() => mockValidationFailure);
 
-it('should move to previous step if prev button is pressed', async () => {
-	const executeStepMock = jest.fn().mockResolvedValue(undefined);
-	const backButton = mockWizardLayout['step1']?.buttons['back'];
-	const executeStep = backButton?.executeStep;
-	if (backButton && executeStep) {
-		backButton.executeStep = executeStepMock;
-		const newState = await stateMachineButtonPressed(
-			'back',
-			mockStepData,
-			mockWizardLayout,
-			false,
-			mockStorage,
-		);
-		expect(executeStepMock).toHaveBeenCalledWith(
-			mockStepData,
-			mockWizardLayout['step1'],
-			mockStorage,
-		);
-		expect(newState.currentStepId).toEqual('exit');
-	}
+		const nextButton = mockWizardLayout['step1']?.buttons['next'];
+		const onAfterStepStartValidate = nextButton?.onAfterStepStartValidate;
+		if (nextButton && onAfterStepStartValidate) {
+			nextButton.onAfterStepStartValidate = onAfterStepStartValidateMock;
+			const result = await stateMachineButtonPressed(
+				'next',
+				mockStepData,
+				mockWizardLayout,
+				false,
+				mockStorage,
+			);
+			expect(onAfterStepStartValidateMock).toHaveBeenCalledWith(
+				mockStepData,
+				undefined,
+				mockStorage,
+			);
+			expect(result.currentStepId).toEqual('step1');
+			expect(result.errorMessage).toEqual(mockValidationFailure.message);
+			resetMockHooksOnButton(nextButton);
+		}
+	});
+
+	it('should fail to execute step and return error message if there is validation error', async () => {
+		const executeStepMock = jest.fn().mockReturnValue(mockExecutionFailure);
+		const nextButton = mockWizardLayout['step1']?.buttons['next'];
+		const executeStep = nextButton?.executeStep;
+		if (nextButton && executeStep) {
+			nextButton.executeStep = executeStepMock;
+			const result = await stateMachineButtonPressed(
+				'next',
+				mockStepData,
+				mockWizardLayout,
+				false,
+				mockStorage,
+			);
+			expect(executeStepMock).toHaveBeenCalled;
+			expect(result.currentStepId).toEqual('step1');
+			expect(result.errorMessage).toEqual(mockExecutionFailure.message);
+			resetMockHooksOnButton(nextButton);
+		}
+	});
+
+	it('should move to previous step if prev button is pressed', async () => {
+		const executeStepMock = jest.fn(() => mockExecutionSuccess);
+		const backButton = mockWizardLayout['step1']?.buttons['back'];
+		const executeStep = backButton?.executeStep;
+		if (backButton && executeStep) {
+			backButton.executeStep = executeStepMock;
+			const newState = await stateMachineButtonPressed(
+				'back',
+				mockStepData,
+				mockWizardLayout,
+				false,
+				mockStorage,
+			);
+			expect(executeStepMock).toHaveBeenCalledWith(
+				mockStepData,
+				mockWizardLayout['step1'],
+				mockStorage,
+			);
+			expect(newState.currentStepId).toEqual('exit');
+			resetMockHooksOnButton(backButton);
+		}
+	});
 });

--- a/libs/state-machine/src/lib/stateMachineButtonPressed.ts
+++ b/libs/state-machine/src/lib/stateMachineButtonPressed.ts
@@ -6,6 +6,7 @@ import type {
 	WizardStepLayout,
 } from './types';
 import {
+	isWizardExecutionFailure,
 	makeStepDataWithErrorMessage,
 	validateIncomingFormData,
 } from './utility';
@@ -104,9 +105,9 @@ export async function stateMachineButtonPressed<
 		currentStepLayout,
 		storageInstance,
 	);
-	if (typeof executionResult === 'string') {
+	if (isWizardExecutionFailure(executionResult)) {
 		return makeStepDataWithErrorMessage(
-			executionResult,
+			executionResult.message,
 			incomingStepData.currentStepId,
 			incomingStepData.formData,
 		);

--- a/libs/state-machine/src/lib/stateMachineButtonPressed.ts
+++ b/libs/state-machine/src/lib/stateMachineButtonPressed.ts
@@ -54,9 +54,10 @@ export async function stateMachineButtonPressed<
 	);
 	if (incomingDataError) {
 		return makeStepDataWithErrorMessage(
-			incomingDataError,
+			incomingDataError.message,
 			incomingStepData.currentStepId,
 			incomingStepData.formData,
+			{ zodIssues: incomingDataError.issues },
 		);
 	}
 
@@ -110,6 +111,7 @@ export async function stateMachineButtonPressed<
 			executionResult.message,
 			incomingStepData.currentStepId,
 			incomingStepData.formData,
+			executionResult.details,
 		);
 	}
 

--- a/libs/state-machine/src/lib/stateMachineButtonPressed.ts
+++ b/libs/state-machine/src/lib/stateMachineButtonPressed.ts
@@ -62,33 +62,35 @@ export async function stateMachineButtonPressed<
 	}
 
 	if (buttonPressedDetails.onAfterStepStartValidate) {
-		const validationResult =
+		const validationFailure =
 			await buttonPressedDetails.onAfterStepStartValidate(
 				incomingStepData,
 				undefined,
 				storageInstance,
 			);
-		if (validationResult !== undefined) {
+		if (validationFailure) {
 			return makeStepDataWithErrorMessage(
-				validationResult,
+				validationFailure.message,
 				incomingStepData.currentStepId,
 				incomingStepData.formData,
+				validationFailure.details,
 			);
 		}
 	}
 
 	if (buttonPressedDetails.onBeforeStepChangeValidate) {
-		const validationResult =
+		const validationFailure =
 			await buttonPressedDetails.onBeforeStepChangeValidate(
 				incomingStepData,
 				currentStepLayout,
 				storageInstance,
 			);
-		if (validationResult !== undefined) {
+		if (validationFailure) {
 			return makeStepDataWithErrorMessage(
-				validationResult,
+				validationFailure.message,
 				incomingStepData.currentStepId,
 				incomingStepData.formData,
+				validationFailure.details,
 			);
 		}
 	}

--- a/libs/state-machine/src/lib/stateMachineButtonPressed.ts
+++ b/libs/state-machine/src/lib/stateMachineButtonPressed.ts
@@ -6,7 +6,6 @@ import type {
 	WizardStepLayout,
 } from './types';
 import {
-	isWizardExecutionFailure,
 	makeStepDataWithErrorMessage,
 	validateIncomingFormData,
 } from './utility';
@@ -105,7 +104,8 @@ export async function stateMachineButtonPressed<
 		currentStepLayout,
 		storageInstance,
 	);
-	if (isWizardExecutionFailure(executionResult)) {
+
+	if (executionResult.isFailure) {
 		return makeStepDataWithErrorMessage(
 			executionResult.message,
 			incomingStepData.currentStepId,
@@ -115,6 +115,6 @@ export async function stateMachineButtonPressed<
 
 	return {
 		currentStepId: stepToMoveTo,
-		formData: executionResult,
+		formData: executionResult.data,
 	};
 }

--- a/libs/state-machine/src/lib/stateMachineSkipPressed.ts
+++ b/libs/state-machine/src/lib/stateMachineSkipPressed.ts
@@ -5,10 +5,7 @@ import type {
 	WizardLayout,
 	WizardStepData,
 } from './types';
-import {
-	isWizardExecutionFailure,
-	makeStepDataWithErrorMessage,
-} from './utility';
+import { makeStepDataWithErrorMessage } from './utility';
 
 export async function stateMachineSkipPressed<
 	T extends GenericStorageInterface,
@@ -68,7 +65,7 @@ export async function stateMachineSkipPressed<
 		storageInstance,
 	);
 
-	if (isWizardExecutionFailure(executeSkipResult)) {
+	if (executeSkipResult.isFailure) {
 		return makeStepDataWithErrorMessage(
 			executeSkipResult.message,
 			requestBody.stepId,
@@ -77,7 +74,7 @@ export async function stateMachineSkipPressed<
 	}
 
 	return {
-		formData: executeSkipResult,
+		formData: executeSkipResult.data,
 		currentStepId: requestBody.stepToSkipToId,
 	};
 }

--- a/libs/state-machine/src/lib/stateMachineSkipPressed.ts
+++ b/libs/state-machine/src/lib/stateMachineSkipPressed.ts
@@ -70,6 +70,7 @@ export async function stateMachineSkipPressed<
 			executeSkipResult.message,
 			requestBody.stepId,
 			requestBody.formData,
+			executeSkipResult.details,
 		);
 	}
 

--- a/libs/state-machine/src/lib/stateMachineSkipPressed.ts
+++ b/libs/state-machine/src/lib/stateMachineSkipPressed.ts
@@ -5,7 +5,10 @@ import type {
 	WizardLayout,
 	WizardStepData,
 } from './types';
-import { makeStepDataWithErrorMessage } from './utility';
+import {
+	isWizardExecutionFailure,
+	makeStepDataWithErrorMessage,
+} from './utility';
 
 export async function stateMachineSkipPressed<
 	T extends GenericStorageInterface,
@@ -65,9 +68,9 @@ export async function stateMachineSkipPressed<
 		storageInstance,
 	);
 
-	if (typeof executeSkipResult === 'string') {
+	if (isWizardExecutionFailure(executeSkipResult)) {
 		return makeStepDataWithErrorMessage(
-			executeSkipResult,
+			executeSkipResult.message,
 			requestBody.stepId,
 			requestBody.formData,
 		);

--- a/libs/state-machine/src/lib/types.ts
+++ b/libs/state-machine/src/lib/types.ts
@@ -2,7 +2,7 @@ import type {
 	FormDataRecord,
 	WizardButtonType,
 } from '@newsletters-nx/newsletters-data-client';
-import type { ZodObject, ZodRawShape } from 'zod';
+import type { ZodIssue, ZodObject, ZodRawShape } from 'zod';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- needs to be completely generic?
 export type GenericStorageInterface = any;
@@ -11,6 +11,9 @@ export type WizardFormData = FormDataRecord;
 export type WizardExecutionFailure = {
 	isFailure: true;
 	message: string;
+	details?: {
+		zodIssues?: ZodIssue[];
+	};
 };
 export type WizardExecutionSuccess = {
 	isFailure: false;
@@ -33,6 +36,7 @@ export interface WizardStepData {
 	formData?: WizardFormData;
 	currentStepId: string;
 	errorMessage?: string;
+	errorDetails?: WizardExecutionFailure['details'];
 	// ID should be the id of item being edited, as determined by
 	// the page URL, rather than from the form data inputted by the user.
 	// It should be undefined for a "create" operation where the page will
@@ -141,6 +145,8 @@ export interface CurrentStepRouteResponse {
 
 	/** a user-friendly error message */
 	errorMessage?: string;
+
+	errorDetails?: WizardExecutionFailure['details'];
 
 	/** Whether the request resulted in a persistent error (as a opposed temporary connectivity error
 	 *  or validation error on the user input), so the user should not be prompted to try again */

--- a/libs/state-machine/src/lib/types.ts
+++ b/libs/state-machine/src/lib/types.ts
@@ -4,9 +4,14 @@ import type {
 } from '@newsletters-nx/newsletters-data-client';
 import type { ZodObject, ZodRawShape } from 'zod';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- needs to be completey generic?
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- needs to be completely generic?
 export type GenericStorageInterface = any;
 export type WizardFormData = FormDataRecord;
+
+export type WizardExecutionFailure = {
+	_isWizardFailure: true;
+	message: string;
+};
 
 /**
  * Interface for a button displayed in the wizard.
@@ -47,13 +52,13 @@ export type AsyncExecution<T extends GenericStorageInterface> = (
 	stepData: WizardStepData,
 	stepLayout?: WizardStepLayout<T>,
 	storageInstance?: T,
-) => Promise<WizardFormData | string>;
+) => Promise<WizardFormData | WizardExecutionFailure>;
 
 type Execution<T extends GenericStorageInterface> = (
 	stepData: WizardStepData,
 	stepLayout?: WizardStepLayout<T>,
 	storageInstance?: T,
-) => WizardFormData | string;
+) => WizardFormData | WizardExecutionFailure;
 
 export type FindStepIdFunction = {
 	(

--- a/libs/state-machine/src/lib/types.ts
+++ b/libs/state-machine/src/lib/types.ts
@@ -8,12 +8,14 @@ import type { ZodIssue, ZodObject, ZodRawShape } from 'zod';
 export type GenericStorageInterface = any;
 export type WizardFormData = FormDataRecord;
 
+export type FailureDetails = {
+	zodIssues?: ZodIssue[];
+};
+
 export type WizardExecutionFailure = {
 	isFailure: true;
 	message: string;
-	details?: {
-		zodIssues?: ZodIssue[];
-	};
+	details?: FailureDetails;
 };
 export type WizardExecutionSuccess = {
 	isFailure?: false;
@@ -36,7 +38,7 @@ export interface WizardStepData {
 	formData?: WizardFormData;
 	currentStepId: string;
 	errorMessage?: string;
-	errorDetails?: WizardExecutionFailure['details'];
+	errorDetails?: FailureDetails;
 	// ID should be the id of item being edited, as determined by
 	// the page URL, rather than from the form data inputted by the user.
 	// It should be undefined for a "create" operation where the page will
@@ -146,7 +148,7 @@ export interface CurrentStepRouteResponse {
 	/** a user-friendly error message */
 	errorMessage?: string;
 
-	errorDetails?: WizardExecutionFailure['details'];
+	errorDetails?: FailureDetails;
 
 	/** Whether the request resulted in a persistent error (as a opposed temporary connectivity error
 	 *  or validation error on the user input), so the user should not be prompted to try again */

--- a/libs/state-machine/src/lib/types.ts
+++ b/libs/state-machine/src/lib/types.ts
@@ -16,7 +16,7 @@ export type WizardExecutionFailure = {
 	};
 };
 export type WizardExecutionSuccess = {
-	isFailure: false;
+	isFailure?: false;
 	data: WizardFormData;
 };
 

--- a/libs/state-machine/src/lib/types.ts
+++ b/libs/state-machine/src/lib/types.ts
@@ -9,8 +9,12 @@ export type GenericStorageInterface = any;
 export type WizardFormData = FormDataRecord;
 
 export type WizardExecutionFailure = {
-	_isWizardFailure: true;
+	isFailure: true;
 	message: string;
+};
+export type WizardExecutionSuccess = {
+	isFailure: false;
+	data: WizardFormData;
 };
 
 /**
@@ -52,13 +56,13 @@ export type AsyncExecution<T extends GenericStorageInterface> = (
 	stepData: WizardStepData,
 	stepLayout?: WizardStepLayout<T>,
 	storageInstance?: T,
-) => Promise<WizardFormData | WizardExecutionFailure>;
+) => Promise<WizardExecutionSuccess | WizardExecutionFailure>;
 
 type Execution<T extends GenericStorageInterface> = (
 	stepData: WizardStepData,
 	stepLayout?: WizardStepLayout<T>,
 	storageInstance?: T,
-) => WizardFormData | WizardExecutionFailure;
+) => WizardExecutionSuccess | WizardExecutionFailure;
 
 export type FindStepIdFunction = {
 	(

--- a/libs/state-machine/src/lib/types.ts
+++ b/libs/state-machine/src/lib/types.ts
@@ -10,8 +10,14 @@ export type WizardFormData = FormDataRecord;
 
 export type FailureDetails = {
 	zodIssues?: ZodIssue[];
+	/** array of user-friendly messages describing a set of problems that make the failure */
+	problemList?: string[];
 };
 
+export type ValidationFailure = {
+	message: string;
+	details?: FailureDetails;
+};
 export type WizardExecutionFailure = {
 	isFailure: true;
 	message: string;
@@ -50,13 +56,13 @@ export type AsyncValidator<T extends GenericStorageInterface> = (
 	stepData: WizardStepData,
 	stepLayout?: WizardStepLayout<T>,
 	storageInstance?: T,
-) => Promise<string | undefined>;
+) => Promise<ValidationFailure | undefined>;
 
 type Validator<T extends GenericStorageInterface> = (
 	stepData: WizardStepData,
 	stepLayout?: WizardStepLayout<T>,
 	storageInstance?: T,
-) => string | undefined;
+) => ValidationFailure | undefined;
 
 export type AsyncExecution<T extends GenericStorageInterface> = (
 	stepData: WizardStepData,

--- a/libs/state-machine/src/lib/utility.ts
+++ b/libs/state-machine/src/lib/utility.ts
@@ -39,12 +39,8 @@ export const validateIncomingFormData = (
 
 		const parseResult = formSchemaForIncomingStep.safeParse(formData);
 		if (!parseResult.success) {
-			const issueList = parseResult.error.issues.map((issue) => {
-				const fieldName = issue.path.map((part) => part.toString()).join('/');
-				return `${fieldName}: "${issue.message}"`;
-			});
 			return {
-				message: `VALIDATION ERRORS: ${issueList.join('; ')}`,
+				message: `VALIDATION ERRORS x${parseResult.error.issues.length}`,
 				issues: parseResult.error.issues,
 			};
 		}

--- a/libs/state-machine/src/lib/utility.ts
+++ b/libs/state-machine/src/lib/utility.ts
@@ -1,16 +1,12 @@
 import type { FormDataRecord } from '@newsletters-nx/newsletters-data-client';
 import type { ZodIssue } from 'zod';
-import type {
-	WizardExecutionFailure,
-	WizardStepData,
-	WizardStepLayout,
-} from './types';
+import type { FailureDetails, WizardStepData, WizardStepLayout } from './types';
 
 export const makeStepDataWithErrorMessage = (
 	errorMessage: string,
 	stepId: string,
 	formData?: FormDataRecord,
-	errorDetails?: WizardExecutionFailure['details'],
+	errorDetails?: FailureDetails,
 ): WizardStepData => {
 	return {
 		...{

--- a/libs/state-machine/src/lib/utility.ts
+++ b/libs/state-machine/src/lib/utility.ts
@@ -48,23 +48,3 @@ export const validateIncomingFormData = (
 
 	return undefined;
 };
-
-export const makeWizardExecutionFailure = (
-	message: string,
-	details?: WizardExecutionFailure['details'],
-): WizardExecutionFailure => {
-	return {
-		isFailure: true,
-		message,
-		details,
-	};
-};
-
-export const makeWizardExecutionSuccess = (
-	data: WizardFormData,
-): WizardExecutionSuccess => {
-	return {
-		isFailure: false,
-		data,
-	};
-};

--- a/libs/state-machine/src/lib/utility.ts
+++ b/libs/state-machine/src/lib/utility.ts
@@ -1,5 +1,9 @@
 import type { FormDataRecord } from '@newsletters-nx/newsletters-data-client';
-import type { WizardStepData, WizardStepLayout } from './types';
+import type {
+	WizardExecutionFailure,
+	WizardStepData,
+	WizardStepLayout,
+} from './types';
 
 export const makeStepDataWithErrorMessage = (
 	errorMessage: string,
@@ -39,4 +43,23 @@ export const validateIncomingFormData = (
 	}
 
 	return false;
+};
+
+export const makeWizardExecutionFailure = (
+	message: string,
+): WizardExecutionFailure => {
+	return {
+		_isWizardFailure: true,
+		message,
+	};
+};
+
+export const isWizardExecutionFailure = (
+	value: unknown,
+): value is WizardExecutionFailure => {
+	if (!value || typeof value !== 'object') {
+		return false;
+	}
+	const record = value as Record<string, unknown>;
+	return !!record['_isWizardFailure'];
 };

--- a/libs/state-machine/src/lib/utility.ts
+++ b/libs/state-machine/src/lib/utility.ts
@@ -1,6 +1,8 @@
 import type { FormDataRecord } from '@newsletters-nx/newsletters-data-client';
 import type {
 	WizardExecutionFailure,
+	WizardExecutionSuccess,
+	WizardFormData,
 	WizardStepData,
 	WizardStepLayout,
 } from './types';
@@ -49,17 +51,16 @@ export const makeWizardExecutionFailure = (
 	message: string,
 ): WizardExecutionFailure => {
 	return {
-		_isWizardFailure: true,
+		isFailure: true,
 		message,
 	};
 };
 
-export const isWizardExecutionFailure = (
-	value: unknown,
-): value is WizardExecutionFailure => {
-	if (!value || typeof value !== 'object') {
-		return false;
-	}
-	const record = value as Record<string, unknown>;
-	return !!record['_isWizardFailure'];
+export const makeWizardExecutionSuccess = (
+	data: WizardFormData,
+): WizardExecutionSuccess => {
+	return {
+		isFailure: false,
+		data,
+	};
 };

--- a/libs/state-machine/src/lib/utility.ts
+++ b/libs/state-machine/src/lib/utility.ts
@@ -2,8 +2,6 @@ import type { FormDataRecord } from '@newsletters-nx/newsletters-data-client';
 import type { ZodIssue } from 'zod';
 import type {
 	WizardExecutionFailure,
-	WizardExecutionSuccess,
-	WizardFormData,
 	WizardStepData,
 	WizardStepLayout,
 } from './types';


### PR DESCRIPTION
## What does this change?

The validation hooks (`AsyncValidator` and `Validator` types used for `onAfterStepStartValidate` and `onBeforeStepChangeValidate`) return an object with a message property and optional `FailureDetails` if the validation fails (instead of a string). The return value is still `undefined` if the validation passes.

The `AsyncExecution` and `Execution` functions (for `executeStep` and `executeSkip`) will return a `WizardExecutionFailure`(instead of a string - has the message property and same optional `FailureDetails` as the validation failures)  or `WizardExecutionSuccess`

Where the execution or validation fails, the message and the details are passed down through the API layer and UI.

The `FailureAlert` component uses the details(if present) as well as the message to provide more structured / readable feedback than it could with string error messages alone.


## How to test

Run the launch wizard for "avon-recruitment", but change the identityName to "blue-empowering" - the error details from the"check-input-is-unique" module will be include a list of "problems"  rendered as a list.

Try to submit any step with invalid input (eg empty string for newsletter's name) - the schema validation errors will be included in the error details and rendered nicely within the alert.

## How can we measure success?

We are able to provide richer feedback on error states / user errors than we can with strings.

The `FailureDetails` type can be expanded to add extra metadata that we might want use for logging/analysis/monitoring 

## Have we considered potential risks?

A little more complexity, but should be offset by removing the confusion from interpreting strings as indicating an error.

## Images

<img width="1032" alt="Screenshot 2023-06-01 at 13 06 55" src="https://github.com/guardian/newsletters-nx/assets/30567854/b39d54b4-9a01-413f-9020-34cbd4fa6f4d">

<img width="1032" alt="Screenshot 2023-06-01 at 14 42 54" src="https://github.com/guardian/newsletters-nx/assets/30567854/5b932f00-a375-494b-adbb-39aaf3b00b30">

