### PR TITLE
accept hyphens and underscores in identiytname as what's on uses this

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a monorepo for:
 
 -   defining the data model for editorial newsletters at the Guardian
 -   serving an API to access the newsletter data
--   serving a user interface for editorial to manage thier newsletters
+-   serving a user interface for editorial to manage their newsletters
 -   the state-machine library used between UI and API
 
 🛠**CURRENT STATUS: in development / WIP**🛠

--- a/apps/newsletters-ui/src/app/components/views/DraftDetailView.tsx
+++ b/apps/newsletters-ui/src/app/components/views/DraftDetailView.tsx
@@ -1,11 +1,16 @@
 import { useLoaderData } from 'react-router-dom';
 import { isDraft } from '@newsletters-nx/newsletters-data-client';
+import { ContentWrapper } from '../../ContentWrapper';
 import { DraftDetails } from '../DraftDetails';
 
 export const DraftDetailView = () => {
 	const matchedItem = useLoaderData();
 	if (!matchedItem) {
-		return <article>NOT FOUND!</article>;
+		return (
+			<ContentWrapper>
+				<article>NOT FOUND!</article>
+			</ContentWrapper>
+		);
 	}
 
 	if (!isDraft(matchedItem)) {

--- a/apps/newsletters-ui/src/app/components/views/NewsletterDetailView.tsx
+++ b/apps/newsletters-ui/src/app/components/views/NewsletterDetailView.tsx
@@ -6,11 +6,19 @@ import { NewsletterDataDetails } from '../NewsletterDataDetails';
 export const NewsletterDetailView = () => {
 	const matchedItem = useLoaderData();
 	if (!matchedItem) {
-		return <article>NOT FOUND!</article>;
+		return (
+			<ContentWrapper>
+				<article>NOT FOUND!</article>
+			</ContentWrapper>
+		);
 	}
 
 	if (!isNewsletterData(matchedItem)) {
-		return <article>NOT VALID DATA!</article>;
+		return (
+			<ContentWrapper>
+				<article>NOT VALID DATA!</article>;
+			</ContentWrapper>
+		);
 	}
 
 	return (

--- a/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
@@ -3,7 +3,7 @@ import {
 	kebabOrUnderscoreCasedString,
 	nonEmptyString,
 	underscoreCasedString,
-} from './zod-helpers/schema-helpers';
+} from './zod-helpers';
 
 export const themeEnumSchema = z.enum([
 	'news',
@@ -108,7 +108,7 @@ export const newsletterDataSchema = z.object({
 	status: z.enum(['paused', 'cancelled', 'live']),
 	emailConfirmation: z.boolean().describe('email confirmation'),
 	brazeSubscribeAttributeName: underscoreCasedString(),
-	brazeSubscribeEventNamePrefix: underscoreCasedString(),
+	brazeSubscribeEventNamePrefix: kebabOrUnderscoreCasedString(),
 	brazeNewsletterName: underscoreCasedString(),
 	theme: themeEnumSchema,
 	group: nonEmptyString(),

--- a/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import {
-	kebabCasedString,
+	kebabOrUnderscoreCasedString,
 	nonEmptyString,
 	underscoreCasedString,
 } from './zod-helpers/schema-helpers';
@@ -101,7 +101,7 @@ export type NewsletterCategory = z.infer<typeof newsletterCategoriesSchema>;
  * The actual data model is TBC.
  */
 export const newsletterDataSchema = z.object({
-	identityName: kebabCasedString().describe('identity name'),
+	identityName: kebabOrUnderscoreCasedString().describe('identity name'),
 	name: nonEmptyString(),
 	category: newsletterCategoriesSchema,
 	restricted: z.boolean(),

--- a/libs/newsletters-data-client/src/lib/zod-helpers/schema-helpers.ts
+++ b/libs/newsletters-data-client/src/lib/zod-helpers/schema-helpers.ts
@@ -3,20 +3,12 @@ import { z } from 'zod';
 export const nonEmptyString = () =>
 	z.string().min(1, { message: 'Must not be empty' });
 
-export const kebabCasedString = () =>
-	z
-		.string()
-		.regex(
-			/^[a-z]+(-[a-z]+)*$/,
-			'Must be in kebab-case (only lower case words connected by dashes)',
-		);
-
 export const underscoreCasedString = () =>
 	z
 		.string()
 		.regex(
-			/^[a-zA-Z]+(_[a-zA-z]+)*$/,
-			'Must contain only words(upper or lower case letters) connected by underscores',
+			/^[a-zA-Z0-9]+(_[a-zA-z0-9]+)*$/,
+			'Must contain letters or numbers, connected by underscores',
 		);
 
 
@@ -24,6 +16,6 @@ export const kebabOrUnderscoreCasedString = () =>
 	z
 		.string()
 		.regex(
-			/^[a-z]+(?:[-_][a-z]+)*$/,
-			'Must be in lower case only, separated by dashes or underscores',
+			/^[a-z0-9]+(?:[-_][a-z0-9]+)*$/,
+			'Must numbers or lower-case letters only, separated by dashes or underscores',
 		);

--- a/libs/newsletters-data-client/src/lib/zod-helpers/schema-helpers.ts
+++ b/libs/newsletters-data-client/src/lib/zod-helpers/schema-helpers.ts
@@ -18,3 +18,12 @@ export const underscoreCasedString = () =>
 			/^[a-zA-Z]+(_[a-zA-z]+)*$/,
 			'Must contain only words(upper or lower case letters) connected by underscores',
 		);
+
+
+export const kebabOrUnderscoreCasedString = () =>
+	z
+		.string()
+		.regex(
+			/^[a-z]+(?:[-_][a-z]+)*$/,
+			'Must be in lower case only, separated by dashes or underscores',
+		);


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a new schema helper which permits a mix of underscore and hyphens to support the existing formats. The help is used in `identityName` 
Update - to support existing values, have converted the existing `underscoreCasedString` has been update to be alpha-numeric

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Verify that `what's on`, `Tokyo2020` and `guardian_weekly_newsletter` are returned 

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

What's on is back on

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

this will permit a variation in formats, but it's already possible. We might wish to lock this down later / migrate existing data, but that's a task for another day,

