### PR TITLE
remove manual colours, styling and emojis

### DIFF
--- a/apps/newsletters-ui/src/app/Layout.tsx
+++ b/apps/newsletters-ui/src/app/Layout.tsx
@@ -1,9 +1,4 @@
 import styled from '@emotion/styled';
-import {
-	brand,
-	space,
-	textSansObjectStyles,
-} from '@guardian/source-foundations';
 import { Box } from '@mui/material';
 import { Outlet } from 'react-router-dom';
 import { MainNav } from './components/MainNav';
@@ -15,25 +10,10 @@ const Frame = styled.div`
 	box-sizing: border-box;
 	align-items: stretch;
 
-	>
-		h1 {
-			${textSansObjectStyles.xlarge({ fontStyle: 'italic' })};
-			margin: 0;
-			color: ${brand[300]};
-		}
-	}
-
 	> main {
 		box-sizing: border-box;
 		flex: 1;
 		overflow: auto;
-	}
-
-	> footer {
-		box-sizing: border-box;
-		padding: ${space[1]}px;
-		border-top: 2px solid ${brand[300]};
-		background-color: ${brand[800]};
 	}
 `;
 

--- a/apps/newsletters-ui/src/app/components/DraftDetails.tsx
+++ b/apps/newsletters-ui/src/app/components/DraftDetails.tsx
@@ -1,9 +1,7 @@
-import { space } from '@guardian/source-foundations';
 import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
 import {
+	Box,
 	ButtonGroup,
-	Card,
-	CardContent,
 	Container,
 	Paper,
 	Table,
@@ -61,94 +59,78 @@ export const DraftDetails = ({ draft }: Props) => {
 
 	return (
 		<Container maxWidth="lg">
-			<Card
+			<Typography variant="h2">{draft.name ?? 'UNNAMED DRAFT'}</Typography>
+
+			<Typography sx={{ fontSize: 16 }}>category: {draft.category}</Typography>
+			<Typography sx={{ fontSize: 16 }}>id: {draft.listId}</Typography>
+			<Typography sx={{ fontSize: 16 }}>
+				created: {draft.creationTimeStamp}
+			</Typography>
+
+			<DeleteDraftButton
+				draft={draft}
+				hasBeenDeleted={hasBeenDeleted}
+				setHasBeenDeleted={setHasBeenDeleted}
+				margin={1}
+			/>
+
+			{draft.listId && (
+				<ButtonGroup>
+					<NavigateButton
+						href={`..`}
+						startIcon={<span>←</span>}
+						color="secondary"
+					>
+						back to list
+					</NavigateButton>
+					<EditDraftNavigateButtons draft={draft} />
+
+					{readyToLaunch && (
+						<NavigateButton
+							href={`/newsletters/launch-newsletter/${draft.listId}`}
+							startIcon={<RocketLaunchIcon />}
+							color="success"
+						>
+							Launch
+						</NavigateButton>
+					)}
+				</ButtonGroup>
+			)}
+
+			{issues.length > 0 && !hasBeenDeleted && (
+				<Box marginY={1}>
+					<ZodIssuesReport
+						issues={issues}
+						caption={'Missing data needed before launch'}
+					/>
+				</Box>
+			)}
+
+			<TableContainer
+				component={Paper}
 				sx={{
-					marginBottom: space[2],
-					marginTop: space[1],
+					backgroundColor: hasBeenDeleted ? 'error.light' : 'primary.light',
 				}}
 			>
-				<CardContent>
-					<Typography variant="h2">{draft.name ?? 'UNNAMED DRAFT'}</Typography>
-					<Typography sx={{ fontSize: 16 }}>
-						category: {draft.category}
-					</Typography>
-					<Typography sx={{ fontSize: 16 }}>id: {draft.listId}</Typography>
-					<Typography sx={{ fontSize: 16 }}>
-						created: {draft.creationTimeStamp}
-					</Typography>
-				</CardContent>
+				<Table size="small">
+					<caption style={{ captionSide: 'top' }}>
+						{hasBeenDeleted ? 'DELETED' : 'DATA'}
+					</caption>
 
-				<CardContent>
-					<DeleteDraftButton
-						draft={draft}
-						hasBeenDeleted={hasBeenDeleted}
-						setHasBeenDeleted={setHasBeenDeleted}
-						margin={1}
-					/>
-				</CardContent>
-
-				{draft.listId && (
-					<CardContent>
-						<ButtonGroup>
-							<NavigateButton
-								href={`..`}
-								startIcon={<span>←</span>}
-								color="secondary"
-							>
-								back to list
-							</NavigateButton>
-							<EditDraftNavigateButtons draft={draft} />
-
-							{readyToLaunch && (
-								<NavigateButton
-									href={`/newsletters/launch-newsletter/${draft.listId}`}
-									startIcon={<RocketLaunchIcon />}
-									color="success"
-								>
-									Launch
-								</NavigateButton>
-							)}
-						</ButtonGroup>
-					</CardContent>
-				)}
-
-				{issues.length > 0 && !hasBeenDeleted && (
-					<CardContent>
-						<ZodIssuesReport
-							issues={issues}
-							caption={'Missing data needed before launch'}
-						/>
-					</CardContent>
-				)}
-
-				<CardContent>
-					<TableContainer
-						component={Paper}
-						sx={{
-							backgroundColor: hasBeenDeleted ? 'error.light' : 'primary.light',
-						}}
-					>
-						<Table size="small">
-							<caption style={{ captionSide: 'top' }}>
-								{hasBeenDeleted ? 'DELETED' : 'DATA'}
-							</caption>
-
-							<TableBody>
-								{Object.keys(draft).map((key) => (
-									<TableRow key={key}>
-										<TableCell size="small" sx={{ fontWeight: 'bold' }}>
-											{key}
-										</TableCell>
-										<TableCell>
-											{propertyToNode(draft, key as keyof DraftNewsletterData)}
-										</TableCell>
-									</TableRow>
-								))}
-							</TableBody>
-						</Table>
-					</TableContainer>
-				</CardContent>
-			</Card>
+					<TableBody>
+						{Object.keys(draft).map((key) => (
+							<TableRow key={key}>
+								<TableCell size="small" sx={{ fontWeight: 'bold' }}>
+									{key}
+								</TableCell>
+								<TableCell>
+									{propertyToNode(draft, key as keyof DraftNewsletterData)}
+								</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
+			</TableContainer>
 		</Container>
 	);
 };

--- a/apps/newsletters-ui/src/app/components/DraftDetails.tsx
+++ b/apps/newsletters-ui/src/app/components/DraftDetails.tsx
@@ -1,4 +1,5 @@
 import { space } from '@guardian/source-foundations';
+import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
 import {
 	ButtonGroup,
 	Card,
@@ -101,11 +102,7 @@ export const DraftDetails = ({ draft }: Props) => {
 							{readyToLaunch && (
 								<NavigateButton
 									href={`/newsletters/launch-newsletter/${draft.listId}`}
-									endIcon={
-										<span role="img" aria-label="rocket">
-											🚀
-										</span>
-									}
+									startIcon={<RocketLaunchIcon />}
 									color="success"
 								>
 									Launch

--- a/apps/newsletters-ui/src/app/components/DraftDetails.tsx
+++ b/apps/newsletters-ui/src/app/components/DraftDetails.tsx
@@ -16,7 +16,6 @@ import type { ReactNode } from 'react';
 import { useState } from 'react';
 import { getDraftNotReadyIssues } from '@newsletters-nx/newsletters-data-client';
 import type { DraftNewsletterData } from '@newsletters-nx/newsletters-data-client';
-import { getPalette } from '../util';
 import { DeleteDraftButton } from './DeleteDraftButton';
 import { EditDraftNavigateButtons } from './EditDraftNavigateButtons';
 import { NavigateButton } from './NavigateButton';
@@ -56,7 +55,6 @@ const propertyToNode = (
 export const DraftDetails = ({ draft }: Props) => {
 	const [hasBeenDeleted, setHasBeenDeleted] = useState(false);
 
-	const palette = getPalette(draft.theme ?? '');
 	const issues = getDraftNotReadyIssues(draft);
 	const readyToLaunch = issues.length === 0;
 
@@ -64,7 +62,6 @@ export const DraftDetails = ({ draft }: Props) => {
 		<Container maxWidth="lg">
 			<Card
 				sx={{
-					backgroundColor: palette[800],
 					marginBottom: space[2],
 					marginTop: space[1],
 				}}
@@ -131,7 +128,7 @@ export const DraftDetails = ({ draft }: Props) => {
 					<TableContainer
 						component={Paper}
 						sx={{
-							backgroundColor: hasBeenDeleted ? 'pink' : undefined,
+							backgroundColor: hasBeenDeleted ? 'error.light' : 'primary.light',
 						}}
 					>
 						<Table size="small">

--- a/apps/newsletters-ui/src/app/components/DraftsTable.tsx
+++ b/apps/newsletters-ui/src/app/components/DraftsTable.tsx
@@ -1,3 +1,4 @@
+import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
 import { Button } from '@mui/material';
 import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
@@ -126,10 +127,9 @@ export const DraftsTable = ({ drafts }: Props) => {
 							href={`/newsletters/launch-newsletter/${draft.listId}`}
 							variant="outlined"
 							color="success"
+							startIcon={<RocketLaunchIcon />}
 						>
-							<span role="img" aria-label="rocket">
-								🚀
-							</span>
+							launch
 						</NavigateButton>
 					);
 				},

--- a/apps/newsletters-ui/src/app/components/DraftsTable.tsx
+++ b/apps/newsletters-ui/src/app/components/DraftsTable.tsx
@@ -1,4 +1,5 @@
 import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
+import SettingsIcon from '@mui/icons-material/Settings';
 import { Button } from '@mui/material';
 import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
@@ -75,7 +76,7 @@ export const DraftsTable = ({ drafts }: Props) => {
 						return (
 							<NavigateButton
 								href={link?.href}
-								startIcon={'⚙'}
+								startIcon={<SettingsIcon />}
 								variant="outlined"
 							>
 								Edit
@@ -88,7 +89,7 @@ export const DraftsTable = ({ drafts }: Props) => {
 							onClick={() => {
 								setDraftInDialog(draft);
 							}}
-							startIcon={'⚙'}
+							startIcon={<SettingsIcon />}
 							variant="outlined"
 						>
 							Edit

--- a/apps/newsletters-ui/src/app/components/EditDraftNavigateButtons.tsx
+++ b/apps/newsletters-ui/src/app/components/EditDraftNavigateButtons.tsx
@@ -1,3 +1,4 @@
+import SettingsIcon from '@mui/icons-material/Settings';
 import type { DraftNewsletterData } from '@newsletters-nx/newsletters-data-client';
 import { getEditDraftWizardLinks } from '../get-draft-edit-wizard-links';
 import { NavigateButton } from './NavigateButton';
@@ -10,7 +11,11 @@ export const EditDraftNavigateButtons = ({ draft }: Props) => {
 	return (
 		<>
 			{getEditDraftWizardLinks(draft).map((link) => (
-				<NavigateButton key={link.href} href={link.href}>
+				<NavigateButton
+					key={link.href}
+					href={link.href}
+					startIcon={<SettingsIcon />}
+				>
 					{link.label}
 				</NavigateButton>
 			))}

--- a/apps/newsletters-ui/src/app/components/Illustration.tsx
+++ b/apps/newsletters-ui/src/app/components/Illustration.tsx
@@ -1,41 +1,39 @@
-import { css } from '@emotion/react';
-import { brand, space } from '@guardian/source-foundations';
+import ImageNotSupportedIcon from '@mui/icons-material/ImageNotSupported';
+import { Stack, Typography } from '@mui/material';
 
 interface Props {
 	name: string;
 	url?: string;
 }
 
-const figureStyles = css`
-	display: inline-flex;
-	margin: 0;
-	border: 2px dashed ${brand[400]};
-	border-radius: ${space[2]}px;
-	padding: ${space[1]}px;
-	flex-direction: column;
-	align-items: center;
-
-	span {
-		font-size: 100px;
-	}
-`;
-
 export const Illustration = ({ name, url }: Props) => {
-	if (!url) {
-		return (
-			<figure css={figureStyles}>
-				<span role="img" aria-label="no illustration">
-					🚫
-				</span>
-				<figcaption>{name} has no illustration</figcaption>
-			</figure>
-		);
-	}
+	const image = url ? (
+		<img src={url} alt="" height={100} />
+	) : (
+		<ImageNotSupportedIcon color="primary" sx={{ height: 100, width: 100 }} />
+	);
+
+	const captionText = url
+		? `illustration for ${name}`
+		: `${name} has no illustration`;
 
 	return (
-		<figure css={figureStyles}>
-			<img src={url} alt="" height={100} />
-			<figcaption>illustration for {name}</figcaption>
-		</figure>
+		<Stack
+			component={'figure'}
+			alignItems={'center'}
+			margin={0}
+			marginBottom={1}
+			padding={1}
+			sx={{
+				borderWidth: 1,
+				borderColor: 'primary.dark',
+				borderStyle: 'dashed',
+			}}
+		>
+			{image}
+			<Typography component={'figcaption'} variant="caption">
+				{captionText}
+			</Typography>
+		</Stack>
 	);
 };

--- a/apps/newsletters-ui/src/app/util.ts
+++ b/apps/newsletters-ui/src/app/util.ts
@@ -1,45 +1,7 @@
-import {
-	brand,
-	culture,
-	lifestyle,
-	news,
-	opinion,
-	specialReport,
-	sport,
-} from '@guardian/source-foundations';
-
 export {
 	isPrimitiveRecord,
 	isArrayOfPrimitiveRecords as isPrimitiveRecordArray,
 } from '@newsletters-nx/newsletters-data-client';
-
-export type SourcePalette =
-	| typeof culture
-	| typeof lifestyle
-	| typeof news
-	| typeof opinion
-	| typeof sport
-	| typeof brand
-	| typeof specialReport;
-
-export const getPalette = (theme: string): SourcePalette => {
-	switch (theme) {
-		case 'sport':
-			return sport;
-		case 'lifestyle':
-			return lifestyle;
-		case 'opinion':
-			return opinion;
-		case 'culture':
-			return culture;
-		case 'news':
-			return news;
-		case 'features':
-			return specialReport;
-		default:
-			return brand;
-	}
-};
 
 export const getGuardianUrl = (relativeUrl: string): string =>
 	`https://www.theguardian.com${


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

 - removes the `getPalette` feature that was setting the colour of the `draftDetails` based on the theme value
 - simplifies the `draftDetails` component mark-up
 - replaces Emoji's with MUI Icons
 - changes the `Illustration` component to use MUI styling
 - removes the use of source values outside the app-theme and styling modules

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Simpler could and more consistent visual language, driven by the MUI theme

## Have we considered potential risks?

visual change only

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
<img width="1160" alt="Screenshot 2023-06-20 at 16 45 00" src="https://github.com/guardian/newsletters-nx/assets/30567854/5ee099a6-2e60-4361-a11e-c767649d8de7">
<img width="1151" alt="Screenshot 2023-06-20 at 16 44 39" src="https://github.com/guardian/newsletters-nx/assets/30567854/9f41026f-9eed-4443-8dc0-2ae64eade53c">

