### PR TITLE
Cancelled newsletter API support

### DIFF
--- a/apps/newsletters-api/src/app/routes/newsletters.ts
+++ b/apps/newsletters-api/src/app/routes/newsletters.ts
@@ -12,30 +12,45 @@ import {
 	mapStorageFailureReasonToStatusCode,
 } from '../responses';
 
+interface IListNewslettersQuerystring {
+	includeCancelled?: string;
+}
 export function registerNewsletterRoutes(app: FastifyInstance) {
 	// not using the makeSuccess function on this route as
 	// we are emulating the response of the legacy API
-	app.get('/api/legacy/newsletters', async (req, res) => {
-		const storageResponse = await newsletterStore.list();
-		if (!storageResponse.ok) {
-			return res
-				.status(mapStorageFailureReasonToStatusCode(storageResponse.reason))
-				.send(makeErrorResponse(storageResponse.message));
-		}
+	app.get<{ Querystring: IListNewslettersQuerystring }>(
+		'/api/legacy/newsletters',
+		async (req, res) => {
+			const { includeCancelled } = req.query;
+			const storageResponse = await newsletterStore.list(
+				includeCancelled === 'true',
+			);
+			if (!storageResponse.ok) {
+				return res
+					.status(mapStorageFailureReasonToStatusCode(storageResponse.reason))
+					.send(makeErrorResponse(storageResponse.message));
+			}
 
-		return storageResponse.data.map(transformDataToLegacyNewsletter);
-	});
+			return storageResponse.data.map(transformDataToLegacyNewsletter);
+		},
+	);
 
-	app.get('/api/newsletters', async (req, res) => {
-		const storageResponse = await newsletterStore.list();
-		if (!storageResponse.ok) {
-			return res
-				.status(mapStorageFailureReasonToStatusCode(storageResponse.reason))
-				.send(makeErrorResponse(storageResponse.message));
-		}
+	app.get<{ Querystring: IListNewslettersQuerystring }>(
+		'/api/newsletters',
+		async (req, res) => {
+			const { includeCancelled } = req.query;
+			const storageResponse = await newsletterStore.list(
+				includeCancelled === 'true',
+			);
+			if (!storageResponse.ok) {
+				return res
+					.status(mapStorageFailureReasonToStatusCode(storageResponse.reason))
+					.send(makeErrorResponse(storageResponse.message));
+			}
 
-		return makeSuccessResponse(storageResponse.data);
-	});
+			return makeSuccessResponse(storageResponse.data);
+		},
+	);
 
 	app.get<{ Params: { newsletterId: string } }>(
 		'/api/newsletters/:newsletterId',

--- a/apps/newsletters-ui/src/app/loaders/newsletters.ts
+++ b/apps/newsletters-ui/src/app/loaders/newsletters.ts
@@ -5,12 +5,10 @@ import type {
 } from '@newsletters-nx/newsletters-data-client';
 import { fetchApiData } from '../api-requests/fetch-api-data';
 
-export const listLoader: LoaderFunction = async (): Promise<
-	NewsletterData[]
-> => {
-	const list = (await fetchApiData<NewsletterData[]>(`api/newsletters`)) ?? [];
-	return list;
-};
+export const listLoader: LoaderFunction = async (): Promise<NewsletterData[]> =>
+	(await fetchApiData<NewsletterData[]>(
+		`api/newsletters?includeCancelled=true`,
+	)) ?? [];
 
 export const detailLoader: LoaderFunction = async ({
 	params,

--- a/libs/newsletter-workflow/src/lib/check-input-is-unique.ts
+++ b/libs/newsletter-workflow/src/lib/check-input-is-unique.ts
@@ -44,7 +44,9 @@ export const checkFormDataValuesAreUnique =
 		if (!launchService) {
 			return { message: 'no launch service' };
 		}
-		const newsletterListResponse = await launchService.newsletterStorage.list();
+		const newsletterListResponse = await launchService.newsletterStorage.list(
+			true,
+		);
 		if (!newsletterListResponse.ok) {
 			return {
 				message:

--- a/libs/newsletter-workflow/src/lib/getInitialStateForLaunch.ts
+++ b/libs/newsletter-workflow/src/lib/getInitialStateForLaunch.ts
@@ -36,7 +36,7 @@ export const getInitialStateForLaunch = async (
 		};
 	}
 	const storageResponse = await launchService.draftStorage.read(id);
-	const allLaunchedResponse = await launchService.newsletterStorage.list();
+	const allLaunchedResponse = await launchService.newsletterStorage.list(true);
 
 	const draft: DraftNewsletterData = storageResponse.ok
 		? storageResponse.data

--- a/libs/newsletters-data-client/src/lib/newsletter-storage/InMemoryNewsletterStorage.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/InMemoryNewsletterStorage.ts
@@ -169,10 +169,17 @@ export class InMemoryNewsletterStorage implements NewsletterStorage {
 		return Promise.resolve(response);
 	}
 
-	list() {
+	list(includeCancelled: boolean) {
+		const allNewsletters = [...this.memory]
+			.map(this.stripMeta)
+			.map((item) => ({ ...item }));
 		const response: SuccessfulStorageResponse<NewsletterDataWithoutMeta[]> = {
 			ok: true,
-			data: [...this.memory].map(this.stripMeta).map((item) => ({ ...item })),
+			data: includeCancelled
+				? allNewsletters
+				: allNewsletters.filter(
+						(newsletter) => newsletter.status !== 'cancelled',
+				  ),
 		};
 		return Promise.resolve(response);
 	}

--- a/libs/newsletters-data-client/src/lib/newsletter-storage/NewsletterStorage.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/NewsletterStorage.ts
@@ -72,7 +72,9 @@ export abstract class NewsletterStorage {
 		| UnsuccessfulStorageResponse
 	>;
 
-	abstract list(): Promise<
+	abstract list(
+		includeCancelled: boolean,
+	): Promise<
 		| SuccessfulStorageResponse<NewsletterDataWithoutMeta[]>
 		| UnsuccessfulStorageResponse
 	>;

--- a/libs/newsletters-data-client/src/lib/newsletter-storage/s3-newsletter-storage.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/s3-newsletter-storage.ts
@@ -118,7 +118,9 @@ export class S3NewsletterStorage implements NewsletterStorage {
 		});
 	}
 
-	async list(): Promise<
+	async list(
+		includeCancelled: boolean,
+	): Promise<
 		| SuccessfulStorageResponse<NewsletterDataWithoutMeta[]>
 		| UnsuccessfulStorageResponse
 	> {
@@ -139,7 +141,11 @@ export class S3NewsletterStorage implements NewsletterStorage {
 
 			return {
 				ok: true,
-				data: listWithoutMeta,
+				data: includeCancelled
+					? listWithoutMeta
+					: listWithoutMeta.filter(
+							(newsletter) => newsletter.status !== 'cancelled',
+					  ),
 			};
 		} catch (error) {
 			return {


### PR DESCRIPTION
## What does this change?

The existing newsletters API can optionally include cancelled newsletters in the response based on a query param value. This PR adds that same fuctionality to the new API



## How to test

- Check out branch
- Run App
- Hit the [legacy endpoint](http://localhost:4200/api/legacy/newsletters) without a query param - should see no cancelled newsletters
- Hit the [legacy endpoint](http://localhost:4200/api/legacy/newsletters?includeCancelled=true) with a query param `includeCancelled=true`- Now they should appear
- Same for the non legacy API:
- [Without query param](http://localhost:4200/api/newsletters)
- [And with](http://localhost:4200/api/newsletters?includeCancelled=true)

## How can we measure success?

It works

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

Think this is OK - Have hard code true to the UI call as we alway want to be able to manage from the tool

