### PR TITLE
Dblatcher skipping modal

### DIFF
--- a/apps/newsletters-ui/src/app/components/SkipConfirmationDialog.tsx
+++ b/apps/newsletters-ui/src/app/components/SkipConfirmationDialog.tsx
@@ -1,0 +1,35 @@
+import {
+	Button,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogTitle,
+} from '@mui/material';
+
+interface Props {
+	currentStepId: string;
+	showSkipModalFor?: string;
+	handleCancelSkip: () => void;
+	handleConfirmSkip: () => void;
+}
+
+export const SkipConfirmationDialog = ({
+	currentStepId,
+	showSkipModalFor,
+	handleCancelSkip,
+	handleConfirmSkip,
+}: Props) => {
+	return (
+		<Dialog open={!!showSkipModalFor}>
+			<DialogTitle>Skip modal</DialogTitle>
+			<DialogContent>
+				Do you want to cancel the changes you have made to "{currentStepId}"
+				skip to "{showSkipModalFor}"?
+			</DialogContent>
+			<DialogActions>
+				<Button onClick={handleCancelSkip}>no</Button>
+				<Button onClick={handleConfirmSkip}>yes</Button>
+			</DialogActions>
+		</Dialog>
+	);
+};

--- a/apps/newsletters-ui/src/app/components/SkipConfirmationDialog.tsx
+++ b/apps/newsletters-ui/src/app/components/SkipConfirmationDialog.tsx
@@ -3,32 +3,49 @@ import {
 	Dialog,
 	DialogActions,
 	DialogContent,
+	DialogContentText,
 	DialogTitle,
 } from '@mui/material';
