### PR TITLE
use semantic elements and aria labels

### DIFF
--- a/apps/newsletters-ui/src/app/components/StepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StepNav.tsx
@@ -56,6 +56,30 @@ const CompletionCaption = (props: { status: StepStatus | undefined }) => {
 	}
 };
 
+const ariaLabelForNonButtonStep = (
+	description: string,
+	active: boolean,
+	status?: StepStatus,
+): string => {
+	if (active) {
+		return `${description} (current step)`;
+	}
+
+	let statusDecription = '';
+	switch (status) {
+		case StepStatus.Complete:
+			statusDecription = '(complete)';
+			break;
+		case StepStatus.Incomplete:
+			statusDecription = '(incomplete)';
+			break;
+		case StepStatus.Optional:
+			statusDecription = '(optional)';
+	}
+
+	return `${description} ${statusDecription}`;
+};
+
 export const StepNav = ({
 	currentStepId,
 	stepperConfig,
@@ -132,10 +156,15 @@ export const StepNav = ({
 			sx={{ flexWrap: 'wrap' }}
 			nonLinear={stepperConfig.isNonLinear}
 			connector={null}
+			component={'nav'}
 		>
 			{filteredStepList.map((step) => {
+				const stepStatus = completionRecord[step.id];
+				const description = step.label ?? step.id;
+				const isButton = shouldRenderAsButton(step);
+
 				const caption = stepperConfig.indicateStepsComplete ? (
-					<CompletionCaption status={completionRecord[step.id]} />
+					<CompletionCaption status={stepStatus} />
 				) : undefined;
 
 				return (
@@ -146,19 +175,31 @@ export const StepNav = ({
 						}}
 						key={step.id}
 						active={isCurrent(step)}
+						component={isButton ? 'div' : 'section'}
+						aria-label={
+							isButton
+								? undefined
+								: ariaLabelForNonButtonStep(
+										description,
+										isCurrent(step),
+										stepStatus,
+								  )
+						}
+						aria-live="polite"
 					>
-						{shouldRenderAsButton(step) ? (
+						{isButton ? (
 							<StepButton
+								aria-label={`skip to "${description}" step`}
 								className="left-aligned-step-button"
 								onClick={() => {
 									handleStepClick(step.id);
 								}}
 								optional={caption}
 							>
-								{step.label ?? step.id}
+								{description}
 							</StepButton>
 						) : (
-							<StepLabel optional={caption}> {step.label ?? step.id}</StepLabel>
+							<StepLabel optional={caption}> {description}</StepLabel>
 						)}
 					</Step>
 				);


### PR DESCRIPTION
## What does this change?

Puts some semantic mark-up and aria-labels on the step nav:
 - the Stepper itself uses a 'nav', grouping the Steps together on the accessibility tree
 - the Steps not containing buttons use 'section', to group and label the contents
 - the Steps containing buttons remain as 'div' (no semantic significance), as the 'button' within it is the semantic element

## How to test

view the accessibility tree on a wizard page - the document structure is clearer.

## How can we measure success?

The wizard pages would be more accessible to screen reader users

## Have we considered potential risks?

This is a small improvement, but would need proper user testing to asses how intuitive the pages are.

## Images
## Accessibility

|before|after|
|---|---|
| <img width="493" alt="Screenshot 2023-06-02 at 08 56 04" src="https://github.com/guardian/newsletters-nx/assets/30567854/3d82ce5b-1f6e-472b-977b-c9f9813f84d2"> | <img width="559" alt="Screenshot 2023-06-02 at 09 26 42" src="https://github.com/guardian/newsletters-nx/assets/30567854/b47ad2c1-d49d-4c5c-a0e1-e05737b0b163"> |

