### PR TITLE
Dbltacher rendering option ready bug

### DIFF
--- a/libs/newsletter-workflow/src/lib/getInitialStateForLaunch.ts
+++ b/libs/newsletter-workflow/src/lib/getInitialStateForLaunch.ts
@@ -7,6 +7,7 @@ import type {
 } from '@newsletters-nx/newsletters-data-client';
 import {
 	addSuffixToMakeTokenUnique,
+	defaultRenderingOptionsValues,
 	getDraftNotReadyIssues,
 	renderingOptionsSchema,
 	withDefaultNewsletterValuesAndDerivedFields,
@@ -46,7 +47,10 @@ export const getInitialStateForLaunch = async (
 	const hasRenderingOptionsIfNeeded =
 		draft.category === 'article-based'
 			? draft.renderingOptions
-				? renderingOptionsSchema.safeParse(draft.renderingOptions).success
+				? renderingOptionsSchema.safeParse({
+						...defaultRenderingOptionsValues,
+						...draft.renderingOptions,
+				  }).success
 				: false
 			: true;
 

--- a/libs/newsletters-data-client/src/lib/draft-to-newsletter.ts
+++ b/libs/newsletters-data-client/src/lib/draft-to-newsletter.ts
@@ -69,8 +69,11 @@ export const getDraftNotReadyIssues = (draft: DraftNewsletterData) => {
 
 const TOTAL_FIELD_COUNT = getDraftNotReadyIssues({}).length;
 
-const renderingOptionsNotReadyIssues = (record: unknown) => {
-	const report = renderingOptionsSchema.safeParse(record);
+const renderingOptionsNotReadyIssues = (record: Record<string, unknown>) => {
+	const report = renderingOptionsSchema.safeParse({
+		...defaultRenderingOptionsValues,
+		...record,
+	});
 	if (!report.success) {
 		return report.error.issues;
 	}
@@ -109,7 +112,7 @@ export const calculateProgress = (draft: DraftNewsletterData): number => {
 		(RENDERING_OPTIONS_FIELD_COUNT - renderingOptionsIssuesCount) /
 		RENDERING_OPTIONS_FIELD_COUNT;
 
-	// Arbitrary calculation - wieght the basic data as 2/3's of the total score
-	const combined = (basicDataRatio * 2 + renderingOptionsDataRatio) / 3;
+	// Arbitrary calculation - wieght the basic data as 1/4's of the total score
+	const combined = (basicDataRatio * 3 + renderingOptionsDataRatio) / 4;
 	return Math.floor(combined * 100);
 };

--- a/libs/newsletters-data-client/src/lib/draft-to-newsletter.ts
+++ b/libs/newsletters-data-client/src/lib/draft-to-newsletter.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import type { NewsletterFieldsDerivedFromName } from './deriveNewsletterFields';
 import { deriveNewsletterFieldsFromName } from './deriveNewsletterFields';
 import type {
@@ -38,14 +39,19 @@ export const hasAllRequiredData = (draft: DraftNewsletterData): boolean => {
 };
 
 export const getDraftNotReadyIssues = (draft: DraftNewsletterData) => {
-	const report = newsletterDataSchema.safeParse(
+	const schemaToUse =
+		draft.category === 'article-based'
+			? newsletterDataSchema.merge(
+					z.object({
+						renderingOptions: renderingOptionsSchema,
+					}),
+			  )
+			: newsletterDataSchema;
+
+	const report = schemaToUse.safeParse(
 		withDefaultNewsletterValuesAndDerivedFields(draft),
 	);
-
-	if (!report.success) {
-		return report.error.issues;
-	}
-	return [];
+	return report.success ? [] : report.error.issues;
 };
 
 const TOTAL_FIELD_COUNT = getDraftNotReadyIssues({}).length;

--- a/libs/newsletters-data-client/src/lib/draft-to-newsletter.ts
+++ b/libs/newsletters-data-client/src/lib/draft-to-newsletter.ts
@@ -4,6 +4,7 @@ import { deriveNewsletterFieldsFromName } from './deriveNewsletterFields';
 import type {
 	DraftNewsletterData,
 	NewsletterData,
+	RenderingOptions,
 } from './newsletter-data-type';
 import {
 	newsletterDataSchema,
@@ -19,23 +20,35 @@ const defaultNewsletterValues: DraftNewsletterData = {
 	figmaIncludesThrashers: false,
 } as const;
 
+export const defaultRenderingOptionsValues: Partial<RenderingOptions> = {
+	displayDate: false,
+	displayImageCaptions: false,
+	displayStandfirst: false,
+} as const;
+
 export const withDefaultNewsletterValuesAndDerivedFields = (
 	draft: DraftNewsletterData,
 ): DraftNewsletterData &
 	Pick<NewsletterData, NewsletterFieldsDerivedFromName> => {
 	const derivedFields = deriveNewsletterFieldsFromName(draft.name ?? '');
 
+	if (draft.renderingOptions) {
+		return {
+			...defaultNewsletterValues,
+			...derivedFields,
+			...draft,
+			renderingOptions: {
+				...defaultRenderingOptionsValues,
+				...draft.renderingOptions,
+			},
+		};
+	}
+
 	return {
 		...defaultNewsletterValues,
 		...derivedFields,
 		...draft,
 	};
-};
-
-export const hasAllRequiredData = (draft: DraftNewsletterData): boolean => {
-	return newsletterDataSchema.safeParse(
-		withDefaultNewsletterValuesAndDerivedFields(draft),
-	).success;
 };
 
 export const getDraftNotReadyIssues = (draft: DraftNewsletterData) => {
@@ -56,7 +69,7 @@ export const getDraftNotReadyIssues = (draft: DraftNewsletterData) => {
 
 const TOTAL_FIELD_COUNT = getDraftNotReadyIssues({}).length;
 
-export const renderingOptionsNotReadyIssues = (record: unknown) => {
+const renderingOptionsNotReadyIssues = (record: unknown) => {
 	const report = renderingOptionsSchema.safeParse(record);
 	if (!report.success) {
 		return report.error.issues;


### PR DESCRIPTION
## What does this change?

Fixes some logic gaps and aligns the validation to the UI:
 - `renderingOptions` must be set on an  "article-rendering" draft 
 - the boolean values in `renderingOptions` (not optional in the schema) not expliclity set are defaulted from `undefined` to `false` when launching or checking readiness.

## How to test

on main
 - no issues would be raised on the details page for an "article-rendering" draft with undefined renderingOptions
 - an "article-rendering" draft with a renderingOptions with boolean values set to `undefined` (IE from the "Optional" steps were skipped) would fail validation by the launch wizard and not be launched

on branch:
 - on the details page for an "article-rendering" draft with undefined `renderingOptions` the "rendering options is undefined" issue will be flagged
 - when launching and checking for issues,  undefined boolean values in the rendering options will default to false.

## How can we measure success?

Less confused users.

## Have we considered potential risks?

Data input to store still needs to be valid, so should be safe.