+import type { StepperConfig } from '@newsletters-nx/state-machine';
 
 interface Props {
 	currentStepId: string;
-	showSkipModalFor?: string;
+	targetStepId?: string;
 	handleCancelSkip: () => void;
 	handleConfirmSkip: () => void;
+	stepperConfig: StepperConfig;
 }
 
 export const SkipConfirmationDialog = ({
 	currentStepId,
-	showSkipModalFor,
+	targetStepId,
 	handleCancelSkip,
 	handleConfirmSkip,
+	stepperConfig,
 }: Props) => {
+	const currentStepListing = stepperConfig.steps.find(
+		(step) => step.id === currentStepId,
+	);
+	const currentStepLabel = currentStepListing?.label ?? currentStepId;
+	const targetStepListing = stepperConfig.steps.find(
+		(step) => step.id === targetStepId,
+	);
+	const targetStepLabel = targetStepListing?.label ?? targetStepId;
+
 	return (
-		<Dialog open={!!showSkipModalFor}>
-			<DialogTitle>Skip modal</DialogTitle>
+		<Dialog open={!!targetStepId}>
+			<DialogTitle>Discard changes to {currentStepLabel}?</DialogTitle>
 			<DialogContent>
-				Do you want to cancel the changes you have made to "{currentStepId}"
-				skip to "{showSkipModalFor}"?
+				<DialogContentText>
+					Skipping to "{targetStepLabel}" will discard the changes made on
+					"currentStepLabel".
+				</DialogContentText>
 			</DialogContent>
 			<DialogActions>
-				<Button onClick={handleCancelSkip}>no</Button>
-				<Button onClick={handleConfirmSkip}>yes</Button>
+				<Button onClick={handleCancelSkip}>Stay on this step</Button>
+				<Button onClick={handleConfirmSkip} variant="contained">
+					Discard Changes and skip
+				</Button>
 			</DialogActions>
 		</Dialog>
 	);

--- a/apps/newsletters-ui/src/app/components/Wizard.tsx
+++ b/apps/newsletters-ui/src/app/components/Wizard.tsx
@@ -1,14 +1,4 @@
-import {
-	Alert,
-	Box,
-	Button,
-	Dialog,
-	DialogActions,
-	DialogContent,
-	DialogTitle,
-	Stack,
-	Typography,
-} from '@mui/material';
+import { Alert, Box, Stack, Typography } from '@mui/material';
 import { useCallback, useEffect, useState } from 'react';
 import type { WizardId } from '@newsletters-nx/newsletter-workflow';
 import {
@@ -24,6 +14,7 @@ import type {
 } from '@newsletters-nx/state-machine';
 import { makeWizardStepRequest } from '../api-requests/make-wizard-step-request';
 import { MarkdownView } from './MarkdownView';
+import { SkipConfirmationDialog } from './SkipConfirmationDialog';
 import { StateEditForm } from './StateEditForm';
 import { StepNav } from './StepNav';
 import { WizardActionButton } from './WizardActionButton';
@@ -209,11 +200,11 @@ export const Wizard: React.FC<WizardProps> = ({
 	};
 
 	const handleCancelSkip = () => {
-		return setShowSkipModalFor(undefined);
+		setShowSkipModalFor(undefined);
 	};
 
 	const handleConfirmSkip = () => {
-		return void fetchStep({
+		void fetchStep({
 			wizardId: wizardId,
 			id: id,
 			stepId: serverData.currentStepId,
@@ -261,19 +252,12 @@ export const Wizard: React.FC<WizardProps> = ({
 				))}
 			</Stack>
 
-			{showSkipModalFor && (
-				<Dialog open>
-					<DialogTitle>Skip modal</DialogTitle>
-					<DialogContent>
-						Do you want to cancel the changes you have made to "
-						{serverData.currentStepId}" skip to "{showSkipModalFor}"?
-					</DialogContent>
-					<DialogActions>
-						<Button onClick={handleCancelSkip}>no</Button>
-						<Button onClick={handleConfirmSkip}>yes</Button>
-					</DialogActions>
-				</Dialog>
-			)}
+			<SkipConfirmationDialog
+				currentStepId={serverData.currentStepId}
+				showSkipModalFor={showSkipModalFor}
+				handleCancelSkip={handleCancelSkip}
+				handleConfirmSkip={handleConfirmSkip}
+			/>
 		</Box>
 	);
 };

--- a/apps/newsletters-ui/src/app/components/Wizard.tsx
+++ b/apps/newsletters-ui/src/app/components/Wizard.tsx
@@ -74,10 +74,18 @@ export const Wizard: React.FC<WizardProps> = ({
 	const [formData, setFormData] = useState<WizardFormData | undefined>(
 		undefined,
 	);
+	const [currentStepHasBeenChanged, setCurrentStepHasBeenChanged] =
+		useState(false);
 	const [listId, setListId] = useState<number | undefined>(undefined);
 	const [serverErrorMessage, setServerErrorMessage] = useState<
 		string | undefined
 	>();
+
+	const handleFormChange = (updatedLocalState: WizardFormData): void => {
+		console.log('CHANGE MADE!');
+		setCurrentStepHasBeenChanged(true);
+		return setFormData(updatedLocalState);
+	};
 
 	const fetchStep = useCallback(
 		async (body: CurrentStepRouteRequest) => {
@@ -97,6 +105,8 @@ export const Wizard: React.FC<WizardProps> = ({
 					...blank,
 					...data.formData,
 				});
+				console.log('new data - setCurrentStepHasBeenChanged = false ');
+				setCurrentStepHasBeenChanged(false);
 			} catch (error: unknown /* FIXME! */) {
 				setServerErrorMessage('Wizard failed');
 				console.error('Error invoking next step of wizard:', error);
@@ -172,7 +182,7 @@ export const Wizard: React.FC<WizardProps> = ({
 				<StateEditForm
 					formSchema={formSchema}
 					formData={formData}
-					setFormData={setFormData}
+					setFormData={handleFormChange}
 					maxOptionsForRadioButtons={5}
 				/>
 			)}
@@ -195,6 +205,11 @@ export const Wizard: React.FC<WizardProps> = ({
 					/>
 				))}
 			</Stack>
+			<Box>
+				<Typography>
+					{currentStepHasBeenChanged ? 'CHANGED' : 'NOT CHANGED'}
+				</Typography>
+			</Box>
 		</Box>
 	);
 };

--- a/apps/newsletters-ui/src/app/components/Wizard.tsx
+++ b/apps/newsletters-ui/src/app/components/Wizard.tsx
@@ -95,7 +95,6 @@ export const Wizard: React.FC<WizardProps> = ({
 				}
 
 				setServerData(data);
-
 				const schema = getFormSchema(wizardId, data.currentStepId);
 				const blank = schema ? getEmptySchemaData(schema) : undefined;
 
@@ -103,7 +102,6 @@ export const Wizard: React.FC<WizardProps> = ({
 					...blank,
 					...data.formData,
 				});
-				console.log('new data - setCurrentStepHasBeenChanged = false ');
 				setCurrentStepHasBeenChanged(false);
 				setShowSkipModalFor(undefined);
 			} catch (error: unknown /* FIXME! */) {
@@ -152,17 +150,14 @@ export const Wizard: React.FC<WizardProps> = ({
 
 	const handleFormChange = (updatedLocalState: WizardFormData): void => {
 		if (showSkipModalFor) {
-			console.log('UI BLOCKED FOR MODAL');
 			return;
 		}
-		console.log('CHANGE MADE!');
 		setCurrentStepHasBeenChanged(true);
 		return setFormData(updatedLocalState);
 	};
 
 	const handleButtonClick = (buttonId: string) => () => {
 		if (showSkipModalFor) {
-			console.log('UI BLOCKED FOR MODAL');
 			return;
 		}
 		void fetchStep({
@@ -176,7 +171,6 @@ export const Wizard: React.FC<WizardProps> = ({
 
 	const handleStepClick = (stepToSkipToId: string) => {
 		if (showSkipModalFor) {
-			console.log('UI BLOCKED FOR MODAL');
 			return;
 		}
 

--- a/apps/newsletters-ui/src/app/components/Wizard.tsx
+++ b/apps/newsletters-ui/src/app/components/Wizard.tsx
@@ -254,9 +254,10 @@ export const Wizard: React.FC<WizardProps> = ({
 
 			<SkipConfirmationDialog
 				currentStepId={serverData.currentStepId}
-				showSkipModalFor={showSkipModalFor}
+				targetStepId={showSkipModalFor}
 				handleCancelSkip={handleCancelSkip}
 				handleConfirmSkip={handleConfirmSkip}
+				stepperConfig={stepperConfig}
 			/>
 		</Box>
 	);

--- a/libs/newsletter-workflow/src/lib/executeSkip.ts
+++ b/libs/newsletter-workflow/src/lib/executeSkip.ts
@@ -1,7 +1,5 @@
-import {
-	draftNewsletterDataToFormData,
-	type DraftStorage,
-} from '@newsletters-nx/newsletters-data-client';
+import { draftNewsletterDataToFormData } from '@newsletters-nx/newsletters-data-client';
+import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
 import type {
 	AsyncExecution,
 	WizardStepData,

--- a/libs/newsletter-workflow/src/lib/executeSkip.ts
+++ b/libs/newsletter-workflow/src/lib/executeSkip.ts
@@ -1,10 +1,28 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import {
+	draftNewsletterDataToFormData,
+	type DraftStorage,
+} from '@newsletters-nx/newsletters-data-client';
 import type {
 	AsyncExecution,
-	WizardFormData,
 	WizardStepData,
 	WizardStepLayout,
 } from '@newsletters-nx/state-machine';
+
+const getListId = (stepData: WizardStepData): number | undefined => {
+	if (stepData.id) {
+		return Number(stepData.id);
+	}
+	const listIdOnForm = stepData.formData?.['listId'];
+	if (listIdOnForm) {
+		if (typeof listIdOnForm === 'number') {
+			return listIdOnForm;
+		}
+		if (typeof listIdOnForm === 'string') {
+			return Number(listIdOnForm);
+		}
+	}
+	return undefined;
+};
 
 export const executeSkip: AsyncExecution<DraftStorage> = async (
 	stepData: WizardStepData,
@@ -14,10 +32,22 @@ export const executeSkip: AsyncExecution<DraftStorage> = async (
 	if (!storageInstance) {
 		return { isFailure: true, message: 'no storage instance' };
 	}
-	return new Promise((resolve, reject) => {
-		if (!stepData.formData) {
-			reject('missing form data');
-		}
-		resolve({ data: stepData.formData as WizardFormData });
-	});
+
+	const listId = getListId(stepData);
+	if (typeof listId === 'undefined') {
+		return {
+			isFailure: true,
+			message: 'incoming data did not include the listId',
+		};
+	}
+	const storageResponse = await storageInstance.read(listId);
+
+	if (!storageResponse.ok) {
+		return {
+			isFailure: true,
+			message: `failed to fetch data for draft #${listId}`,
+		};
+	}
+
+	return { data: draftNewsletterDataToFormData(storageResponse.data) };
 };

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/createDraftNewsletterLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/createDraftNewsletterLayout.ts
@@ -29,5 +29,6 @@ The first step is to enter the name of your newsletter. For example,  **Down to 
 	schema: formSchemas.startDraftNewsletter,
 	role: 'CREATE_START',
 	canSkipTo: true,
+	skippingWillPersistLocalChanges: true,
 	executeSkip: executeCreate,
 };

--- a/libs/state-machine/src/lib/getStepList.ts
+++ b/libs/state-machine/src/lib/getStepList.ts
@@ -8,7 +8,7 @@ export type StepListing = {
 	parentStepId?: WizardStepLayout['parentStepId'];
 	canSkipTo?: boolean;
 	canSkipFrom?: boolean;
-	skippingWillPersistLocalChanges: boolean;
+	skippingWillPersistLocalChanges?: boolean;
 	schema?: ZodObject<ZodRawShape>;
 	isOptional: boolean;
 };
@@ -31,8 +31,7 @@ export const getStepperConfig = (wizard: WizardLayout): StepperConfig => {
 					parentStepId: step.parentStepId,
 					canSkipTo: step.canSkipTo,
 					canSkipFrom: !!step.executeSkip,
-					skippingWillPersistLocalChanges:
-						!!step.skippingWillPersistLocalChanges,
+					skippingWillPersistLocalChanges: step.skippingWillPersistLocalChanges,
 					schema: step.schema,
 					isOptional: !step.schema || step.schema.safeParse({}).success,
 				},

--- a/libs/state-machine/src/lib/getStepList.ts
+++ b/libs/state-machine/src/lib/getStepList.ts
@@ -8,6 +8,7 @@ export type StepListing = {
 	parentStepId?: WizardStepLayout['parentStepId'];
 	canSkipTo?: boolean;
 	canSkipFrom?: boolean;
+	skippingWillPersistLocalChanges: boolean;
 	schema?: ZodObject<ZodRawShape>;
 	isOptional: boolean;
 };
@@ -30,6 +31,8 @@ export const getStepperConfig = (wizard: WizardLayout): StepperConfig => {
 					parentStepId: step.parentStepId,
 					canSkipTo: step.canSkipTo,
 					canSkipFrom: !!step.executeSkip,
+					skippingWillPersistLocalChanges:
+						!!step.skippingWillPersistLocalChanges,
 					schema: step.schema,
 					isOptional: !step.schema || step.schema.safeParse({}).success,
 				},

--- a/libs/state-machine/src/lib/types.ts
+++ b/libs/state-machine/src/lib/types.ts
@@ -107,6 +107,7 @@ export interface WizardStepLayout<T extends GenericStorageInterface = unknown> {
 	buttons: Record<string, WizardStepLayoutButton<T>>;
 	schema?: ZodObject<ZodRawShape>;
 	canSkipTo?: boolean;
+	skippingWillPersistLocalChanges?: boolean;
 	executeSkip?: AsyncExecution<T> | Execution<T>;
 	getInitialFormData?: {
 		(


### PR DESCRIPTION
## What does this change?

The `executeSkip` function used in the wizardLayouts will send the version of the data previously persisted  on the server back to the client - effectively causing the client to 'discard' the local changes to the data the user may have made before skipping from the current step.

Adds an optional boolean property to the `WizardLayoutStep` to specify that skipping **FROM** that step will persist the data (the default behaviour is  assumed to be that skipping will NOT persist the local changes). This is set to `true` on the `createDraftNewsletterLayout` since it uses `executeCreate` rather than `executeSkip`.

Before the user skips and discard the local changes on the step, they are presented with a confirmation modal. The modal is NOT presented if the user has not made any changes on the step since they landed on it.

## How to test

Run the wizard - go to any step other than the initial `createDraftNewsletterLayout`. Make a change to a field and click another step to skip. The modal will offer the choice of staying on the current step or discarding your local change.

## How can we measure success?

Clearer to users what is saved and what is not. No mismatch between the client and server leading to unexpected behaviour.

## Have we considered potential risks?

yes

## Images

<img width="946" alt="Screenshot 2023-06-08 at 15 26 37" src="https://github.com/guardian/newsletters-nx/assets/30567854/2f0cc519-7705-4f4a-8f07-819bbadabd0d">

