### PR TITLE
Using a fixed header to keep nav in view on scroll.

### DIFF
--- a/apps/newsletters-ui/src/app/Layout.tsx
+++ b/apps/newsletters-ui/src/app/Layout.tsx
@@ -4,6 +4,7 @@ import {
 	space,
 	textSansObjectStyles,
 } from '@guardian/source-foundations';
+import { Box } from '@mui/material';
 import { Outlet } from 'react-router-dom';
 import { MainNav } from './components/MainNav';
 
@@ -46,7 +47,9 @@ export function Layout(props: IRootRoute) {
 			<header>
 				<MainNav />
 			</header>
-			<main>{props.outlet ? props.outlet : <Outlet />}</main>
+			<Box pt={8}>
+				<main>{props.outlet ? props.outlet : <Outlet />}</main>
+			</Box>
 		</Frame>
 	);
 }

--- a/apps/newsletters-ui/src/app/components/MainNav.tsx
+++ b/apps/newsletters-ui/src/app/components/MainNav.tsx
@@ -47,7 +47,7 @@ export function MainNav() {
 	};
 
 	return (
-		<AppBar position="static">
+		<AppBar position="fixed">
 			<Container maxWidth="xl">
 				<Toolbar disableGutters>
 					<MailOutlineIcon

--- a/apps/newsletters-ui/src/app/components/views/NewslettersListView.tsx
+++ b/apps/newsletters-ui/src/app/components/views/NewslettersListView.tsx
@@ -15,7 +15,7 @@ export const NewslettersListView = () => {
 		<ContentWrapper>
 			<Typography variant="h2">View launched newsletters</Typography>
 			<Typography>Please find below a list of existing newsletters.</Typography>
-			<NewslettersTable newsletters={newsLetters} />;
+			<NewslettersTable newsletters={newsLetters} />
 		</ContentWrapper>
 	);
 };


### PR DESCRIPTION
## What does this change?

Couple of small tweaks:

The App bar was static - setting it to fixed to keep it in view on scroll where the content is larger that the viewport

There was also a semi-colon that was added to the launched view in error at some stage. This removes that

## How to test

Check it looks OK

![Kapture 2023-06-12 at 13 05 56](https://github.com/guardian/newsletters-nx/assets/3277259/79a7df08-6e6d-4f13-8dbf-6cb52ced851f)
