### PR TITLE
Dblatcher drafts metadata

### DIFF
--- a/apps/newsletters-api/src/app/routes/currentStep.ts
+++ b/apps/newsletters-api/src/app/routes/currentStep.ts
@@ -11,7 +11,10 @@ import {
 	StateMachineErrorCode,
 } from '@newsletters-nx/state-machine';
 import { permissionService } from '../../services/permissions';
-import { draftStore, makelaunchServiceForUser } from '../../services/storage';
+import {
+	makeDraftServiceForUser,
+	makelaunchServiceForUser,
+} from '../../services/storage';
 import { getUserProfile } from '../get-user-profile';
 
 const getHttpCode = (error: StateMachineError): number => {
@@ -89,12 +92,11 @@ export function registerCurrentStepRoute(app: FastifyInstance) {
 				return res.status(400).send(errorResponse);
 			}
 
-			const serviceInterface =
-				requestBody.wizardId === 'LAUNCH_NEWSLETTER'
-					? user.profile
-						? makelaunchServiceForUser(user.profile)
-						: undefined
-					: draftStore;
+			const serviceInterface = user.profile
+				? requestBody.wizardId === 'LAUNCH_NEWSLETTER'
+					? makelaunchServiceForUser(user.profile)
+					: makeDraftServiceForUser(user.profile)
+				: undefined;
 
 			if (!serviceInterface) {
 				const errorResponse: CurrentStepRouteResponse = {

--- a/apps/newsletters-api/src/services/storage/index.ts
+++ b/apps/newsletters-api/src/services/storage/index.ts
@@ -1,4 +1,5 @@
 import {
+	DraftService,
 	InMemoryNewsletterStorage,
 	isNewsletterData,
 	LaunchService,
@@ -35,4 +36,12 @@ const newsletterStore: NewsletterStorage = isUsingInMemoryStore
 const makelaunchServiceForUser = (userProfile: UserProfile) =>
 	new LaunchService(draftStore, newsletterStore, userProfile);
 
-export { draftStore, newsletterStore, makelaunchServiceForUser };
+const makeDraftServiceForUser = (userProfile: UserProfile) =>
+	new DraftService(draftStore, userProfile);
+
+export {
+	draftStore,
+	newsletterStore,
+	makelaunchServiceForUser,
+	makeDraftServiceForUser,
+};

--- a/apps/newsletters-ui/src/app/components/views/DraftDetailView.tsx
+++ b/apps/newsletters-ui/src/app/components/views/DraftDetailView.tsx
@@ -1,5 +1,5 @@
 import { useLoaderData } from 'react-router-dom';
-import { isDraft } from '@newsletters-nx/newsletters-data-client';
+import { isDraftNewsletterData } from '@newsletters-nx/newsletters-data-client';
 import { ContentWrapper } from '../../ContentWrapper';
 import { DraftDetails } from '../DraftDetails';
 
@@ -13,7 +13,7 @@ export const DraftDetailView = () => {
 		);
 	}
 
-	if (!isDraft(matchedItem)) {
+	if (!isDraftNewsletterData(matchedItem)) {
 		return <article>INVALID DATA</article>;
 	}
 

--- a/apps/newsletters-ui/src/app/components/views/DraftListView.tsx
+++ b/apps/newsletters-ui/src/app/components/views/DraftListView.tsx
@@ -1,7 +1,7 @@
 import AddIcon from '@mui/icons-material/Add';
 import { Box, Button, Container, Typography } from '@mui/material';
 import { useLoaderData } from 'react-router-dom';
-import { isDraft } from '@newsletters-nx/newsletters-data-client';
+import { isDraftNewsletterData } from '@newsletters-nx/newsletters-data-client';
 import { ContentWrapper } from '../../ContentWrapper';
 import { DraftsTable } from '../DraftsTable';
 
@@ -11,7 +11,7 @@ export const DraftListView = () => {
 		return <nav>No Drafts</nav>;
 	}
 
-	const drafts = list.filter(isDraft);
+	const drafts = list.filter(isDraftNewsletterData);
 	return (
 		<ContentWrapper>
 			<Typography variant="h2">View draft newsletters</Typography>

--- a/libs/newsletter-workflow/src/lib/executeCreate.ts
+++ b/libs/newsletter-workflow/src/lib/executeCreate.ts
@@ -52,10 +52,13 @@ export const executeCreate: AsyncExecution<DraftService> = async (
 		...parseResult.data,
 	});
 
-	const storageResponse = await draftService.draftStorage.create({
-		...draft,
-		listId: undefined,
-	});
+	const storageResponse = await draftService.draftStorage.create(
+		{
+			...draft,
+			listId: undefined,
+		},
+		draftService.userProfile,
+	);
 	if (storageResponse.ok) {
 		return {
 			data: draftNewsletterDataToFormData(storageResponse.data),

--- a/libs/newsletter-workflow/src/lib/executeCreate.ts
+++ b/libs/newsletter-workflow/src/lib/executeCreate.ts
@@ -1,6 +1,6 @@
 import type {
 	DraftNewsletterData,
-	DraftStorage,
+	DraftService,
 } from '@newsletters-nx/newsletters-data-client';
 import {
 	draftNewsletterDataToFormData,
@@ -14,14 +14,14 @@ import {
 } from '@newsletters-nx/state-machine';
 import type { AsyncExecution } from '@newsletters-nx/state-machine';
 
-export const executeCreate: AsyncExecution<DraftStorage> = async (
+export const executeCreate: AsyncExecution<DraftService> = async (
 	stepData,
 	stepLayout,
-	storageInstance,
+	draftService,
 ) => {
-	if (!storageInstance) {
+	if (!draftService) {
 		throw new StateMachineError(
-			'no storageInstance',
+			'no draft service',
 			StateMachineErrorCode.StorageAccessError,
 			true,
 		);
@@ -52,7 +52,7 @@ export const executeCreate: AsyncExecution<DraftStorage> = async (
 		...parseResult.data,
 	});
 
-	const storageResponse = await storageInstance.create({
+	const storageResponse = await draftService.draftStorage.create({
 		...draft,
 		listId: undefined,
 	});

--- a/libs/newsletter-workflow/src/lib/executeModify.ts
+++ b/libs/newsletter-workflow/src/lib/executeModify.ts
@@ -64,6 +64,7 @@ const doModify = async (
 			};
 			const storageResponse = await service.draftStorage.update(
 				draftNewsletter,
+				service.userProfile,
 			);
 			if (storageResponse.ok) {
 				return {

--- a/libs/newsletter-workflow/src/lib/executeModify.ts
+++ b/libs/newsletter-workflow/src/lib/executeModify.ts
@@ -36,7 +36,7 @@ const doModify = async (
 
 	const serviceIsADraftInstance = isADraftStorage(service);
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- linting bug?
-	const ourDraftService: DraftStorage = serviceIsADraftInstance
+	const ourDraftStorage: DraftStorage = serviceIsADraftInstance
 		? service
 		: service.draftStorage;
 
@@ -74,7 +74,7 @@ const doModify = async (
 				...formDataToDraftNewsletterData(stepData.formData),
 				...listIdEntry,
 			};
-			const storageResponse = await ourDraftService.update(draftNewsletter);
+			const storageResponse = await ourDraftStorage.update(draftNewsletter);
 			if (storageResponse.ok) {
 				return {
 					data: draftNewsletterDataToFormData(storageResponse.data),

--- a/libs/newsletter-workflow/src/lib/executeModify.ts
+++ b/libs/newsletter-workflow/src/lib/executeModify.ts
@@ -1,5 +1,5 @@
 import type {
-	DraftStorage,
+	DraftService,
 	DraftWithId,
 	LaunchService,
 } from '@newsletters-nx/newsletters-data-client';
@@ -16,16 +16,10 @@ import type {
 } from '@newsletters-nx/state-machine';
 import { validateIncomingFormData } from '@newsletters-nx/state-machine';
 
-const isADraftStorage = (
-	service: LaunchService | DraftStorage,
-): service is DraftStorage => {
-	return typeof (service as LaunchService).launchDraft === 'undefined';
-};
-
 const doModify = async (
 	stepData: WizardStepData,
 	stepLayout?: WizardStepLayout,
-	service?: LaunchService | DraftStorage,
+	service?: LaunchService | DraftService,
 ): Promise<WizardExecutionSuccess | WizardExecutionFailure> => {
 	if (!service) {
 		return {
@@ -33,12 +27,6 @@ const doModify = async (
 			message: 'no draft storage instance',
 		};
 	}
-
-	const serviceIsADraftInstance = isADraftStorage(service);
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- linting bug?
-	const ourDraftStorage: DraftStorage = serviceIsADraftInstance
-		? service
-		: service.draftStorage;
 
 	if (stepData.formData) {
 		const { listId } = stepData.formData;
@@ -74,7 +62,9 @@ const doModify = async (
 				...formDataToDraftNewsletterData(stepData.formData),
 				...listIdEntry,
 			};
-			const storageResponse = await ourDraftStorage.update(draftNewsletter);
+			const storageResponse = await service.draftStorage.update(
+				draftNewsletter,
+			);
 			if (storageResponse.ok) {
 				return {
 					data: draftNewsletterDataToFormData(storageResponse.data),
@@ -92,12 +82,12 @@ const doModify = async (
 	};
 };
 
-export const executeModify: AsyncExecution<DraftStorage> = async (
+export const executeModify: AsyncExecution<DraftService> = async (
 	stepData: WizardStepData,
-	stepLayout?: WizardStepLayout<DraftStorage>,
-	draftStorage?: DraftStorage,
+	stepLayout?: WizardStepLayout<DraftService>,
+	draftService?: DraftService,
 ) => {
-	return doModify(stepData, stepLayout as WizardStepLayout, draftStorage);
+	return doModify(stepData, stepLayout as WizardStepLayout, draftService);
 };
 
 export const executeModifyWithinLaunch: AsyncExecution<LaunchService> = async (

--- a/libs/newsletter-workflow/src/lib/executeSkip.ts
+++ b/libs/newsletter-workflow/src/lib/executeSkip.ts
@@ -1,5 +1,5 @@
 import { draftNewsletterDataToFormData } from '@newsletters-nx/newsletters-data-client';
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type {
 	AsyncExecution,
 	WizardStepData,
@@ -22,13 +22,13 @@ const getListId = (stepData: WizardStepData): number | undefined => {
 	return undefined;
 };
 
-export const executeSkip: AsyncExecution<DraftStorage> = async (
+export const executeSkip: AsyncExecution<DraftService> = async (
 	stepData: WizardStepData,
-	stepLayout?: WizardStepLayout<DraftStorage>,
-	storageInstance?: DraftStorage,
+	stepLayout?: WizardStepLayout<DraftService>,
+	draftService?: DraftService,
 ) => {
-	if (!storageInstance) {
-		return { isFailure: true, message: 'no storage instance' };
+	if (!draftService) {
+		return { isFailure: true, message: 'no draft service instance' };
 	}
 
 	const listId = getListId(stepData);
@@ -38,7 +38,7 @@ export const executeSkip: AsyncExecution<DraftStorage> = async (
 			message: 'incoming data did not include the listId',
 		};
 	}
-	const storageResponse = await storageInstance.read(listId);
+	const storageResponse = await draftService.draftStorage.read(listId);
 
 	if (!storageResponse.ok) {
 		return {

--- a/libs/newsletter-workflow/src/lib/getDraftFromStorage.ts
+++ b/libs/newsletter-workflow/src/lib/getDraftFromStorage.ts
@@ -1,6 +1,6 @@
 import { draftNewsletterDataToFormData } from '@newsletters-nx/newsletters-data-client';
 import type {
-	DraftStorage,
+	DraftService,
 	FormDataRecord,
 } from '@newsletters-nx/newsletters-data-client';
 import type { CurrentStepRouteRequest } from '@newsletters-nx/state-machine';
@@ -11,7 +11,7 @@ import {
 
 export const getDraftFromStorage = async (
 	requestBody: CurrentStepRouteRequest,
-	storageInstance: DraftStorage,
+	draftService: DraftService,
 ): Promise<FormDataRecord> => {
 	const listId =
 		typeof requestBody.formData?.['listId'] === 'number'
@@ -25,7 +25,7 @@ export const getDraftFromStorage = async (
 	}
 	const idAsNumber = +existingItemId;
 
-	const storageResponse = await storageInstance.read(idAsNumber);
+	const storageResponse = await draftService.draftStorage.read(idAsNumber);
 	if (!storageResponse.ok) {
 		throw new StateMachineError(
 			`cannot load draft newsletter with id ${existingItemId}`,

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/emailCentralProductionLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/emailCentralProductionLayout.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
@@ -31,7 +31,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const emailCentralProductionLayout: WizardStepLayout<DraftStorage> = {
+export const emailCentralProductionLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown,
 	label: 'Email CP',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/cancelLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/cancelLayout.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 
 const markdownToDisplay = `
@@ -7,7 +7,7 @@ const markdownToDisplay = `
 Collection of newsletter data was cancelled.
 `.trim();
 
-export const cancelLayout: WizardStepLayout<DraftStorage> = {
+export const cancelLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown: markdownToDisplay,
 	buttons: {},
 	role: 'EARLY_EXIT',

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/categoryLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/categoryLayout.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import {
 	getNextStepId,
@@ -28,7 +28,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const categoryLayout: WizardStepLayout<DraftStorage> = {
+export const categoryLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown,
 	label: 'Production Category',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/createDraftNewsletterLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/createDraftNewsletterLayout.ts
@@ -1,10 +1,10 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import { getNextStepId } from '@newsletters-nx/state-machine';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeCreate } from '../../executeCreate';
 import { formSchemas } from './formSchemas';
 
-export const createDraftNewsletterLayout: WizardStepLayout<DraftStorage> = {
+export const createDraftNewsletterLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown: `# Start creating a newsletter
 
 Welcome!  This wizard will guide you through the process of creating a newsletter using email-rendering.

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/dateLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/dateLayout.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import {
 	getNextStepId,
 	getPreviousOrEditStartStepId,
@@ -34,7 +34,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const dateLayout: WizardStepLayout<DraftStorage> = {
+export const dateLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown,
 	label: 'Launch/Promotion Dates',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/editDraftNewsletterLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/editDraftNewsletterLayout.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { getNextStepId } from '@newsletters-nx/state-machine';
 import { executeModify } from '../../executeModify';
@@ -6,7 +6,7 @@ import { executeSkip } from '../../executeSkip';
 import { getDraftFromStorage } from '../../getDraftFromStorage';
 import { formSchemas } from './formSchemas';
 
-export const editDraftNewsletterLayout: WizardStepLayout<DraftStorage> = {
+export const editDraftNewsletterLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown: `## Change Newsletter name
 
 You can edit the name of the newsletter.

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/finishLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/finishLayout.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeSkip } from '../../executeSkip';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
@@ -19,7 +19,7 @@ const messageAboutRenderingOptions = `You will need to set the [rendering option
 
 const staticMarkdown = markdownTemplate.replace(regExPatterns.name, '');
 
-const finishLayout: WizardStepLayout<DraftStorage> = {
+const finishLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown: staticMarkdown,
 	indicateStepsCompleteOnThisWizard: true,
 	label: 'Finish',

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/frequencyLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/frequencyLayout.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import { getNextStepId } from '@newsletters-nx/state-machine';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeModify } from '../../executeModify';
@@ -39,7 +39,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const frequencyLayout: WizardStepLayout<DraftStorage> = {
+export const frequencyLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown,
 	label: 'Send Frequency',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/index.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/index.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardLayout } from '@newsletters-nx/state-machine';
 import { cancelLayout } from './cancelLayout';
 import { categoryLayout } from './categoryLayout';
@@ -17,7 +17,7 @@ import { signUpPageLayout } from './signUpPageLayout';
 import { singleThrasherLayout } from './singleThrasherLayout';
 import { tagsLayout } from './tagsLayout';
 
-export const newsletterDataLayout: WizardLayout<DraftStorage> = {
+export const newsletterDataLayout: WizardLayout<DraftService> = {
 	cancel: cancelLayout,
 	createDraftNewsletter: createDraftNewsletterLayout,
 	editDraftNewsletter: editDraftNewsletterLayout,

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/multiThrashersLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/multiThrashersLayout.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import {
 	getNextStepId,
@@ -30,7 +30,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const multiThrashersLayout: WizardStepLayout<DraftStorage> = {
+export const multiThrashersLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown,
 	label: 'Multi Thrashers',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/newsletterDesignLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/newsletterDesignLayout.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import {
 	getNextStepId,
@@ -23,7 +23,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const newsletterDesignLayout: WizardStepLayout<DraftStorage> = {
+export const newsletterDesignLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown,
 	label: 'Newsletter Design',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/onlineArticleLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/onlineArticleLayout.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import {
 	getNextStepId,
@@ -26,7 +26,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const onlineArticleLayout: WizardStepLayout<DraftStorage> = {
+export const onlineArticleLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown,
 	label: 'Online Article',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/pillarAndGroupLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/pillarAndGroupLayout.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import {
 	getNextStepId,
 	getPreviousOrStartStepId,
@@ -35,7 +35,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const pillarAndGroupLayout: WizardStepLayout<DraftStorage> = {
+export const pillarAndGroupLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown,
 	label: 'Pillar and Group',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/regionFocusLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/regionFocusLayout.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import {
 	getNextStepId,
 	getPreviousOrEditStartStepId,
@@ -22,7 +22,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const regionFocusLayout: WizardStepLayout<DraftStorage> = {
+export const regionFocusLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown,
 	label: 'Geo Focus',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/signUpEmbedLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/signUpEmbedLayout.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import {
 	getNextStepId,
@@ -24,7 +24,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const signUpEmbedLayout: WizardStepLayout<DraftStorage> = {
+export const signUpEmbedLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown,
 	label: 'Sign Up Embed',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/signUpPageLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/signUpPageLayout.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import {
 	getNextStepId,
@@ -24,7 +24,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const signUpPageLayout: WizardStepLayout<DraftStorage> = {
+export const signUpPageLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown,
 	label: 'Sign Up Page',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/singleThrasherLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/singleThrasherLayout.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import {
 	getNextStepId,
@@ -28,7 +28,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const singleThrasherLayout: WizardStepLayout<DraftStorage> = {
+export const singleThrasherLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown,
 	label: 'Single Thrasher',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/tagsLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/tagsLayout.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import {
 	getNextStepId,
@@ -36,7 +36,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const tagsLayout: WizardStepLayout<DraftStorage> = {
+export const tagsLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown,
 	label: 'Tag Setup',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/cancelLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/cancelLayout.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 
 const markdownToDisplay = `
@@ -7,7 +7,7 @@ const markdownToDisplay = `
 Setting the render options was cancelled.
 `.trim();
 
-export const cancelLayout: WizardStepLayout<DraftStorage> = {
+export const cancelLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown: markdownToDisplay,
 	buttons: {},
 	role: 'EARLY_EXIT',

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/finishLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/finishLayout.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import { getPreviousOrEditStartStepId } from '@newsletters-nx/state-machine';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { executeModify } from '../../executeModify';
@@ -17,7 +17,7 @@ You can see the full details of **{{name}}** on the [details page](drafts/{{list
 
 const staticMarkdown = markdownTemplate.replace(regExPatterns.name, '');
 
-const finishLayout: WizardStepLayout<DraftStorage> = {
+const finishLayout: WizardStepLayout<DraftService> = {
 	indicateStepsCompleteOnThisWizard: true,
 	staticMarkdown: staticMarkdown,
 	label: 'Finish',

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/footerLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/footerLayout.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import {
 	getNextStepId,
@@ -25,7 +25,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const footerLayout: WizardStepLayout<DraftStorage> = {
+export const footerLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown,
 	label: 'Footer Setup',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/imageLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/imageLayout.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import {
 	getNextStepId,
@@ -23,7 +23,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const imageLayout: WizardStepLayout<DraftStorage> = {
+export const imageLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown,
 	label: 'Images',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/index.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/index.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardLayout } from '@newsletters-nx/state-machine';
 import { cancelLayout } from './cancelLayout';
 import { finishLayout } from './finishLayout';
@@ -10,7 +10,7 @@ import { podcastLayout } from './podcastLayout';
 import { readMoreLayout } from './readMoreLayout';
 import { startLayout } from './startLayout';
 
-export const renderingOptionsLayout: WizardLayout<DraftStorage> = {
+export const renderingOptionsLayout: WizardLayout<DraftService> = {
 	start: startLayout,
 	newsletterHeader: newsletterHeaderLayout,
 	image: imageLayout,

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/linkListLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/linkListLayout.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import {
 	getNextStepId,
@@ -29,7 +29,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const linkListLayout: WizardStepLayout<DraftStorage> = {
+export const linkListLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown,
 	label: 'Link List Sections',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/newsletterHeaderLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/newsletterHeaderLayout.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import {
 	getNextStepId,
@@ -33,7 +33,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const newsletterHeaderLayout: WizardStepLayout<DraftStorage> = {
+export const newsletterHeaderLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown,
 	label: 'Header Setup',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/podcastLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/podcastLayout.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import {
 	getNextStepId,
@@ -29,7 +29,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const podcastLayout: WizardStepLayout<DraftStorage> = {
+export const podcastLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown,
 	label: 'Podcast Sections',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/readMoreLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/readMoreLayout.ts
@@ -1,4 +1,4 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import {
 	getNextStepId,
@@ -28,7 +28,7 @@ const staticMarkdown = markdownTemplate.replace(
 	'the newsletter',
 );
 
-export const readMoreLayout: WizardStepLayout<DraftStorage> = {
+export const readMoreLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown,
 	label: 'Read More Sections',
 	dynamicMarkdown(requestData, responseData) {

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/startLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/startLayout.ts
@@ -1,10 +1,10 @@
-import type { DraftStorage } from '@newsletters-nx/newsletters-data-client';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { getNextStepId } from '@newsletters-nx/state-machine';
 import { executeModify } from '../../executeModify';
 import { getDraftFromStorage } from '../../getDraftFromStorage';
 
-export const startLayout: WizardStepLayout<DraftStorage> = {
+export const startLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown: `## Set Rendering Template Options
 
 This wizard is to choose the options for how an article-based newsletter will appear in Email-rendering.

--- a/libs/newsletters-data-client/src/index.ts
+++ b/libs/newsletters-data-client/src/index.ts
@@ -2,6 +2,7 @@ export * from './lib/api-response-type';
 export * from './lib/deriveNewsletterFields';
 export * from './lib/emailEmbedSchema';
 export * from './lib/legacy-newsletter-type';
+export * from './lib/meta-data-type';
 export * from './lib/newsletter-data-type';
 export * from './lib/draft-storage';
 export * from './lib/draft-to-newsletter';

--- a/libs/newsletters-data-client/src/index.ts
+++ b/libs/newsletters-data-client/src/index.ts
@@ -7,6 +7,7 @@ export * from './lib/draft-storage';
 export * from './lib/draft-to-newsletter';
 export * from './lib/newsletter-storage';
 export * from './lib/launch-service';
+export * from './lib/draft-service';
 export * from './lib/transformDataToLegacyNewsletter';
 export * from './lib/wizard-button-type';
 export * from './lib/transformWizardData';

--- a/libs/newsletters-data-client/src/lib/draft-service/index.ts
+++ b/libs/newsletters-data-client/src/lib/draft-service/index.ts
@@ -1,0 +1,12 @@
+import type { DraftStorage } from '../draft-storage';
+import type { UserProfile } from '../user-profile';
+
+export class DraftService {
+	draftStorage: DraftStorage;
+	userProfile: UserProfile;
+
+	constructor(draftStorage: DraftStorage, userProfile: UserProfile) {
+		this.draftStorage = draftStorage;
+		this.userProfile = userProfile;
+	}
+}

--- a/libs/newsletters-data-client/src/lib/draft-storage/DraftStorage.ts
+++ b/libs/newsletters-data-client/src/lib/draft-storage/DraftStorage.ts
@@ -1,10 +1,6 @@
 import type { MetaData } from '../meta-data-type';
 import { createNewMeta, stripMeta, updateMeta } from '../meta-data-type';
-import type {
-	DraftNewsletterData,
-	DraftNewsletterDataWithMeta,
-	DraftNewsletterDataWithoutMeta,
-} from '../newsletter-data-type';
+import type { DraftNewsletterData } from '../newsletter-data-type';
 import type {
 	SuccessfulStorageResponse,
 	UnsuccessfulStorageResponse,
@@ -14,38 +10,56 @@ import type { UserProfile } from '../user-profile';
 export type DraftWithoutId = DraftNewsletterData & { listId: undefined };
 export type DraftWithId = DraftNewsletterData & { listId: number };
 
+export type DraftWithMetaAndId = DraftNewsletterData & {
+	listId: number;
+	meta: MetaData;
+};
+export type DraftWithMetaButNoId = DraftNewsletterData & {
+	listId: undefined;
+	meta: MetaData;
+};
+export type DraftWithIdButNoMeta = DraftNewsletterData & {
+	listId: number;
+	meta: undefined;
+};
+
 export abstract class DraftStorage {
 	abstract create(
 		draft: DraftWithoutId,
+		user: UserProfile,
 	): Promise<
-		SuccessfulStorageResponse<DraftWithId> | UnsuccessfulStorageResponse
+		| SuccessfulStorageResponse<DraftWithIdButNoMeta>
+		| UnsuccessfulStorageResponse
 	>;
 
 	abstract read(
 		listId: number,
 	): Promise<
-		SuccessfulStorageResponse<DraftWithId> | UnsuccessfulStorageResponse
+		| SuccessfulStorageResponse<DraftWithIdButNoMeta>
+		| UnsuccessfulStorageResponse
 	>;
 
 	abstract update(
 		draft: DraftWithId,
+		user: UserProfile,
 	): Promise<
-		SuccessfulStorageResponse<DraftWithId> | UnsuccessfulStorageResponse
+		| SuccessfulStorageResponse<DraftWithIdButNoMeta>
+		| UnsuccessfulStorageResponse
 	>;
 
 	abstract deleteItem(
 		listId: number,
 	): Promise<
-		SuccessfulStorageResponse<DraftWithId> | UnsuccessfulStorageResponse
+		| SuccessfulStorageResponse<DraftWithIdButNoMeta>
+		| UnsuccessfulStorageResponse
 	>;
 
 	abstract readAll(): Promise<
-		SuccessfulStorageResponse<DraftWithId[]> | UnsuccessfulStorageResponse
+		| SuccessfulStorageResponse<DraftWithIdButNoMeta[]>
+		| UnsuccessfulStorageResponse
 	>;
 
-	stripMeta(
-		data: DraftNewsletterDataWithMeta | DraftNewsletterData,
-	): DraftNewsletterDataWithoutMeta {
+	stripMeta(data: DraftWithMetaAndId): DraftWithIdButNoMeta {
 		return stripMeta(data);
 	}
 

--- a/libs/newsletters-data-client/src/lib/draft-storage/DraftStorage.ts
+++ b/libs/newsletters-data-client/src/lib/draft-storage/DraftStorage.ts
@@ -10,14 +10,11 @@ import type { UserProfile } from '../user-profile';
 export type DraftWithoutId = DraftNewsletterData & { listId: undefined };
 export type DraftWithId = DraftNewsletterData & { listId: number };
 
-export type DraftWithMetaAndId = DraftNewsletterData & {
+export type DraftWithIdAndMeta = DraftNewsletterData & {
 	listId: number;
 	meta: MetaData;
 };
-export type DraftWithMetaButNoId = DraftNewsletterData & {
-	listId: undefined;
-	meta: MetaData;
-};
+
 export type DraftWithIdButNoMeta = DraftNewsletterData & {
 	listId: number;
 	meta: undefined;
@@ -59,7 +56,7 @@ export abstract class DraftStorage {
 		| UnsuccessfulStorageResponse
 	>;
 
-	stripMeta(data: DraftWithMetaAndId): DraftWithIdButNoMeta {
+	stripMeta(data: DraftWithIdAndMeta): DraftWithIdButNoMeta {
 		return stripMeta(data);
 	}
 

--- a/libs/newsletters-data-client/src/lib/draft-storage/DraftStorage.ts
+++ b/libs/newsletters-data-client/src/lib/draft-storage/DraftStorage.ts
@@ -1,9 +1,16 @@
-import type { DraftNewsletterData } from '../newsletter-data-type';
+import type { MetaData } from '../meta-data-type';
+import { createNewMeta, stripMeta, updateMeta } from '../meta-data-type';
+import type {
+	DraftNewsletterData,
+	DraftNewsletterDataWithMeta,
+	DraftNewsletterDataWithoutMeta,
+} from '../newsletter-data-type';
 import { isDraftNewsletterData } from '../newsletter-data-type';
 import type {
 	SuccessfulStorageResponse,
 	UnsuccessfulStorageResponse,
 } from '../storage-response-types';
+import type { UserProfile } from '../user-profile';
 
 export type DraftWithoutId = DraftNewsletterData & { listId: undefined };
 export type DraftWithId = DraftNewsletterData & { listId: number };
@@ -38,4 +45,18 @@ export abstract class DraftStorage {
 	abstract readAll(): Promise<
 		SuccessfulStorageResponse<DraftWithId[]> | UnsuccessfulStorageResponse
 	>;
+
+	stripMeta(
+		data: DraftNewsletterDataWithMeta | DraftNewsletterData,
+	): DraftNewsletterDataWithoutMeta {
+		return stripMeta(data);
+	}
+
+	createNewMeta(user: UserProfile): MetaData {
+		return createNewMeta(user);
+	}
+
+	updateMeta(meta: MetaData, user: UserProfile): MetaData {
+		return updateMeta(meta, user);
+	}
 }

--- a/libs/newsletters-data-client/src/lib/draft-storage/DraftStorage.ts
+++ b/libs/newsletters-data-client/src/lib/draft-storage/DraftStorage.ts
@@ -5,7 +5,6 @@ import type {
 	DraftNewsletterDataWithMeta,
 	DraftNewsletterDataWithoutMeta,
 } from '../newsletter-data-type';
-import { isDraftNewsletterData } from '../newsletter-data-type';
 import type {
 	SuccessfulStorageResponse,
 	UnsuccessfulStorageResponse,
@@ -14,8 +13,6 @@ import type { UserProfile } from '../user-profile';
 
 export type DraftWithoutId = DraftNewsletterData & { listId: undefined };
 export type DraftWithId = DraftNewsletterData & { listId: number };
-
-export const isDraft = isDraftNewsletterData;
 
 export abstract class DraftStorage {
 	abstract create(

--- a/libs/newsletters-data-client/src/lib/draft-storage/DraftStorage.ts
+++ b/libs/newsletters-data-client/src/lib/draft-storage/DraftStorage.ts
@@ -36,6 +36,12 @@ export abstract class DraftStorage {
 		| UnsuccessfulStorageResponse
 	>;
 
+	abstract readWithMeta(
+		listId: number,
+	): Promise<
+		SuccessfulStorageResponse<DraftWithIdAndMeta> | UnsuccessfulStorageResponse
+	>;
+
 	abstract update(
 		draft: DraftWithId,
 		user: UserProfile,

--- a/libs/newsletters-data-client/src/lib/draft-storage/InMemoryDraftStorage.ts
+++ b/libs/newsletters-data-client/src/lib/draft-storage/InMemoryDraftStorage.ts
@@ -3,7 +3,8 @@ import type {
 	SuccessfulStorageResponse,
 	UnsuccessfulStorageResponse,
 } from '../storage-response-types';
-import type { DraftStorage, DraftWithId, DraftWithoutId } from './DraftStorage';
+import { DraftStorage } from './DraftStorage';
+import type { DraftWithId, DraftWithoutId } from './DraftStorage';
 
 // TODO - serialise Drafts before returning
 // so objects in memory can't be directly modified outside the Storage
@@ -111,4 +112,8 @@ export class InMemoryDraftStorage implements DraftStorage {
 		);
 		return currentHighestListId + 1;
 	}
+
+	stripMeta = DraftStorage.prototype.stripMeta;
+	createNewMeta = DraftStorage.prototype.createNewMeta;
+	updateMeta = DraftStorage.prototype.updateMeta;
 }

--- a/libs/newsletters-data-client/src/lib/draft-storage/InMemoryDraftStorage.ts
+++ b/libs/newsletters-data-client/src/lib/draft-storage/InMemoryDraftStorage.ts
@@ -8,15 +8,15 @@ import type { UserProfile } from '../user-profile';
 import { DraftStorage } from './DraftStorage';
 import type {
 	DraftWithId,
+	DraftWithIdAndMeta,
 	DraftWithIdButNoMeta,
-	DraftWithMetaAndId,
 	DraftWithoutId,
 } from './DraftStorage';
 
 // TODO - serialise Drafts before returning
 // so objects in memory can't be directly modified outside the Storage
 export class InMemoryDraftStorage implements DraftStorage {
-	private memory: DraftWithMetaAndId[];
+	private memory: DraftWithIdAndMeta[];
 
 	constructor(drafts?: DraftWithId[]) {
 		this.memory = drafts
@@ -35,7 +35,7 @@ export class InMemoryDraftStorage implements DraftStorage {
 			meta: undefined,
 		};
 
-		const newDraftWithListIdAndMeta: DraftWithMetaAndId = {
+		const newDraftWithListIdAndMeta: DraftWithIdAndMeta = {
 			...newDraftWithListId,
 			meta: this.createNewMeta(user),
 		};
@@ -80,7 +80,7 @@ export class InMemoryDraftStorage implements DraftStorage {
 			return Promise.resolve(response);
 		}
 
-		const updatedDraft: DraftWithMetaAndId = {
+		const updatedDraft: DraftWithIdAndMeta = {
 			...match,
 			...changeToDraft,
 			meta: this.updateMeta(match.meta, user),

--- a/libs/newsletters-data-client/src/lib/draft-storage/InMemoryDraftStorage.ts
+++ b/libs/newsletters-data-client/src/lib/draft-storage/InMemoryDraftStorage.ts
@@ -66,6 +66,25 @@ export class InMemoryDraftStorage implements DraftStorage {
 		return Promise.resolve(response);
 	}
 
+	readWithMeta(listId: number) {
+		const match = this.memory.find((draft) => draft.listId === listId);
+
+		if (!match) {
+			const response: UnsuccessfulStorageResponse = {
+				ok: false,
+				message: `No draft with listId ${listId} found.`,
+				reason: StorageRequestFailureReason.NotFound,
+			};
+			return Promise.resolve(response);
+		}
+
+		const response: SuccessfulStorageResponse<DraftWithIdAndMeta> = {
+			ok: true,
+			data: match,
+		};
+		return Promise.resolve(response);
+	}
+
 	update(changeToDraft: DraftWithId, user: UserProfile) {
 		const match = this.memory.find(
 			(existingDraft) => existingDraft.listId === changeToDraft.listId,

--- a/libs/newsletters-data-client/src/lib/draft-storage/S3DraftStorage/index.ts
+++ b/libs/newsletters-data-client/src/lib/draft-storage/S3DraftStorage/index.ts
@@ -215,4 +215,8 @@ export class S3DraftStorage extends DraftStorage {
 	private getListOfObjectsKeys = getListOfObjectsKeys(this);
 	private fetchObject = fetchObject(this);
 	private deleteObject = deleteObject(this);
+
+	stripMeta = DraftStorage.prototype.stripMeta;
+	createNewMeta = DraftStorage.prototype.createNewMeta;
+	updateMeta = DraftStorage.prototype.updateMeta;
 }

--- a/libs/newsletters-data-client/src/lib/draft-storage/S3DraftStorage/index.ts
+++ b/libs/newsletters-data-client/src/lib/draft-storage/S3DraftStorage/index.ts
@@ -8,8 +8,8 @@ import { StorageRequestFailureReason } from '../../storage-response-types';
 import type { UserProfile } from '../../user-profile';
 import type {
 	DraftWithId,
+	DraftWithIdAndMeta,
 	DraftWithIdButNoMeta,
-	DraftWithMetaAndId,
 	DraftWithoutId,
 } from '../DraftStorage';
 import { DraftStorage } from '../DraftStorage';
@@ -144,7 +144,7 @@ export class S3DraftStorage extends DraftStorage {
 				);
 			}
 
-			const draftWithMetaAndId: DraftWithMetaAndId = {
+			const draftWithMetaAndId: DraftWithIdAndMeta = {
 				...draft,
 				meta: this.updateMeta(existingDraft?.meta ?? makeBlankMeta(), user),
 			};

--- a/libs/newsletters-data-client/src/lib/draft-storage/S3DraftStorage/index.ts
+++ b/libs/newsletters-data-client/src/lib/draft-storage/S3DraftStorage/index.ts
@@ -1,13 +1,20 @@
 import type { S3Client } from '@aws-sdk/client-s3';
+import { makeBlankMeta } from '../../meta-data-type';
 import type {
 	SuccessfulStorageResponse,
 	UnsuccessfulStorageResponse,
 } from '../../storage-response-types';
 import { StorageRequestFailureReason } from '../../storage-response-types';
-import type { DraftWithId, DraftWithoutId } from '../DraftStorage';
+import type { UserProfile } from '../../user-profile';
+import type {
+	DraftWithId,
+	DraftWithIdButNoMeta,
+	DraftWithMetaAndId,
+	DraftWithoutId,
+} from '../DraftStorage';
 import { DraftStorage } from '../DraftStorage';
 import { errorToResponse } from './errorToResponse';
-import { objectToDraftWithId } from './objectToDraftWithId';
+import { objectToDraftWithMetaAndId } from './objectToDraftWithId';
 import {
 	deleteObject,
 	fetchObject,
@@ -28,8 +35,10 @@ export class S3DraftStorage extends DraftStorage {
 
 	async create(
 		draft: DraftWithoutId,
+		user: UserProfile,
 	): Promise<
-		SuccessfulStorageResponse<DraftWithId> | UnsuccessfulStorageResponse
+		| SuccessfulStorageResponse<DraftWithIdButNoMeta>
+		| UnsuccessfulStorageResponse
 	> {
 		try {
 			const nextId = await this.getNextId();
@@ -37,11 +46,12 @@ export class S3DraftStorage extends DraftStorage {
 				...draft,
 				creationTimeStamp: Date.now(),
 				listId: nextId,
+				meta: this.createNewMeta(user),
 			});
 
 			//fetching the data from s3 again to make sure the put worked. Is this necessary?
 			const getObjectOutput = await this.fetchObject(this.listIdToKey(nextId));
-			const newDraft = await objectToDraftWithId(getObjectOutput);
+			const newDraft = await objectToDraftWithMetaAndId(getObjectOutput);
 			if (!newDraft) {
 				return {
 					ok: false,
@@ -54,7 +64,7 @@ export class S3DraftStorage extends DraftStorage {
 
 			return {
 				ok: true,
-				data: newDraft,
+				data: this.stripMeta(newDraft),
 			};
 		} catch (err) {
 			return errorToResponse(err, draft.listId);
@@ -62,17 +72,18 @@ export class S3DraftStorage extends DraftStorage {
 	}
 
 	async readAll(): Promise<
-		UnsuccessfulStorageResponse | SuccessfulStorageResponse<DraftWithId[]>
+		| UnsuccessfulStorageResponse
+		| SuccessfulStorageResponse<DraftWithIdButNoMeta[]>
 	> {
 		try {
 			const listOfKeys = await this.getListOfObjectsKeys();
-			const data: DraftWithId[] = [];
+			const data: DraftWithIdButNoMeta[] = [];
 			await Promise.all(
 				listOfKeys.map(async (key) => {
 					const output = await this.fetchObject(key);
-					const draft = await objectToDraftWithId(output);
+					const draft = await objectToDraftWithMetaAndId(output);
 					if (draft) {
-						data.push(draft);
+						data.push(this.stripMeta(draft));
 					}
 				}),
 			);
@@ -89,12 +100,13 @@ export class S3DraftStorage extends DraftStorage {
 	async read(
 		listId: number,
 	): Promise<
-		SuccessfulStorageResponse<DraftWithId> | UnsuccessfulStorageResponse
+		| SuccessfulStorageResponse<DraftWithIdButNoMeta>
+		| UnsuccessfulStorageResponse
 	> {
 		try {
 			const key = this.listIdToKey(listId);
 			const object = await this.fetchObject(key);
-			const draft = await objectToDraftWithId(object);
+			const draft = await objectToDraftWithMetaAndId(object);
 
 			if (!draft) {
 				return {
@@ -106,7 +118,7 @@ export class S3DraftStorage extends DraftStorage {
 
 			return {
 				ok: true,
-				data: draft,
+				data: this.stripMeta(draft),
 			};
 		} catch (err) {
 			return errorToResponse(err, listId);
@@ -115,17 +127,35 @@ export class S3DraftStorage extends DraftStorage {
 
 	async update(
 		draft: DraftWithId,
+		user: UserProfile,
 	): Promise<
-		SuccessfulStorageResponse<DraftWithId> | UnsuccessfulStorageResponse
+		| SuccessfulStorageResponse<DraftWithIdButNoMeta>
+		| UnsuccessfulStorageResponse
 	> {
 		try {
-			await this.putDraftObject(draft);
+			// fetch the exsting draft in order to read the meta data
+			const key = this.listIdToKey(draft.listId);
+			const object = await this.fetchObject(key);
+			const existingDraft = await objectToDraftWithMetaAndId(object);
+
+			if (!existingDraft?.meta) {
+				console.warn(
+					`Did not get valid meta data for ${key} - creating new meta data`,
+				);
+			}
+
+			const draftWithMetaAndId: DraftWithMetaAndId = {
+				...draft,
+				meta: this.updateMeta(existingDraft?.meta ?? makeBlankMeta(), user),
+			};
+
+			await this.putDraftObject(draftWithMetaAndId);
 
 			//fetching the data from s3 again to make sure the put worked. Is this necessary?
 			const getObjectOutput = await this.fetchObject(
 				this.listIdToKey(draft.listId),
 			);
-			const updatedDraft = await objectToDraftWithId(getObjectOutput);
+			const updatedDraft = await objectToDraftWithMetaAndId(getObjectOutput);
 
 			if (!updatedDraft) {
 				return {
@@ -139,7 +169,7 @@ export class S3DraftStorage extends DraftStorage {
 
 			return {
 				ok: true,
-				data: updatedDraft,
+				data: this.stripMeta(updatedDraft),
 			};
 		} catch (err) {
 			return errorToResponse(err, draft.listId);
@@ -149,12 +179,13 @@ export class S3DraftStorage extends DraftStorage {
 	async deleteItem(
 		listId: number,
 	): Promise<
-		SuccessfulStorageResponse<DraftWithId> | UnsuccessfulStorageResponse
+		| SuccessfulStorageResponse<DraftWithIdButNoMeta>
+		| UnsuccessfulStorageResponse
 	> {
 		try {
 			const key = this.listIdToKey(listId);
 			const getObjectOutput = await this.fetchObject(key);
-			const draftToDelete = await objectToDraftWithId(getObjectOutput);
+			const draftToDelete = await objectToDraftWithMetaAndId(getObjectOutput);
 
 			if (!draftToDelete) {
 				return {
@@ -168,7 +199,7 @@ export class S3DraftStorage extends DraftStorage {
 
 			return {
 				ok: true,
-				data: draftToDelete,
+				data: this.stripMeta(draftToDelete),
 			};
 		} catch (err) {
 			return errorToResponse(err, listId);

--- a/libs/newsletters-data-client/src/lib/draft-storage/S3DraftStorage/objectToDraftWithId.ts
+++ b/libs/newsletters-data-client/src/lib/draft-storage/S3DraftStorage/objectToDraftWithId.ts
@@ -1,10 +1,10 @@
 import type { GetObjectCommandOutput } from '@aws-sdk/client-s3';
-import { isDraftNewsletterData } from '../../newsletter-data-type';
-import type { DraftWithId } from '../DraftStorage';
+import { isDraftNewsletterDataWithMeta } from '../../newsletter-data-type';
+import type { DraftWithMetaAndId } from '../DraftStorage';
 
-export const objectToDraftWithId = async (
+export const objectToDraftWithMetaAndId = async (
 	getObjectOutput: GetObjectCommandOutput,
-): Promise<DraftWithId | undefined> => {
+): Promise<DraftWithMetaAndId | undefined> => {
 	try {
 		const { Body } = getObjectOutput;
 		const content = await Body?.transformToString();
@@ -12,13 +12,14 @@ export const objectToDraftWithId = async (
 			return undefined;
 		}
 		const parsedContent = JSON.parse(content) as unknown;
-		if (!isDraftNewsletterData(parsedContent)) {
+		if (!isDraftNewsletterDataWithMeta(parsedContent)) {
 			return undefined;
 		}
 		if (typeof parsedContent.listId !== 'number') {
 			return undefined;
 		}
-		return parsedContent as DraftWithId;
+
+		return parsedContent as DraftWithMetaAndId;
 	} catch (err) {
 		console.warn('objectToDraft failed');
 		console.warn(err);

--- a/libs/newsletters-data-client/src/lib/draft-storage/S3DraftStorage/objectToDraftWithId.ts
+++ b/libs/newsletters-data-client/src/lib/draft-storage/S3DraftStorage/objectToDraftWithId.ts
@@ -1,10 +1,10 @@
 import type { GetObjectCommandOutput } from '@aws-sdk/client-s3';
 import { isDraftNewsletterDataWithMeta } from '../../newsletter-data-type';
-import type { DraftWithMetaAndId } from '../DraftStorage';
+import type { DraftWithIdAndMeta } from '../DraftStorage';
 
 export const objectToDraftWithMetaAndId = async (
 	getObjectOutput: GetObjectCommandOutput,
-): Promise<DraftWithMetaAndId | undefined> => {
+): Promise<DraftWithIdAndMeta | undefined> => {
 	try {
 		const { Body } = getObjectOutput;
 		const content = await Body?.transformToString();
@@ -19,7 +19,7 @@ export const objectToDraftWithMetaAndId = async (
 			return undefined;
 		}
 
-		return parsedContent as DraftWithMetaAndId;
+		return parsedContent as DraftWithIdAndMeta;
 	} catch (err) {
 		console.warn('objectToDraft failed');
 		console.warn(err);

--- a/libs/newsletters-data-client/src/lib/draft-storage/S3DraftStorage/s3Functions.ts
+++ b/libs/newsletters-data-client/src/lib/draft-storage/S3DraftStorage/s3Functions.ts
@@ -4,7 +4,7 @@ import {
 	ListObjectsCommand,
 	PutObjectCommand,
 } from '@aws-sdk/client-s3';
-import type { DraftWithMetaAndId } from '../DraftStorage';
+import type { DraftWithIdAndMeta } from '../DraftStorage';
 import type { S3DraftStorage } from '.';
 
 export const deleteObject =
@@ -45,7 +45,7 @@ export const getListOfObjectsKeys =
 	};
 
 export const putDraftObject =
-	(s3DraftStorage: S3DraftStorage) => async (draft: DraftWithMetaAndId) => {
+	(s3DraftStorage: S3DraftStorage) => async (draft: DraftWithIdAndMeta) => {
 		const key = s3DraftStorage.listIdToKey(draft.listId);
 		const body = JSON.stringify(draft);
 

--- a/libs/newsletters-data-client/src/lib/draft-storage/S3DraftStorage/s3Functions.ts
+++ b/libs/newsletters-data-client/src/lib/draft-storage/S3DraftStorage/s3Functions.ts
@@ -4,7 +4,7 @@ import {
 	ListObjectsCommand,
 	PutObjectCommand,
 } from '@aws-sdk/client-s3';
-import type { DraftWithId } from '../DraftStorage';
+import type { DraftWithMetaAndId } from '../DraftStorage';
 import type { S3DraftStorage } from '.';
 
 export const deleteObject =
@@ -45,7 +45,7 @@ export const getListOfObjectsKeys =
 	};
 
 export const putDraftObject =
-	(s3DraftStorage: S3DraftStorage) => async (draft: DraftWithId) => {
+	(s3DraftStorage: S3DraftStorage) => async (draft: DraftWithMetaAndId) => {
 		const key = s3DraftStorage.listIdToKey(draft.listId);
 		const body = JSON.stringify(draft);
 

--- a/libs/newsletters-data-client/src/lib/launch-service/index.ts
+++ b/libs/newsletters-data-client/src/lib/launch-service/index.ts
@@ -1,7 +1,7 @@
 import type { DraftStorage } from '../draft-storage';
 import { withDefaultNewsletterValuesAndDerivedFields } from '../draft-to-newsletter';
 import type {
-	DraftNewsletterData,
+	DraftNewsletterDataWithMeta,
 	NewsletterData,
 } from '../newsletter-data-type';
 import type { NewsletterStorage } from '../newsletter-storage';
@@ -33,15 +33,17 @@ export class LaunchService {
 		SuccessfulStorageResponse<NewsletterData> | UnsuccessfulStorageResponse
 	> {
 		const { draftStorage, newsletterStorage } = this;
-		const draftGetResponse = await draftStorage.read(draftId);
+		const draftGetResponse = await draftStorage.readWithMeta(draftId);
 		if (!draftGetResponse.ok) {
 			return draftGetResponse;
 		}
 
-		const draftPopulatedWithDefaults: DraftNewsletterData =
-			withDefaultNewsletterValuesAndDerivedFields(draftGetResponse.data);
+		const draftPopulatedWithDefaults: DraftNewsletterDataWithMeta = {
+			...withDefaultNewsletterValuesAndDerivedFields(draftGetResponse.data),
+			meta: draftGetResponse.data.meta,
+		};
 
-		const draftWithDefaultsThenExtraValues: DraftNewsletterData = {
+		const draftWithDefaultsThenExtraValues: DraftNewsletterDataWithMeta = {
 			...draftPopulatedWithDefaults,
 			...extraValues,
 		};

--- a/libs/newsletters-data-client/src/lib/meta-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/meta-data-type.ts
@@ -37,3 +37,10 @@ export const stripMeta = <T extends Partial<Record<string, unknown>>>(
 		meta: undefined,
 	};
 };
+
+export const makeBlankMeta = (): MetaData => ({
+	createdTimestamp: 0,
+	createdBy: 'unknown',
+	updatedTimestamp: 0,
+	updatedBy: 'unknown',
+});

--- a/libs/newsletters-data-client/src/lib/meta-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/meta-data-type.ts
@@ -4,8 +4,10 @@ import type { UserProfile } from './user-profile';
 export const metaDataSchema = z.object({
 	createdTimestamp: z.number(),
 	updatedTimestamp: z.number(),
+	launchTimestamp: z.number().optional(),
 	createdBy: z.string(),
 	updatedBy: z.string(),
+	launchedBy: z.string().optional(),
 });
 
 export type MetaData = z.infer<typeof metaDataSchema>;
@@ -20,8 +22,23 @@ export const createNewMeta = (user: UserProfile): MetaData => {
 	};
 };
 
-export const updateMeta = (meta: MetaData, user: UserProfile): MetaData => {
+export const updateMeta = (
+	meta: MetaData,
+	user: UserProfile,
+	isLaunch = false,
+): MetaData => {
 	const now = Date.now();
+
+	if (isLaunch) {
+		return {
+			...meta,
+			updatedTimestamp: now,
+			updatedBy: user.email ?? '[unknown]',
+			launchTimestamp: now,
+			launchedBy: user.email ?? '[unknown]',
+		};
+	}
+
 	return {
 		...meta,
 		updatedTimestamp: now,

--- a/libs/newsletters-data-client/src/lib/meta-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/meta-data-type.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const metaDataSchema = z.object({
+	createdTimestamp: z.number(),
+	updatedTimestamp: z.number(),
+	createdBy: z.string(),
+	updatedBy: z.string(),
+});
+
+export type MetaData = z.infer<typeof metaDataSchema>;

--- a/libs/newsletters-data-client/src/lib/meta-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/meta-data-type.ts
@@ -1,4 +1,4 @@
-import { unknown, z } from 'zod';
+import { z } from 'zod';
 import type { UserProfile } from './user-profile';
 
 export const metaDataSchema = z.object({

--- a/libs/newsletters-data-client/src/lib/meta-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/meta-data-type.ts
@@ -1,4 +1,5 @@
-import { z } from 'zod';
+import { unknown, z } from 'zod';
+import type { UserProfile } from './user-profile';
 
 export const metaDataSchema = z.object({
 	createdTimestamp: z.number(),
@@ -8,3 +9,31 @@ export const metaDataSchema = z.object({
 });
 
 export type MetaData = z.infer<typeof metaDataSchema>;
+
+export const createNewMeta = (user: UserProfile): MetaData => {
+	const now = Date.now();
+	return {
+		createdTimestamp: now,
+		createdBy: user.email ?? '[unknown]',
+		updatedTimestamp: now,
+		updatedBy: user.email ?? '[unknown]',
+	};
+};
+
+export const updateMeta = (meta: MetaData, user: UserProfile): MetaData => {
+	const now = Date.now();
+	return {
+		...meta,
+		updatedTimestamp: now,
+		updatedBy: user.email ?? '[unknown]',
+	};
+};
+
+export const stripMeta = <T extends Partial<Record<string, unknown>>>(
+	data: T,
+) => {
+	return {
+		...data,
+		meta: undefined,
+	};
+};

--- a/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
@@ -1,4 +1,6 @@
 import { z } from 'zod';
+import type { MetaData } from './meta-data-type';
+import { metaDataSchema } from './meta-data-type';
 import {
 	kebabOrUnderscoreCasedString,
 	nonEmptyString,
@@ -160,6 +162,17 @@ export function isNewsletterData(subject: unknown): subject is NewsletterData {
 	return newsletterDataSchema.safeParse(subject).success;
 }
 
+export type NewsletterDataWithMeta = NewsletterData & { meta: MetaData };
+export type NewsletterDataWithoutMeta = NewsletterData & { meta: undefined };
+
+export function isNewsletterDataWithMeta(
+	subject: unknown,
+): subject is NewsletterDataWithMeta {
+	return newsletterDataSchema
+		.extend({ meta: metaDataSchema })
+		.safeParse(subject).success;
+}
+
 export function isPartialNewsletterData(
 	subject: unknown,
 ): subject is Partial<NewsletterData> {
@@ -175,21 +188,16 @@ export function isDraftNewsletterData(
 	return draftNewsletterDataSchema.safeParse(subject).success;
 }
 
-export const metaDataSchema = z.object({
-	createdTimestamp: z.number(),
-	updatedTimestamp: z.number(),
-	createdBy: z.string(),
-	updatedBy: z.string(),
-});
+export type DraftNewsletterDataWithMeta = DraftNewsletterData & {
+	meta: MetaData;
+};
+export type DraftNewsletterDataWithoutMeta = DraftNewsletterData & {
+	meta: undefined;
+};
 
-export type MetaData = z.infer<typeof metaDataSchema>;
-
-export type NewsletterDataWithMeta = NewsletterData & { meta: MetaData };
-export type NewsletterDataWithoutMeta = NewsletterData & { meta: undefined };
-
-export function isNewsletterDataWithMeta(
+export function isDraftNewsletterDataWithMeta(
 	subject: unknown,
-): subject is NewsletterDataWithMeta {
+): subject is DraftNewsletterDataWithMeta {
 	return newsletterDataSchema
 		.extend({ meta: metaDataSchema })
 		.safeParse(subject).success;

--- a/libs/newsletters-data-client/src/lib/newsletter-storage/InMemoryNewsletterStorage.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/InMemoryNewsletterStorage.ts
@@ -1,3 +1,4 @@
+import { makeBlankMeta } from '../meta-data-type';
 import type {
 	DraftNewsletterData,
 	NewsletterData,
@@ -11,7 +12,7 @@ import type {
 	UnsuccessfulStorageResponse,
 } from '../storage-response-types';
 import type { UserProfile } from '../user-profile';
-import { makeBlankMeta, NewsletterStorage } from './NewsletterStorage';
+import { NewsletterStorage } from './NewsletterStorage';
 
 // TODO - serialise Drafts before returning
 // so objects in memory can't be directly modified outside the Storage

--- a/libs/newsletters-data-client/src/lib/newsletter-storage/InMemoryNewsletterStorage.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/InMemoryNewsletterStorage.ts
@@ -57,7 +57,7 @@ export class InMemoryNewsletterStorage implements NewsletterStorage {
 		const newNewsletterWithNewId: NewsletterDataWithMeta = {
 			...draft,
 			listId: this.getNextId(),
-			meta: this.updateMeta(draft.meta, user),
+			meta: this.updateMetaForLaunch(draft.meta, user),
 		};
 		this.memory.push(newNewsletterWithNewId);
 
@@ -193,4 +193,5 @@ export class InMemoryNewsletterStorage implements NewsletterStorage {
 	stripMeta = NewsletterStorage.prototype.stripMeta;
 	createNewMeta = NewsletterStorage.prototype.createNewMeta;
 	updateMeta = NewsletterStorage.prototype.updateMeta;
+	updateMetaForLaunch = NewsletterStorage.prototype.updateMetaForLaunch;
 }

--- a/libs/newsletters-data-client/src/lib/newsletter-storage/InMemoryNewsletterStorage.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/InMemoryNewsletterStorage.ts
@@ -1,11 +1,11 @@
 import { makeBlankMeta } from '../meta-data-type';
 import type {
-	DraftNewsletterData,
+	DraftNewsletterDataWithMeta,
 	NewsletterData,
 	NewsletterDataWithMeta,
 	NewsletterDataWithoutMeta,
 } from '../newsletter-data-type';
-import { isNewsletterData } from '../newsletter-data-type';
+import { isNewsletterDataWithMeta } from '../newsletter-data-type';
 import { StorageRequestFailureReason } from '../storage-response-types';
 import type {
 	SuccessfulStorageResponse,
@@ -28,11 +28,11 @@ export class InMemoryNewsletterStorage implements NewsletterStorage {
 			: [];
 	}
 
-	create(draft: DraftNewsletterData, user: UserProfile) {
+	create(draft: DraftNewsletterDataWithMeta, user: UserProfile) {
 		// TODO - use the schema.safeParse and if the test fails,
 		// use the list of issues to generate a message with the
 		// wrong/missing fields listed.
-		const draftReady = isNewsletterData(draft);
+		const draftReady = isNewsletterDataWithMeta(draft);
 		if (!draftReady) {
 			const error: UnsuccessfulStorageResponse = {
 				ok: false,
@@ -57,7 +57,7 @@ export class InMemoryNewsletterStorage implements NewsletterStorage {
 		const newNewsletterWithNewId: NewsletterDataWithMeta = {
 			...draft,
 			listId: this.getNextId(),
-			meta: this.createNewMeta(user),
+			meta: this.updateMeta(draft.meta, user),
 		};
 		this.memory.push(newNewsletterWithNewId);
 

--- a/libs/newsletters-data-client/src/lib/newsletter-storage/NewsletterStorage.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/NewsletterStorage.ts
@@ -2,7 +2,7 @@ import type { MetaData } from '../meta-data-type';
 import { createNewMeta, stripMeta, updateMeta } from '../meta-data-type';
 import { isPartialNewsletterData } from '../newsletter-data-type';
 import type {
-	DraftNewsletterData,
+	DraftNewsletterDataWithMeta,
 	NewsletterData,
 	NewsletterDataWithMeta,
 	NewsletterDataWithoutMeta,
@@ -21,7 +21,7 @@ export const IMMUTABLE_PROPERTIES: Readonly<string[]> = [
 
 export abstract class NewsletterStorage {
 	abstract create(
-		draft: DraftNewsletterData,
+		draft: DraftNewsletterDataWithMeta,
 		user: UserProfile,
 	): Promise<
 		| SuccessfulStorageResponse<NewsletterDataWithoutMeta>

--- a/libs/newsletters-data-client/src/lib/newsletter-storage/NewsletterStorage.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/NewsletterStorage.ts
@@ -19,13 +19,6 @@ export const IMMUTABLE_PROPERTIES: Readonly<string[]> = [
 	'identityName',
 ];
 
-export const makeBlankMeta = (): MetaData => ({
-	createdTimestamp: 0,
-	createdBy: 'unknown',
-	updatedTimestamp: 0,
-	updatedBy: 'unknown',
-});
-
 export abstract class NewsletterStorage {
 	abstract create(
 		draft: DraftNewsletterData,

--- a/libs/newsletters-data-client/src/lib/newsletter-storage/NewsletterStorage.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/NewsletterStorage.ts
@@ -1,7 +1,7 @@
+import type { MetaData } from '../meta-data-type';
 import { isPartialNewsletterData } from '../newsletter-data-type';
 import type {
 	DraftNewsletterData,
-	MetaData,
 	NewsletterData,
 	NewsletterDataWithMeta,
 	NewsletterDataWithoutMeta,

--- a/libs/newsletters-data-client/src/lib/newsletter-storage/NewsletterStorage.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/NewsletterStorage.ts
@@ -1,4 +1,5 @@
 import type { MetaData } from '../meta-data-type';
+import { createNewMeta, stripMeta, updateMeta } from '../meta-data-type';
 import { isPartialNewsletterData } from '../newsletter-data-type';
 import type {
 	DraftNewsletterData,
@@ -135,28 +136,14 @@ export abstract class NewsletterStorage {
 	stripMeta(
 		data: NewsletterDataWithMeta | NewsletterData,
 	): NewsletterDataWithoutMeta {
-		return {
-			...data,
-			meta: undefined,
-		};
+		return stripMeta(data);
 	}
 
 	createNewMeta(user: UserProfile): MetaData {
-		const now = Date.now();
-		return {
-			createdTimestamp: now,
-			createdBy: user.email ?? '[unknown]',
-			updatedTimestamp: now,
-			updatedBy: user.email ?? '[unknown]',
-		};
+		return createNewMeta(user);
 	}
 
 	updateMeta(meta: MetaData, user: UserProfile): MetaData {
-		const now = Date.now();
-		return {
-			...meta,
-			updatedTimestamp: now,
-			updatedBy: user.email ?? '[unknown]',
-		};
+		return updateMeta(meta, user);
 	}
 }

--- a/libs/newsletters-data-client/src/lib/newsletter-storage/NewsletterStorage.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/NewsletterStorage.ts
@@ -139,4 +139,7 @@ export abstract class NewsletterStorage {
 	updateMeta(meta: MetaData, user: UserProfile): MetaData {
 		return updateMeta(meta, user);
 	}
+	updateMetaForLaunch(meta: MetaData, user: UserProfile): MetaData {
+		return updateMeta(meta, user, true);
+	}
 }

--- a/libs/newsletters-data-client/src/lib/newsletter-storage/s3-newsletter-storage.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/s3-newsletter-storage.ts
@@ -1,4 +1,5 @@
 import type { S3Client } from '@aws-sdk/client-s3';
+import { makeBlankMeta } from '../meta-data-type';
 import {
 	isNewsletterData,
 	isNewsletterDataWithMeta,
@@ -15,7 +16,7 @@ import type {
 } from '../storage-response-types';
 import { StorageRequestFailureReason } from '../storage-response-types';
 import type { UserProfile } from '../user-profile';
-import { makeBlankMeta, NewsletterStorage } from './NewsletterStorage';
+import { NewsletterStorage } from './NewsletterStorage';
 import { objectToNewsletter } from './objectToNewsletter';
 import {
 	fetchObject,

--- a/libs/newsletters-data-client/src/lib/newsletter-storage/s3-newsletter-storage.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/s3-newsletter-storage.ts
@@ -84,7 +84,7 @@ export class S3NewsletterStorage implements NewsletterStorage {
 		const newNewsletter: NewsletterDataWithMeta = {
 			...draft,
 			listId: nextId,
-			meta: this.updateMeta(draft.meta, user),
+			meta: this.updateMetaForLaunch(draft.meta, user),
 		};
 
 		try {
@@ -336,4 +336,5 @@ export class S3NewsletterStorage implements NewsletterStorage {
 	stripMeta = NewsletterStorage.prototype.stripMeta;
 	createNewMeta = NewsletterStorage.prototype.createNewMeta;
 	updateMeta = NewsletterStorage.prototype.updateMeta;
+	updateMetaForLaunch = NewsletterStorage.prototype.updateMetaForLaunch;
 }

--- a/libs/newsletters-data-client/src/lib/newsletter-storage/s3-newsletter-storage.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/s3-newsletter-storage.ts
@@ -1,15 +1,12 @@
 import type { S3Client } from '@aws-sdk/client-s3';
 import { makeBlankMeta } from '../meta-data-type';
-import {
-	isNewsletterData,
-	isNewsletterDataWithMeta,
-} from '../newsletter-data-type';
 import type {
-	DraftNewsletterData,
+	DraftNewsletterDataWithMeta,
 	NewsletterData,
 	NewsletterDataWithMeta,
 	NewsletterDataWithoutMeta,
 } from '../newsletter-data-type';
+import { isNewsletterDataWithMeta } from '../newsletter-data-type';
 import type {
 	SuccessfulStorageResponse,
 	UnsuccessfulStorageResponse,
@@ -37,13 +34,13 @@ export class S3NewsletterStorage implements NewsletterStorage {
 	}
 
 	async create(
-		draft: DraftNewsletterData,
+		draft: DraftNewsletterDataWithMeta,
 		user: UserProfile,
 	): Promise<
 		| SuccessfulStorageResponse<NewsletterDataWithoutMeta>
 		| UnsuccessfulStorageResponse
 	> {
-		const draftReady = isNewsletterData(draft);
+		const draftReady = isNewsletterDataWithMeta(draft);
 
 		if (!draftReady) {
 			const error: UnsuccessfulStorageResponse = {
@@ -87,7 +84,7 @@ export class S3NewsletterStorage implements NewsletterStorage {
 		const newNewsletter: NewsletterDataWithMeta = {
 			...draft,
 			listId: nextId,
-			meta: this.createNewMeta(user),
+			meta: this.updateMeta(draft.meta, user),
 		};
 
 		try {


### PR DESCRIPTION
## What does this change?

Creates a `DraftService` class, with a DraftStorage and UserProfile and updates the Wizards to use that as the service interface instead of just the DraftStorage.

The `DraftStorage` methods now use handle metadata in a similar way to the `NewsletterStorage`.

`NewsletterStorage.create` will now use the 'created' data from the draft's metadata and add a properties for when the newsletter was launched and by whom.

## How to test

Can test locally by adding some log statement to see the meta data if being populated correctly.

On Code, the S3 draft files should be getting populated with the meta data. Launching a newsletter should keep the created data from the draft it was created from.


## How can we measure success?

Can use the meta data in S3 to follow changes to drafts and launches.

## Have we considered potential risks?

should test carefully on code.

