### PR TITLE
Dblatcher fix sending undefined

### DIFF
--- a/apps/newsletters-api/src/services/storage/inMemoryStorageInstance.ts
+++ b/apps/newsletters-api/src/services/storage/inMemoryStorageInstance.ts
@@ -26,6 +26,8 @@ export const makeInMemoryStorageInstance = () =>
 			thrasherDate: new Date('1970-01-02T00:21:18.876Z'),
 			privateUntilLaunch: false,
 			onlineArticle: 'Web for all sends',
+			designBriefDoc: 'Its on google drive somewhere.',
+			figmaDesignUrl: 'https://example.com/',
 		},
 		{
 			name: 'blue empowering',

--- a/apps/newsletters-ui/src/app/api-requests/make-wizard-step-request.ts
+++ b/apps/newsletters-ui/src/app/api-requests/make-wizard-step-request.ts
@@ -3,6 +3,25 @@ import type {
 	CurrentStepRouteResponse,
 } from '@newsletters-nx/state-machine';
 
+/**
+ * Replacer function for JSON,stringify - recursively changes values explictly set
+ * to `undefined` with `null` values.
+ *
+ * If explicit 'undefined' values are excluded from the data, it is impossible for
+ * the client to "unset" a previously set value on the server by making it "undefined".
+ *
+ * see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
+ *
+ * Since `undefined` is not value JSON and gets ommitted from the string.
+ * Server-side, the `null`s can be replaced back to `undefined`.
+ */
+const replaceUndefinedWithNull = (key: string, value: unknown): unknown => {
+	if (value === undefined) {
+		return null;
+	}
+	return value;
+};
+
 export const makeWizardStepRequest = async (
 	body: CurrentStepRouteRequest,
 ): Promise<CurrentStepRouteResponse> => {
@@ -11,7 +30,7 @@ export const makeWizardStepRequest = async (
 		headers: {
 			'Content-Type': 'application/json',
 		},
-		body: JSON.stringify(body),
+		body: JSON.stringify(body, replaceUndefinedWithNull),
 	});
 
 	const data = (await response.json()) as CurrentStepRouteResponse;

--- a/apps/newsletters-ui/src/app/util.ts
+++ b/apps/newsletters-ui/src/app/util.ts
@@ -7,7 +7,11 @@ import {
 	specialReport,
 	sport,
 } from '@guardian/source-foundations';
-import type { PrimitiveRecord } from '@newsletters-nx/newsletters-data-client';
+
+export {
+	isPrimitiveRecord,
+	isArrayOfPrimitiveRecords as isPrimitiveRecordArray,
+} from '@newsletters-nx/newsletters-data-client';
 
 export type SourcePalette =
 	| typeof culture
@@ -47,22 +51,3 @@ export const renderYesNo = (value: boolean): string =>
 
 export const isStringArray = (value: unknown): value is string[] =>
 	Array.isArray(value) && value.every((item) => typeof item === 'string');
-
-export const isPrimitiveRecord = (value: unknown): value is PrimitiveRecord => {
-	if (!value || typeof value !== 'object') {
-		return false;
-	}
-	if (Array.isArray(value)) {
-		return false;
-	}
-	return Object.keys(value).every(
-		(propertyValue) =>
-			typeof propertyValue === 'boolean' ||
-			typeof propertyValue === 'number' ||
-			typeof propertyValue === 'string',
-	);
-};
-export const isPrimitiveRecordArray = (
-	value: unknown,
-): value is PrimitiveRecord[] =>
-	Array.isArray(value) && value.every(isPrimitiveRecord);

--- a/libs/newsletter-workflow/src/lib/getValuesFromRecord.ts
+++ b/libs/newsletter-workflow/src/lib/getValuesFromRecord.ts
@@ -6,7 +6,7 @@ export const getStringValuesFromRecord = (
 ): string[] => {
 	return keys.map((key) => {
 		const value = record[key];
-		if (typeof value === 'undefined') {
+		if (typeof value === 'undefined' || value == null) {
 			return '';
 		}
 		return value.toString();

--- a/libs/newsletters-data-client/src/lib/transformWizardData.spec.ts
+++ b/libs/newsletters-data-client/src/lib/transformWizardData.spec.ts
@@ -48,6 +48,15 @@ const DRAFT_WITH_DATES: DraftNewsletterData = {
 	thrasherDate: new Date('10-10-2021'),
 };
 
+const FORM_DATA_WITH_UNDEFINED: FormDataRecord = {
+	name: 'test name',
+	designBriefDoc: undefined,
+};
+const DRAFT_WITH_UNDEFINED: DraftNewsletterData = {
+	name: 'test name',
+	designBriefDoc: undefined,
+};
+
 describe('formDataToDraftNewsletterData', () => {
 	it('will convert valid simple values', () => {
 		const output = formDataToDraftNewsletterData(SIMPLE_VALID_FORM_DATA);
@@ -123,6 +132,15 @@ describe('formDataToDraftNewsletterData', () => {
 	it('manages Date conversions, for dates stored as strings or Date objects', () => {
 		const output = formDataToDraftNewsletterData(FORM_DATA_WITH_DATES);
 		expect(output).toEqual(DRAFT_WITH_DATES);
+	});
+
+	it('preserves undefined values', () => {
+		const output = formDataToDraftNewsletterData(FORM_DATA_WITH_UNDEFINED);
+		expect(output).toEqual(DRAFT_WITH_UNDEFINED);
+
+		expect(Object.entries(output)).toEqual(
+			Object.entries(DRAFT_WITH_UNDEFINED),
+		);
 	});
 });
 

--- a/libs/newsletters-data-client/src/lib/transformWizardData.ts
+++ b/libs/newsletters-data-client/src/lib/transformWizardData.ts
@@ -13,6 +13,7 @@ export type PrimitiveRecord = Partial<
 export type SupportedValue =
 	| string
 	| number
+	| null
 	| boolean
 	| undefined
 	| Date
@@ -23,7 +24,7 @@ export type FormDataRecord = Record<string, SupportedValue>;
 
 const OBJECT_FIELDS_USING_RECORD_INPUT: Array<keyof NewsletterData> = [];
 
-const isPrimitiveRecord = (value: unknown): value is PrimitiveRecord => {
+export const isPrimitiveRecord = (value: unknown): value is PrimitiveRecord => {
 	if (!value || typeof value !== 'object') {
 		return false;
 	}
@@ -36,6 +37,15 @@ const isPrimitiveRecord = (value: unknown): value is PrimitiveRecord => {
 			typeof propertyValue === 'number' ||
 			typeof propertyValue === 'string',
 	);
+};
+
+export const isArrayOfPrimitiveRecords = (
+	value: unknown,
+): value is PrimitiveRecord[] => {
+	if (!Array.isArray(value)) {
+		return false;
+	}
+	return value.every(isPrimitiveRecord);
 };
 
 /**
@@ -113,6 +123,7 @@ export const formDataToDraftNewsletterData = (
 	formData: FormDataRecord,
 ): DraftNewsletterData => {
 	const output: Record<string, unknown> = {};
+	const setKeys = Object.keys(formData);
 
 	for (const key in draftNewsletterDataSchema.shape) {
 		const castKey = key as keyof DraftNewsletterData;
@@ -127,7 +138,16 @@ export const formDataToDraftNewsletterData = (
 			continue;
 		}
 
+		// any propery can be undefined on the draftSchema,
+		// but in practise, if a listId is set, it should
+		// never be unset by the form data from the user.
 		if (typeof recordValue === 'undefined') {
+			if (castKey === 'listId') {
+				continue;
+			}
+			if (setKeys.includes(castKey)) {
+				output[castKey] = undefined;
+			}
 			continue;
 		}
 

--- a/libs/newsletters-data-client/src/lib/transformWizardData.ts
+++ b/libs/newsletters-data-client/src/lib/transformWizardData.ts
@@ -31,7 +31,7 @@ export const isPrimitiveRecord = (value: unknown): value is PrimitiveRecord => {
 	if (Array.isArray(value)) {
 		return false;
 	}
-	return Object.keys(value).every(
+	return Object.values(value).every(
 		(propertyValue) =>
 			typeof propertyValue === 'boolean' ||
 			typeof propertyValue === 'number' ||

--- a/libs/state-machine/src/lib/handleWizardRequest.ts
+++ b/libs/state-machine/src/lib/handleWizardRequest.ts
@@ -10,6 +10,7 @@ import type {
 	WizardLayout,
 	WizardStepLayout,
 } from './types';
+import { replaceNullWithUndefined } from './utility';
 
 /**
  * Execute the changes to state (if any) in response to a
@@ -33,6 +34,10 @@ export async function handleWizardRequestAndReturnWizardResponse<
 	serviceInterface: T,
 ): Promise<CurrentStepRouteResponse> {
 	try {
+		if (requestBody.formData) {
+			replaceNullWithUndefined(requestBody.formData);
+		}
+
 		const stepData =
 			requestBody.stepToSkipToId !== undefined
 				? await stateMachineSkipPressed(

--- a/libs/state-machine/src/lib/utility.spec.ts
+++ b/libs/state-machine/src/lib/utility.spec.ts
@@ -1,0 +1,71 @@
+import type { WizardFormData } from './types';
+import { replaceNullWithUndefined } from './utility';
+
+const SIMPLE_IN: WizardFormData = {
+	name: 'Bill',
+	petsName: null,
+};
+const SIMPLE_OUT: WizardFormData = {
+	name: 'Bill',
+	petsName: undefined,
+};
+
+const OBJECT_IN: WizardFormData = {
+	name: 'Bill',
+	pet: {
+		name: 'Marvin the fish',
+		collarSize: null as unknown as undefined,
+	},
+};
+const OBJECT_OUT: WizardFormData = {
+	name: 'Bill',
+	pet: {
+		name: 'Marvin the fish',
+		collarSize: undefined,
+	},
+};
+const OBJECT_ARRAY_IN: WizardFormData = {
+	name: 'Bill',
+	children: [
+		{
+			name: 'Sally',
+			age: 4,
+			favouriteFood: 'chips',
+		},
+		{
+			name: 'Norma',
+			age: 1,
+			favouriteFood: null as unknown as undefined,
+		},
+	],
+};
+const OBJECT_ARRAY_OUT: WizardFormData = {
+	name: 'Bill',
+	children: [
+		{
+			name: 'Sally',
+			age: 4,
+			favouriteFood: 'chips',
+		},
+		{
+			name: 'Norma',
+			age: 1,
+			favouriteFood: undefined,
+		},
+	],
+};
+
+describe('replaceNullWithUndefined', () => {
+	it('will handle simple cases', () => {
+		const result = replaceNullWithUndefined({ ...SIMPLE_IN });
+		expect(result).toEqual(SIMPLE_OUT);
+	});
+	it('will handle nulls in nested objects', () => {
+		const result = replaceNullWithUndefined({ ...OBJECT_IN });
+		expect(result).toEqual(OBJECT_OUT);
+	});
+	it('will handle nulls in arrays of object', () => {
+		const result = replaceNullWithUndefined({ ...OBJECT_ARRAY_IN });
+		expect(result).toEqual(OBJECT_ARRAY_OUT);
+	});
+});

--- a/libs/state-machine/src/lib/utility.ts
+++ b/libs/state-machine/src/lib/utility.ts
@@ -1,6 +1,15 @@
 import type { FormDataRecord } from '@newsletters-nx/newsletters-data-client';
+import {
+	isArrayOfPrimitiveRecords,
+	isPrimitiveRecord,
+} from '@newsletters-nx/newsletters-data-client';
 import type { ZodIssue } from 'zod';
-import type { FailureDetails, WizardStepData, WizardStepLayout } from './types';
+import type {
+	FailureDetails,
+	WizardFormData,
+	WizardStepData,
+	WizardStepLayout,
+} from './types';
 
 export const makeStepDataWithErrorMessage = (
 	errorMessage: string,
@@ -41,4 +50,38 @@ export const validateIncomingFormData = (
 	}
 
 	return undefined;
+};
+
+/** recursively replace any `null` with `undefined` */
+export const replaceNullWithUndefined = (
+	formData: WizardFormData,
+): WizardFormData => {
+	Object.keys(formData).forEach((key) => {
+		const value = formData[key];
+
+		if (value === null) {
+			formData[key] = undefined;
+		}
+
+		if (isPrimitiveRecord(value)) {
+			Object.keys(value).forEach((nestedkey) => {
+				const nestedValue = value[nestedkey];
+				if ((nestedValue as unknown) === null) {
+					value[nestedkey] = undefined;
+				}
+			});
+		}
+
+		if (isArrayOfPrimitiveRecords(value)) {
+			value.forEach((objectInArray) => {
+				Object.keys(objectInArray).forEach((keyOfObjectInArray) => {
+					const valueOfObjectInArray = objectInArray[keyOfObjectInArray];
+					if ((valueOfObjectInArray as unknown) === null) {
+						objectInArray[keyOfObjectInArray] = undefined;
+					}
+				});
+			});
+		}
+	});
+	return formData;
 };

--- a/libs/state-machine/src/lib/utility.ts
+++ b/libs/state-machine/src/lib/utility.ts
@@ -1,8 +1,4 @@
 import type { FormDataRecord } from '@newsletters-nx/newsletters-data-client';
-import {
-	isArrayOfPrimitiveRecords,
-	isPrimitiveRecord,
-} from '@newsletters-nx/newsletters-data-client';
 import type { ZodIssue } from 'zod';
 import type {
 	FailureDetails,
@@ -10,6 +6,36 @@ import type {
 	WizardStepData,
 	WizardStepLayout,
 } from './types';
+
+type PrimitiveRecordWithNull = Partial<
+	Record<string, string | number | boolean | null>
+>;
+const isPrimitiveRecordAllowingNull = (
+	value: unknown,
+): value is PrimitiveRecordWithNull => {
+	if (!value || typeof value !== 'object') {
+		return false;
+	}
+	if (Array.isArray(value)) {
+		return false;
+	}
+	return Object.values(value).every(
+		(propertyValue) =>
+			typeof propertyValue === 'boolean' ||
+			typeof propertyValue === 'number' ||
+			typeof propertyValue === 'string' ||
+			(typeof propertyValue === 'object' && !propertyValue),
+	);
+};
+
+const isArrayOfPrimitiveRecordsAllowingNull = (
+	value: unknown,
+): value is PrimitiveRecordWithNull[] => {
+	if (!Array.isArray(value)) {
+		return false;
+	}
+	return value.every(isPrimitiveRecordAllowingNull);
+};
 
 export const makeStepDataWithErrorMessage = (
 	errorMessage: string,
@@ -63,7 +89,7 @@ export const replaceNullWithUndefined = (
 			formData[key] = undefined;
 		}
 
-		if (isPrimitiveRecord(value)) {
+		if (isPrimitiveRecordAllowingNull(value)) {
 			Object.keys(value).forEach((nestedkey) => {
 				const nestedValue = value[nestedkey];
 				if ((nestedValue as unknown) === null) {
@@ -72,7 +98,7 @@ export const replaceNullWithUndefined = (
 			});
 		}
 
-		if (isArrayOfPrimitiveRecords(value)) {
+		if (isArrayOfPrimitiveRecordsAllowingNull(value)) {
 			value.forEach((objectInArray) => {
 				Object.keys(objectInArray).forEach((keyOfObjectInArray) => {
 					const valueOfObjectInArray = objectInArray[keyOfObjectInArray];


### PR DESCRIPTION
## What does this change?

 - When the Wizard UI sends a value explicitly set to  `undefined`, the `JSON.stringify` call is configured to replace each `undefined` with a `null` (keys for `undefined` values are ignored, since `undefined` is not valid JSON, but `null` is).
 
 - The `handleWizardRequestAndReturnWizardResponse`  uses `replaceNullWithUndefined` to replace `null`s in the formData with `undefined` before acting on the data.

 - The `formDataToDraftNewsletterData` function does not ignore `undefined` values

Net result - user can send a value of `undefined` to replace an existing truthey value with `undefined` on the server.

## How to test

 - `npm run dev`
 - go tp http://localhost:4200/newsletters/newsletter-data/5770 to open the editor for "Avon Recumbent"
 - skip to the "newsletter design" step, empty the value for "design brief doc"
 - hit "back" to submit the value, bypassing custom validation (which you probably shouldn't be be able to do, but works for the purpose of this fix)
- go to http://localhost:4200/drafts/5770 to see the data - "design brief doc" will be gone

## How can we measure success?

Happier users, no manual editing of the JSON document in s3.

## Have we considered potential risks?

might have similar bugs elsewhere? should we do the same with other stringified data with meaningful `undefined` values? 
