### PR TITLE
Dblatcher radio enum fields

### DIFF
--- a/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
+++ b/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
@@ -74,6 +74,7 @@ export const EditNewsletterForm = ({ originalItem }: Props) => {
 				})}
 				submitButtonText="Update Newsletter"
 				isDisabled={waitingForResponse}
+				maxOptionsForRadioButtons={5}
 				message={
 					waitingForResponse ? (
 						<Alert severity="info">

--- a/apps/newsletters-ui/src/app/components/SchemaForm/RadioSelectInput.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/RadioSelectInput.tsx
@@ -1,0 +1,64 @@
+import type { SelectChangeEvent } from '@mui/material';
+import {
+	FormControl,
+	FormControlLabel,
+	FormLabel,
+	Radio,
+	RadioGroup,
+} from '@mui/material';
+import type { FunctionComponent } from 'react';
+import { defaultFieldStyle } from './styling';
+import type { FieldProps } from './util';
+
+const EMPTY_STRING = '';
+
+export const RadioSelectInput: FunctionComponent<
+	FieldProps & {
+		value: string | undefined;
+		optional?: boolean;
+		inputHandler: { (value: string | undefined): void };
+		options: string[];
+	}
+> = (props) => {
+	const { value, optional, options, inputHandler, label = 'value' } = props;
+	const handleChange = (event: SelectChangeEvent<string>) => {
+		if (event.target.value === EMPTY_STRING) {
+			return inputHandler(undefined);
+		}
+		return inputHandler(event.target.value);
+	};
+	const valueAsString = value ?? EMPTY_STRING;
+
+	return (
+		<div css={defaultFieldStyle}>
+			<FormControl fullWidth>
+				<FormLabel id={`radio-input-label-${label}-${options.toString()}`}>
+					{label}
+				</FormLabel>
+				<RadioGroup
+					aria-labelledby={`radio-input-label-${label}-${options.toString()}`}
+					name={`radio-input-group-${label}`}
+					value={valueAsString}
+					onChange={handleChange}
+				>
+					{optional && (
+						<FormControlLabel
+							value={EMPTY_STRING}
+							control={<Radio />}
+							label={'[none]'}
+						/>
+					)}
+
+					{options.map((option) => (
+						<FormControlLabel
+							key={option}
+							value={option}
+							control={<Radio />}
+							label={option}
+						/>
+					))}
+				</RadioGroup>
+			</FormControl>
+		</div>
+	);
+};

--- a/apps/newsletters-ui/src/app/components/SchemaForm/RecordInput.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/RecordInput.tsx
@@ -8,9 +8,15 @@ interface Props {
 	record: PrimitiveRecord;
 	recordSchema: ZodObject<ZodRawShape>;
 	editRecord: { (record: PrimitiveRecord): void };
+	maxOptionsForRadioButtons?: number;
 }
 
-export const RecordInput = ({ record, recordSchema, editRecord }: Props) => {
+export const RecordInput = ({
+	record,
+	recordSchema,
+	editRecord,
+	maxOptionsForRadioButtons,
+}: Props) => {
 	const warnings = getValidationWarnings(record, recordSchema);
 	return (
 		<SchemaForm
@@ -29,6 +35,7 @@ export const RecordInput = ({ record, recordSchema, editRecord }: Props) => {
 				}
 				return editRecord({ ...record, ...mod });
 			}}
+			maxOptionsForRadioButtons={maxOptionsForRadioButtons}
 		/>
 	);
 };

--- a/apps/newsletters-ui/src/app/components/SchemaForm/SchemaField.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/SchemaField.tsx
@@ -24,6 +24,7 @@ interface SchemaFieldProps<T extends z.ZodRawShape> {
 	showUnsupported?: boolean;
 	numberInputSettings?: NumberInputSettings;
 	validationWarning?: string;
+	maxOptionsForRadioButtons: number;
 }
 
 const WrongTypeMessage = (props: { field: FieldDef }) => (
@@ -41,6 +42,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 	showUnsupported = false,
 	numberInputSettings = {},
 	validationWarning,
+	maxOptionsForRadioButtons,
 }: SchemaFieldProps<T>) {
 	const { key, type, value } = field;
 
@@ -94,7 +96,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 			}
 
 			if (options) {
-				if (options.length <= 5) {
+				if (options.length <= maxOptionsForRadioButtons) {
 					return (
 						<RadioSelectInput
 							{...standardProps}
@@ -150,7 +152,10 @@ export function SchemaField<T extends z.ZodRawShape>({
 				return <WrongTypeMessage field={field} />;
 			}
 
-			if (field.enumOptions && field.enumOptions.length <= 5) {
+			if (
+				field.enumOptions &&
+				field.enumOptions.length <= maxOptionsForRadioButtons
+			) {
 				return (
 					<RadioSelectInput
 						{...standardProps}
@@ -187,6 +192,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 								{...standardProps}
 								value={value ?? []}
 								recordSchema={field.recordSchema}
+								maxOptionsForRadioButtons={maxOptionsForRadioButtons}
 							/>
 						);
 					} else {

--- a/apps/newsletters-ui/src/app/components/SchemaForm/SchemaField.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/SchemaField.tsx
@@ -4,6 +4,7 @@ import { BooleanInput } from './BooleanInput';
 import { DateInput } from './DateInput';
 import { NumberInput } from './NumberInput';
 import { OptionalNumberInput } from './OptionalNumberInput';
+import { RadioSelectInput } from './RadioSelectInput';
 import { SchemaArrayInput } from './SchemaArrayInput';
 // eslint-disable-next-line import/no-cycle -- schemaForm renders recursively for SchemaRecordArrayInput
 import { SchemaRecordArrayInput } from './SchemaRecordArrayInput';
@@ -93,6 +94,15 @@ export function SchemaField<T extends z.ZodRawShape>({
 			}
 
 			if (options) {
+				if (options.length <= 5) {
+					return (
+						<RadioSelectInput
+							{...standardProps}
+							value={value}
+							options={options}
+						/>
+					);
+				}
 				return (
 					<SelectInput {...standardProps} value={value} options={options} />
 				);
@@ -139,6 +149,17 @@ export function SchemaField<T extends z.ZodRawShape>({
 			if (typeof value !== 'string' && typeof value !== 'undefined') {
 				return <WrongTypeMessage field={field} />;
 			}
+
+			if (field.enumOptions && field.enumOptions.length <= 5) {
+				return (
+					<RadioSelectInput
+						{...standardProps}
+						value={value}
+						options={field.enumOptions}
+					/>
+				);
+			}
+
 			return (
 				<SelectInput
 					{...standardProps}

--- a/apps/newsletters-ui/src/app/components/SchemaForm/SchemaRecordArrayInput.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/SchemaRecordArrayInput.tsx
@@ -22,9 +22,16 @@ export const SchemaRecordArrayInput: FunctionComponent<
 		value: PrimitiveRecord[];
 		inputHandler: { (newValue: FieldValue): void };
 		recordSchema: ZodObject<ZodRawShape>;
+		maxOptionsForRadioButtons?: number;
 	}
 > = (props) => {
-	const { value, label, inputHandler, recordSchema } = props;
+	const {
+		value,
+		label,
+		inputHandler,
+		recordSchema,
+		maxOptionsForRadioButtons,
+	} = props;
 
 	const addNew = () => {
 		const newRecord = getEmptySchemaData(recordSchema, true);
@@ -76,6 +83,7 @@ export const SchemaRecordArrayInput: FunctionComponent<
 									editRecord={(record) => {
 										editRecordIndex(index, record);
 									}}
+									maxOptionsForRadioButtons={maxOptionsForRadioButtons}
 								/>
 							</Grid>
 							<Grid item xs={2} pb={1.5}>

--- a/apps/newsletters-ui/src/app/components/SchemaForm/index.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/index.tsx
@@ -17,6 +17,7 @@ interface Props<T extends z.ZodRawShape> {
 	excludedKeys?: string[];
 	readOnlyKeys?: string[];
 	validationWarnings: Partial<Record<keyof T, string>>;
+	maxOptionsForRadioButtons?: number;
 }
 
 const getArrayItemTypeAndRecordSchema = (
@@ -50,6 +51,7 @@ export function SchemaForm<T extends z.ZodRawShape>({
 	excludedKeys = [],
 	readOnlyKeys = [],
 	validationWarnings,
+	maxOptionsForRadioButtons = 0,
 }: Props<T>) {
 	const fields: FieldDef[] = [];
 	for (const key in schema.shape) {
@@ -97,6 +99,7 @@ export function SchemaForm<T extends z.ZodRawShape>({
 					showUnsupported={showUnsupported}
 					stringInputType={field.key === 'text' ? 'textArea' : undefined}
 					validationWarning={validationWarnings[field.key]}
+					maxOptionsForRadioButtons={maxOptionsForRadioButtons}
 				/>
 			))}
 		</article>

--- a/apps/newsletters-ui/src/app/components/SimpleForm.tsx
+++ b/apps/newsletters-ui/src/app/components/SimpleForm.tsx
@@ -21,6 +21,7 @@ interface Props<T extends z.ZodRawShape> {
 	submit: { (data: SchemaObjectType<T>): void };
 	isDisabled?: boolean;
 	message?: ReactNode;
+	maxOptionsForRadioButtons?: number;
 }
 
 /**
@@ -39,6 +40,7 @@ export function SimpleForm<T extends z.ZodRawShape>({
 	submit,
 	isDisabled,
 	message,
+	maxOptionsForRadioButtons,
 }: Props<T>) {
 	const [parseInitialDataResult, setParseInitialDataResult] = useState<
 		z.SafeParseReturnType<typeof schema, SchemaObjectType<T>> | undefined
@@ -143,6 +145,7 @@ export function SimpleForm<T extends z.ZodRawShape>({
 				changeValue={manageChange}
 				validationWarnings={warnings}
 				readOnlyKeys={isDisabled ? Object.keys(schema.shape) : undefined}
+				maxOptionsForRadioButtons={maxOptionsForRadioButtons}
 			/>
 			<Box marginBottom={2}>
 				<Button

--- a/apps/newsletters-ui/src/app/components/StateEditForm.tsx
+++ b/apps/newsletters-ui/src/app/components/StateEditForm.tsx
@@ -9,9 +9,15 @@ interface Props {
 	formSchema: z.ZodObject<z.ZodRawShape>;
 	formData: WizardFormData;
 	setFormData: { (newData: WizardFormData): void };
+	maxOptionsForRadioButtons?: number;
 }
 
-export const StateEditForm = ({ formSchema, formData, setFormData }: Props) => {
+export const StateEditForm = ({
+	formSchema,
+	formData,
+	setFormData,
+	maxOptionsForRadioButtons,
+}: Props) => {
 	const changeFormData = (value: FieldValue, field: FieldDef) => {
 		const mod = getModification(value, field);
 		const revisedData = {
@@ -38,6 +44,7 @@ export const StateEditForm = ({ formSchema, formData, setFormData }: Props) => {
 				data={formData}
 				validationWarnings={getValidationWarnings(formData, formSchema)}
 				changeValue={changeFormData}
+				maxOptionsForRadioButtons={maxOptionsForRadioButtons}
 			/>
 		</Box>
 	);

--- a/apps/newsletters-ui/src/app/components/Wizard.tsx
+++ b/apps/newsletters-ui/src/app/components/Wizard.tsx
@@ -152,6 +152,7 @@ export const Wizard: React.FC<WizardProps> = ({
 					formSchema={formSchema}
 					formData={formData}
 					setFormData={setFormData}
+					maxOptionsForRadioButtons={5}
 				/>
 			)}
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The `SchemaForm` will render a set of radio buttons instead of a drop down, unless the number of options exceeds the new `maxOptionsForRadioButtons` prop.

This prop is set to 5 for all existing uses of the SchemaForm`.

## How to test
Open a form page eg 
http://localhost:4200/newsletters/edit/blue-empowering

or go through a wizard to see some radio buttons.

## Have we considered potential risks?

Should be safe. The change is only presentational.

## Images

<img width="493" alt="Screenshot 2023-06-01 at 17 32 51" src="https://github.com/guardian/newsletters-nx/assets/30567854/1bc266c8-7297-4f0d-81b2-c70a2a1a469d">

