### PR TITLE
remove placeholder thrashers page and fields from edit newsletter form

### DIFF
--- a/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
+++ b/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
@@ -64,12 +64,10 @@ export const EditNewsletterForm = ({ originalItem }: Props) => {
 				submit={requestUpdate}
 				schema={newsletterDataSchema.pick({
 					name: true,
-					signUpHeadline: true,
 					signUpDescription: true,
 					frequency: true,
 					regionFocus: true,
 					theme: true,
-					category: true,
 					status: true,
 				})}
 				submitButtonText="Update Newsletter"

--- a/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
+++ b/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
@@ -1,10 +1,8 @@
 import { Alert, Snackbar } from '@mui/material';
 import { useState } from 'react';
-import type {
-	ApiResponse,
-	NewsletterData,
-} from '@newsletters-nx/newsletters-data-client';
+import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
 import { newsletterDataSchema } from '@newsletters-nx/newsletters-data-client';
+import { requestNewsletterEdit } from '../api-requests/request-newsletter-edit';
 import { SimpleForm } from './SimpleForm';
 
 interface Props {
@@ -25,13 +23,10 @@ export const EditNewsletterForm = ({ originalItem }: Props) => {
 		}
 		setWaitingForResponse(true);
 
-		const response = await fetch(`/api/newsletters/${originalItem.listId}`, {
-			method: 'PATCH',
-			headers: {
-				'Content-Type': 'application/json',
-			},
-			body: JSON.stringify(modification),
-		}).catch((error) => {
+		const response = await requestNewsletterEdit(
+			originalItem.listId,
+			modification,
+		).catch((error: unknown) => {
 			setErrorMessage('Failed to submit form.');
 			setWaitingForResponse(false);
 			console.log(error);
@@ -43,16 +38,13 @@ export const EditNewsletterForm = ({ originalItem }: Props) => {
 			return;
 		}
 
-		const responseBody = (await response.json()) as unknown;
-		const castResponse = responseBody as ApiResponse<NewsletterData>;
-
-		if (castResponse.ok) {
-			setItem(castResponse.data);
+		if (response.ok) {
+			setItem(response.data);
 			setWaitingForResponse(false);
 			setConfirmationMessage('newsletter updated!');
 		} else {
 			setWaitingForResponse(false);
-			setErrorMessage(castResponse.message);
+			setErrorMessage(response.message);
 		}
 	};
 

--- a/apps/newsletters-ui/src/app/components/MainNav.tsx
+++ b/apps/newsletters-ui/src/app/components/MainNav.tsx
@@ -25,7 +25,6 @@ const navLinks: NavLink[] = [
 	{ path: '/newsletters', label: 'Launched' },
 	{ path: '/drafts', label: 'Drafts' },
 	{ path: '/templates', label: 'Email Templates' },
-	{ path: '/thrashers', label: 'Thrashers' },
 ];
 
 const menuItemIsSelected = (path: string): boolean => {

--- a/apps/newsletters-ui/src/app/routes/home.tsx
+++ b/apps/newsletters-ui/src/app/routes/home.tsx
@@ -20,12 +20,12 @@ export const homeRoute: RouteObject = {
 		},
 		{
 			path: 'templates',
-			element: <ContentWrapper><TemplateListView /></ContentWrapper>,
+			element: (
+				<ContentWrapper>
+					<TemplateListView />
+				</ContentWrapper>
+			),
 			loader: renderingTemplateListLoader,
-		},
-		{
-			path: 'thrashers',
-			element: <ContentWrapper>Coming soon...</ContentWrapper>,
 		},
 	],
 };


### PR DESCRIPTION
## What does this change?

Removes the placeholder /thrashers page and the nave button to it
Removes the 'signUpHeading' (no used in production, would be confusing) and 'category' (users cannot change a newsletter from article to fronts based) fields from the edit form.
Simplifies the fetch code in the edit form by using the helper function for making the edit request.

## How to test

changes visible in the UI

## How can we measure success?

Tool's features are easier to understand

## Have we considered potential risks?
none?