### PR TITLE
remove line from markdown about automatic emails for tags

### DIFF
--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/tagsLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/tagsLayout.ts
@@ -19,8 +19,6 @@ Please share the series tag URL for the newsletter.
 
 For example: [tv-and-radio/series/what-s-on-tv](https://www.theguardian.com/tv-and-radio/series/what-s-on-tv) for the What's On newsletter.
 
-*If the tag does not already exist, an email will automatically be sent to Central Production to request its production.*
-
 ### Composer tag relationship for newsletter embeds
 
 In Composer, we now have a feature where a newsletter signup embed is proposed to the user once a tag is added to the article - find out more [here](https://docs.google.com/document/d/1HC_Y6kOStrBNwQR322N8NdiCuhyIjlUke5RWmsRUcpM/edit).


### PR DESCRIPTION

## What does this change?

https://trello.com/c/ZL6Y2oBC/508-copy-for-tag-setup-page
Remove line from markdown about automatic emails for tags

