### PR TITLE
Dblatcher limit edit access

### DIFF
--- a/apps/newsletters-api/src/app/routes/newsletters.ts
+++ b/apps/newsletters-api/src/app/routes/newsletters.ts
@@ -58,7 +58,7 @@ export function registerNewsletterRoutes(app: FastifyInstance) {
 		Body: unknown;
 	}>('/api/newsletters/:newsletterId', async (req, res) => {
 		const user = getUserProfile(req);
-		const permissions = getPermissions(user.profile);
+		const permissions = await getPermissions(user.profile);
 
 		if (!permissions.editNewsletters) {
 			return res

--- a/libs/newsletters-data-client/src/index.ts
+++ b/libs/newsletters-data-client/src/index.ts
@@ -13,3 +13,4 @@ export * from './lib/transformWizardData';
 export * from './lib/storage-response-types';
 export * from './lib/zod-helpers';
 export * from './lib/user-profile';
+export * from './lib/user-permissions';

--- a/libs/newsletters-data-client/src/lib/user-permissions.ts
+++ b/libs/newsletters-data-client/src/lib/user-permissions.ts
@@ -12,18 +12,29 @@ export type UserPermissions = {
 	launchNewsletters: boolean;
 };
 
-const STATIC_USERS: Partial<Record<string, UserAccessLevel>> = {
+const STATIC_USERS = {
 	'david.blatcher@guardian.co.uk': UserAccessLevel.Viewer,
 };
 
-export const getUserAccessLevel = (user?: UserProfile): UserAccessLevel => {
+/**
+ * Placeholder function usering static user data. Async to
+ * simulate a call to the google groups API (or similar)
+ */
+export const getUserAccessLevel = async (
+	user?: UserProfile,
+): Promise<UserAccessLevel> => {
+	const userList: Partial<Record<string, UserAccessLevel>> =
+		await Promise.resolve(STATIC_USERS);
+
 	return user?.email
-		? STATIC_USERS[user.email] ?? UserAccessLevel.Viewer
+		? userList[user.email] ?? UserAccessLevel.Viewer
 		: UserAccessLevel.Viewer;
 };
 
-export const getPermissions = (user?: UserProfile): UserPermissions => {
-	const accessLevel = getUserAccessLevel(user);
+export const getPermissions = async (
+	user?: UserProfile,
+): Promise<UserPermissions> => {
+	const accessLevel = await getUserAccessLevel(user);
 	return {
 		editNewsletters: [
 			UserAccessLevel.Developer,

--- a/libs/newsletters-data-client/src/lib/user-permissions.ts
+++ b/libs/newsletters-data-client/src/lib/user-permissions.ts
@@ -1,0 +1,32 @@
+import type { UserProfile } from './user-profile';
+
+export enum UserAccessLevel {
+	Developer,
+	Editor,
+	Drafter,
+	Viewer,
+}
+
+type Permissions = {
+	editNewsletters: boolean;
+};
+
+const STATIC_USERS: Partial<Record<string, UserAccessLevel>> = {
+	'david.blatcher@guardian.co.uk': UserAccessLevel.Viewer,
+};
+
+export const getUserAccessLevel = (user?: UserProfile): UserAccessLevel => {
+	return user?.email
+		? STATIC_USERS[user.email] ?? UserAccessLevel.Viewer
+		: UserAccessLevel.Viewer;
+};
+
+export const getPermissions = (user?: UserProfile): Permissions => {
+	const accessLevel = getUserAccessLevel(user);
+	return {
+		editNewsletters: [
+			UserAccessLevel.Developer,
+			UserAccessLevel.Editor,
+		].includes(accessLevel),
+	};
+};

--- a/libs/newsletters-data-client/src/lib/user-permissions.ts
+++ b/libs/newsletters-data-client/src/lib/user-permissions.ts
@@ -7,8 +7,9 @@ export enum UserAccessLevel {
 	Viewer,
 }
 
-type Permissions = {
+export type UserPermissions = {
 	editNewsletters: boolean;
+	launchNewsletters: boolean;
 };
 
 const STATIC_USERS: Partial<Record<string, UserAccessLevel>> = {
@@ -21,10 +22,14 @@ export const getUserAccessLevel = (user?: UserProfile): UserAccessLevel => {
 		: UserAccessLevel.Viewer;
 };
 
-export const getPermissions = (user?: UserProfile): Permissions => {
+export const getPermissions = (user?: UserProfile): UserPermissions => {
 	const accessLevel = getUserAccessLevel(user);
 	return {
 		editNewsletters: [
+			UserAccessLevel.Developer,
+			UserAccessLevel.Editor,
+		].includes(accessLevel),
+		launchNewsletters: [
 			UserAccessLevel.Developer,
 			UserAccessLevel.Editor,
 		].includes(accessLevel),


### PR DESCRIPTION
## What does this change?

Adds a function to up the user profile against a static list of users and retrieve a set of `UserPermissions` based on the `UserAccessLevel` for the user.

The API routes for editing Newsletters and handling wizard requests use this function and return a 403 error if the user lacks the required permission.

## How to test

To test locally, you will need to make the existing `getUserProfile` function provide a user object, despite not having the header set by the google auth. You can do this by:
 - set the FAKE_JWT and USE_FAKE_JWT=true local environment variable to give yourself a 'fake' user profile locally. You can get the value for the FAKE_JWT by accessing the request headers from CODE (probably more trouble than its worth); or
 - hard code your user profile and change `getUserProfile` to return it by default

When you have your local user profile (hover over the avatar icon in the UI to check the name is coming through), add the email address to the `STATIC_USERS` object in the user-permissions module, assigning the desired `UserAccessLevel`.

If you set the level to "editor" or "developer" the UI will work as before - if not, you will get user-facing error messages when trying to run the launch wizard or use the 'edit newsletter' pages.


## How can we measure success?

Hard coding the users is an interim solution / WIP .It should be possible to replace the static users with an API call to the google groups service (or similar).

It would have been possible to provide the user permissions to the `launchService` interface and have the Wizard request a markdown message explaining that the particular user does not have permission, but that seemed excessively complex and potentially fragile - it seemed better to block the request at the API level and avoid complicating the existing wizard logic further.


## Have we considered potential risks?

We do need to be wary of 'doing auth' within our application. Provided we are clear on which routes need user-level access logic, it should be okay.

Our error responses  are currently limited to strings - by using the changes in https://github.com/guardian/newsletters-nx/pull/164 we could provide more structured details about the error that the UI could use to render more helpful feedback.

## Images


<img width="813" alt="Screenshot 2023-06-02 at 12 16 36" src="https://github.com/guardian/newsletters-nx/assets/30567854/50bdf509-5317-4b59-a0b4-37479cacaec0">

