### PR TITLE
Limit fetch profile call to initial render

### DIFF
--- a/apps/newsletters-ui/src/app/hooks/user-hooks.ts
+++ b/apps/newsletters-ui/src/app/hooks/user-hooks.ts
@@ -36,7 +36,7 @@ export const useProfile = () => {
 
 	useEffect(() => {
 		void fetchAndSet();
-	});
+	}, []);
 
 	return userProfile;
 };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Noticed that there was a loop in the call to the whoami endpoint from the useHook. This PR updates the hook to fire on initial render which resolve the problem. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Check the network tab in main...
![Screenshot 2023-06-09 at 15 54 32](https://github.com/guardian/newsletters-nx/assets/3277259/9bd66dcf-a658-4139-b4d8-478e2cf2bc6a)

Not check out this branch and try it again.


