### PR TITLE
Edit rendering options form

### DIFF
--- a/apps/newsletters-api/src/app/routes/newsletters.ts
+++ b/apps/newsletters-api/src/app/routes/newsletters.ts
@@ -1,8 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import {
 	isPartialNewsletterData,
-	isStringRecord,
-	replaceNullWithUndefinedForRecord,
+	replaceNullWithUndefinedForUnknown,
 	transformDataToLegacyNewsletter,
 } from '@newsletters-nx/newsletters-data-client';
 import { newsletterStore } from '../../services/storage';
@@ -103,9 +102,7 @@ export function registerNewsletterRoutes(app: FastifyInstance) {
 			return res.status(400).send(makeErrorResponse(`Non numeric id provided`));
 		}
 
-		if (isStringRecord(modifications)) {
-			replaceNullWithUndefinedForRecord(modifications);
-		}
+		replaceNullWithUndefinedForUnknown(modifications);
 
 		if (!isPartialNewsletterData(modifications)) {
 			return res

--- a/apps/newsletters-api/src/app/routes/newsletters.ts
+++ b/apps/newsletters-api/src/app/routes/newsletters.ts
@@ -1,6 +1,8 @@
 import type { FastifyInstance } from 'fastify';
 import {
 	isPartialNewsletterData,
+	isStringRecord,
+	replaceNullWithUndefinedForRecord,
 	transformDataToLegacyNewsletter,
 } from '@newsletters-nx/newsletters-data-client';
 import { newsletterStore } from '../../services/storage';
@@ -99,6 +101,10 @@ export function registerNewsletterRoutes(app: FastifyInstance) {
 
 		if (isNaN(newsletterIdAsNumber)) {
 			return res.status(400).send(makeErrorResponse(`Non numeric id provided`));
+		}
+
+		if (isStringRecord(modifications)) {
+			replaceNullWithUndefinedForRecord(modifications);
 		}
 
 		if (!isPartialNewsletterData(modifications)) {

--- a/apps/newsletters-ui/src/app/api-requests/make-wizard-step-request.ts
+++ b/apps/newsletters-ui/src/app/api-requests/make-wizard-step-request.ts
@@ -1,26 +1,8 @@
+import { replaceUndefinedWithNull } from '@newsletters-nx/newsletters-data-client';
 import type {
 	CurrentStepRouteRequest,
 	CurrentStepRouteResponse,
 } from '@newsletters-nx/state-machine';
-
-/**
- * Replacer function for JSON,stringify - recursively changes values explictly set
- * to `undefined` with `null` values.
- *
- * If explicit 'undefined' values are excluded from the data, it is impossible for
- * the client to "unset" a previously set value on the server by making it "undefined".
- *
- * see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
- *
- * Since `undefined` is not value JSON and gets ommitted from the string.
- * Server-side, the `null`s can be replaced back to `undefined`.
- */
-const replaceUndefinedWithNull = (key: string, value: unknown): unknown => {
-	if (value === undefined) {
-		return null;
-	}
-	return value;
-};
 
 export const makeWizardStepRequest = async (
 	body: CurrentStepRouteRequest,

--- a/apps/newsletters-ui/src/app/api-requests/request-newsletter-edit.ts
+++ b/apps/newsletters-ui/src/app/api-requests/request-newsletter-edit.ts
@@ -2,6 +2,7 @@ import type {
 	ApiResponse,
 	NewsletterData,
 } from '@newsletters-nx/newsletters-data-client';
+import { replaceUndefinedWithNull } from '@newsletters-nx/newsletters-data-client';
 
 export const requestNewsletterEdit = async (
 	listId: number,
@@ -12,7 +13,7 @@ export const requestNewsletterEdit = async (
 		headers: {
 			'Content-Type': 'application/json',
 		},
-		body: JSON.stringify(modification),
+		body: JSON.stringify(modification, replaceUndefinedWithNull),
 	});
 
 	const responseBody = (await response.json()) as ApiResponse<NewsletterData>;

--- a/apps/newsletters-ui/src/app/components/HomeMenu.tsx
+++ b/apps/newsletters-ui/src/app/components/HomeMenu.tsx
@@ -96,6 +96,28 @@ export function HomeMenu() {
 						/>
 					</Grid>
 				)}
+
+				{permissions?.editNewsletters && (
+					<Grid item xs={6} sm={4} display={'flex'}>
+						<ScrollingMenuButton
+							buttonText="set rendering options"
+							buttonProps={{
+								variant: 'outlined',
+								fullWidth: true,
+								size: 'large',
+							}}
+							ariaMenuId="rendering-options-menu"
+							ariaButtonLabel="select newsletter to set rendering options for"
+							options={list.map((newsletter) => ({
+								name: newsletter.name,
+								id: newsletter.identityName,
+							}))}
+							handleSelect={(identityName) => {
+								navigate(`/newsletters/rendering-options/${identityName}`);
+							}}
+						/>
+					</Grid>
+				)}
 			</Grid>
 		</Container>
 	);

--- a/apps/newsletters-ui/src/app/components/RenderingOptionsForm.tsx
+++ b/apps/newsletters-ui/src/app/components/RenderingOptionsForm.tsx
@@ -24,9 +24,8 @@ export const RenderingOptionsForm = ({ originalItem }: Props) => {
 	>(
 		originalItem.renderingOptions ?? getEmptySchemaData(renderingOptionsSchema),
 	);
-	const [renderingOptionsFromServer, setRenderingOptionsFromServer] = useState<
-		RenderingOptions | undefined
-	>(originalItem.renderingOptions);
+
+	const [item, setItem] = useState<NewsletterData>(originalItem);
 
 	const [waitingForResponse, setWaitingForResponse] = useState<boolean>(false);
 	const [errorMessage, setErrorMessage] = useState<string | undefined>();
@@ -35,7 +34,7 @@ export const RenderingOptionsForm = ({ originalItem }: Props) => {
 	>();
 
 	const resetValue =
-		renderingOptionsFromServer ?? getEmptySchemaData(renderingOptionsSchema);
+		item.renderingOptions ?? getEmptySchemaData(renderingOptionsSchema);
 
 	const noChangesMade = useMemo(() => {
 		return JSON.stringify(resetValue) === JSON.stringify(renderingOptions);
@@ -72,7 +71,7 @@ export const RenderingOptionsForm = ({ originalItem }: Props) => {
 
 		if (response.ok) {
 			setRenderingOptions(response.data.renderingOptions);
-			setRenderingOptionsFromServer(response.data.renderingOptions);
+			setItem(response.data);
 			setWaitingForResponse(false);
 			setConfirmationMessage('rendering options updated!');
 		} else {
@@ -83,7 +82,7 @@ export const RenderingOptionsForm = ({ originalItem }: Props) => {
 
 	const reset = () => {
 		setRenderingOptions(
-			renderingOptionsFromServer ?? getEmptySchemaData(renderingOptionsSchema),
+			item.renderingOptions ?? getEmptySchemaData(renderingOptionsSchema),
 		);
 	};
 
@@ -93,8 +92,9 @@ export const RenderingOptionsForm = ({ originalItem }: Props) => {
 				Rendering Options: {originalItem.name}
 			</Typography>
 
+			<Typography>Category: {item.category}</Typography>
 			<Typography>
-				Options set on server: {renderYesNo(!!renderingOptionsFromServer)}
+				Rendering Options defined: {renderYesNo(!!item.renderingOptions)}
 			</Typography>
 
 			{renderingOptions && (

--- a/apps/newsletters-ui/src/app/components/RenderingOptionsForm.tsx
+++ b/apps/newsletters-ui/src/app/components/RenderingOptionsForm.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react';
 import type {
 	FormDataRecord,
 	NewsletterData,
+	RenderingOptions,
 } from '@newsletters-nx/newsletters-data-client';
 import {
 	getEmptySchemaData,
@@ -23,7 +24,6 @@ export const RenderingOptionsForm = ({ originalItem }: Props) => {
 	>(
 		originalItem.renderingOptions ?? getEmptySchemaData(renderingOptionsSchema),
 	);
-
 	const [item, setItem] = useState<NewsletterData>(originalItem);
 	const [subset, setSubset] = useState<FormDataRecord>({
 		category: item.category,
@@ -40,8 +40,10 @@ export const RenderingOptionsForm = ({ originalItem }: Props) => {
 		item.renderingOptions ?? getEmptySchemaData(renderingOptionsSchema);
 
 	const noChangesMade = useMemo(() => {
-		const renderingOptionsMatch =
-			JSON.stringify(resetValue) === JSON.stringify(renderingOptions);
+		const renderingOptionsMatch = Object.keys(resetValue ?? {}).every(
+			(key) =>
+				resetValue?.[key as keyof RenderingOptions] === renderingOptions?.[key],
+		);
 
 		return (
 			renderingOptionsMatch &&

--- a/apps/newsletters-ui/src/app/components/RenderingOptionsForm.tsx
+++ b/apps/newsletters-ui/src/app/components/RenderingOptionsForm.tsx
@@ -1,7 +1,10 @@
-import { Alert, Snackbar } from '@mui/material';
+import { Alert, Snackbar, Typography } from '@mui/material';
 import { useState } from 'react';
-import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
-import { newsletterDataSchema } from '@newsletters-nx/newsletters-data-client';
+import type {
+	NewsletterData,
+	RenderingOptions,
+} from '@newsletters-nx/newsletters-data-client';
+import { renderingOptionsSchema } from '@newsletters-nx/newsletters-data-client';
 import { requestNewsletterEdit } from '../api-requests/request-newsletter-edit';
 import { SimpleForm } from './SimpleForm';
 
@@ -17,16 +20,15 @@ export const RenderingOptionsForm = ({ originalItem }: Props) => {
 		string | undefined
 	>();
 
-	const requestUpdate = async (modification: Partial<NewsletterData>) => {
+	const requestUpdate = async (modification: RenderingOptions) => {
 		if (waitingForResponse) {
 			return;
 		}
 		setWaitingForResponse(true);
 
-		const response = await requestNewsletterEdit(
-			originalItem.listId,
-			modification,
-		).catch((error: unknown) => {
+		const response = await requestNewsletterEdit(originalItem.listId, {
+			renderingOptions: modification,
+		}).catch((error: unknown) => {
 			setErrorMessage('Failed to submit form.');
 			setWaitingForResponse(false);
 			console.log(error);
@@ -41,38 +43,37 @@ export const RenderingOptionsForm = ({ originalItem }: Props) => {
 		if (response.ok) {
 			setItem(response.data);
 			setWaitingForResponse(false);
-			setConfirmationMessage('newsletter updated!');
+			setConfirmationMessage('rendering options updated!');
 		} else {
 			setWaitingForResponse(false);
 			setErrorMessage(response.message);
 		}
 	};
 
+	const { renderingOptions } = item;
+
 	return (
 		<>
-			<SimpleForm
-				title={`${originalItem.identityName} Rendering Options`}
-				initialData={item}
-				submit={requestUpdate}
-				schema={newsletterDataSchema.pick({
-					name: true,
-					signUpDescription: true,
-					frequency: true,
-					regionFocus: true,
-					theme: true,
-					status: true,
-				})}
-				submitButtonText="Update Newsletter"
-				isDisabled={waitingForResponse}
-				maxOptionsForRadioButtons={5}
-				message={
-					waitingForResponse ? (
-						<Alert severity="info">
-							making your updates to {item.identityName}
-						</Alert>
-					) : undefined
-				}
-			/>
+			{!renderingOptions && <Typography>No options set</Typography>}
+
+			{renderingOptions && (
+				<SimpleForm
+					title={`${originalItem.identityName} Rendering Options`}
+					initialData={renderingOptions}
+					submit={requestUpdate}
+					schema={renderingOptionsSchema}
+					submitButtonText="Update Rendering Options"
+					isDisabled={waitingForResponse}
+					maxOptionsForRadioButtons={5}
+					message={
+						waitingForResponse ? (
+							<Alert severity="info">
+								making your updates to {item.identityName}
+							</Alert>
+						) : undefined
+					}
+				/>
+			)}
 
 			<Snackbar
 				sx={{ position: 'static' }}

--- a/apps/newsletters-ui/src/app/components/RenderingOptionsForm.tsx
+++ b/apps/newsletters-ui/src/app/components/RenderingOptionsForm.tsx
@@ -120,70 +120,71 @@ export const RenderingOptionsForm = ({ originalItem }: Props) => {
 				Rendering Options: {originalItem.name}
 			</Typography>
 
+			<Typography variant="h3">Category and series tag</Typography>
+			<StateEditForm
+				formSchema={newsletterDataSchema.pick({
+					category: true,
+					seriesTag: true,
+				})}
+				formData={subset}
+				setFormData={setSubset}
+			/>
+
 			{renderingOptions && (
 				<>
-					<Typography variant="h3">Category and series tag</Typography>
-					<StateEditForm
-						formSchema={newsletterDataSchema.pick({
-							category: true,
-							seriesTag: true,
-						})}
-						formData={subset}
-						setFormData={setSubset}
-					/>
-
 					<Typography variant="h3">Rendering options</Typography>
 					<StateEditForm
 						formSchema={renderingOptionsSchema}
 						formData={renderingOptions}
 						setFormData={setRenderingOptions}
 					/>
-					<Stack maxWidth={'md'} direction={'row'} spacing={2} marginBottom={2}>
-						<Button
-							variant="outlined"
-							size="large"
-							onClick={reset}
-							disabled={waitingForResponse || noChangesMade}
-						>
-							reset
-						</Button>
-						<Button
-							variant="contained"
-							size="large"
-							onClick={handleSubmit}
-							disabled={waitingForResponse}
-						>
-							submit
-						</Button>
-						<Snackbar
-							sx={{ position: 'static' }}
-							open={!!errorMessage}
-							onClose={() => {
-								setErrorMessage(undefined);
-							}}
-						>
-							<Alert
-								onClose={() => {
-									setErrorMessage(undefined);
-								}}
-								severity="error"
-							>
-								{errorMessage}
-							</Alert>
-						</Snackbar>
-
-						<Snackbar
-							sx={{ position: 'static' }}
-							open={!!confirmationMessage}
-							onClose={() => {
-								setConfirmationMessage(undefined);
-							}}
-						>
-							<Alert severity="info">{confirmationMessage}</Alert>
-						</Snackbar>
-					</Stack>
 				</>
 			)}
+
+			<Stack maxWidth={'md'} direction={'row'} spacing={2} marginBottom={2}>
+				<Button
+					variant="outlined"
+					size="large"
+					onClick={reset}
+					disabled={waitingForResponse || noChangesMade}
+				>
+					reset
+				</Button>
+				<Button
+					variant="contained"
+					size="large"
+					onClick={handleSubmit}
+					disabled={waitingForResponse}
+				>
+					submit
+				</Button>
+				<Snackbar
+					sx={{ position: 'static' }}
+					open={!!errorMessage}
+					onClose={() => {
+						setErrorMessage(undefined);
+					}}
+				>
+					<Alert
+						onClose={() => {
+							setErrorMessage(undefined);
+						}}
+						severity="error"
+					>
+						{errorMessage}
+					</Alert>
+				</Snackbar>
+
+				<Snackbar
+					sx={{ position: 'static' }}
+					open={!!confirmationMessage}
+					onClose={() => {
+						setConfirmationMessage(undefined);
+					}}
+				>
+					<Alert severity="info">{confirmationMessage}</Alert>
+				</Snackbar>
+			</Stack>
 		</>
 	);
 };

--- a/apps/newsletters-ui/src/app/components/RenderingOptionsForm.tsx
+++ b/apps/newsletters-ui/src/app/components/RenderingOptionsForm.tsx
@@ -1,6 +1,6 @@
 import { Alert, Button, Snackbar, Typography } from '@mui/material';
 import { Stack } from '@mui/system';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import type {
 	FormDataRecord,
 	NewsletterData,
@@ -33,6 +33,13 @@ export const RenderingOptionsForm = ({ originalItem }: Props) => {
 	const [confirmationMessage, setConfirmationMessage] = useState<
 		string | undefined
 	>();
+
+	const resetValue =
+		renderingOptionsFromServer ?? getEmptySchemaData(renderingOptionsSchema);
+
+	const noChangesMade = useMemo(() => {
+		return JSON.stringify(resetValue) === JSON.stringify(renderingOptions);
+	}, [renderingOptions, resetValue]);
 
 	const handleSubmit = () => {
 		if (waitingForResponse) {
@@ -102,7 +109,7 @@ export const RenderingOptionsForm = ({ originalItem }: Props) => {
 							variant="outlined"
 							size="large"
 							onClick={reset}
-							disabled={waitingForResponse}
+							disabled={waitingForResponse || noChangesMade}
 						>
 							reset
 						</Button>

--- a/apps/newsletters-ui/src/app/components/RenderingOptionsForm.tsx
+++ b/apps/newsletters-ui/src/app/components/RenderingOptionsForm.tsx
@@ -1,8 +1,10 @@
 import { Alert, Box, Button, Snackbar, Typography } from '@mui/material';
+import { Stack } from '@mui/system';
 import { useState } from 'react';
 import type {
 	FormDataRecord,
 	NewsletterData,
+	RenderingOptions,
 } from '@newsletters-nx/newsletters-data-client';
 import { renderingOptionsSchema } from '@newsletters-nx/newsletters-data-client';
 import { requestNewsletterEdit } from '../api-requests/request-newsletter-edit';
@@ -15,6 +17,9 @@ interface Props {
 export const RenderingOptionsForm = ({ originalItem }: Props) => {
 	const [renderingOptions, setRenderingOptions] = useState<
 		FormDataRecord | undefined
+	>(originalItem.renderingOptions);
+	const [renderingOptionsFromServer, setRenderingOptionsFromServer] = useState<
+		RenderingOptions | undefined
 	>(originalItem.renderingOptions);
 
 	const [waitingForResponse, setWaitingForResponse] = useState<boolean>(false);
@@ -54,6 +59,7 @@ export const RenderingOptionsForm = ({ originalItem }: Props) => {
 
 		if (response.ok) {
 			setRenderingOptions(response.data.renderingOptions);
+			setRenderingOptionsFromServer(response.data.renderingOptions);
 			setWaitingForResponse(false);
 			setConfirmationMessage('rendering options updated!');
 		} else {
@@ -62,55 +68,57 @@ export const RenderingOptionsForm = ({ originalItem }: Props) => {
 		}
 	};
 
+	const reset = () => {
+		setRenderingOptions(renderingOptionsFromServer);
+	};
+
 	return (
 		<>
 			{!renderingOptions && <Typography>No options set</Typography>}
 
 			{renderingOptions && (
-				<StateEditForm
-					formSchema={renderingOptionsSchema}
-					formData={renderingOptions}
-					setFormData={setRenderingOptions}
-				/>
+				<>
+					<StateEditForm
+						formSchema={renderingOptionsSchema}
+						formData={renderingOptions}
+						setFormData={setRenderingOptions}
+					/>
+					<Stack maxWidth={'md'} direction={'row'} spacing={2} marginBottom={2}>
+						<Button variant="outlined" size="large" onClick={reset}>
+							reset
+						</Button>
+						<Button variant="contained" size="large" onClick={requestUpdate}>
+							submit
+						</Button>
+						<Snackbar
+							sx={{ position: 'static' }}
+							open={!!errorMessage}
+							onClose={() => {
+								setErrorMessage(undefined);
+							}}
+						>
+							<Alert
+								onClose={() => {
+									setErrorMessage(undefined);
+								}}
+								severity="error"
+							>
+								{errorMessage}
+							</Alert>
+						</Snackbar>
+
+						<Snackbar
+							sx={{ position: 'static' }}
+							open={!!confirmationMessage}
+							onClose={() => {
+								setConfirmationMessage(undefined);
+							}}
+						>
+							<Alert severity="info">{confirmationMessage}</Alert>
+						</Snackbar>
+					</Stack>
+				</>
 			)}
-
-			<Box maxWidth={'md'}>
-				<Button
-					variant="contained"
-					size="large"
-					fullWidth
-					onClick={requestUpdate}
-				>
-					submit
-				</Button>
-			</Box>
-
-			<Snackbar
-				sx={{ position: 'static' }}
-				open={!!errorMessage}
-				onClose={() => {
-					setErrorMessage(undefined);
-				}}
-			>
-				<Alert
-					onClose={() => {
-						setErrorMessage(undefined);
-					}}
-					severity="error"
-				>
-					{errorMessage}
-				</Alert>
-			</Snackbar>
-
-			<Snackbar
-				sx={{ position: 'static' }}
-				open={!!confirmationMessage}
-				onClose={() => {
-					setConfirmationMessage(undefined);
-				}}
-			>
-				<Alert severity="info">{confirmationMessage}</Alert>
-			</Snackbar>
 		</>
 	);
 };

--- a/apps/newsletters-ui/src/app/components/RenderingOptionsForm.tsx
+++ b/apps/newsletters-ui/src/app/components/RenderingOptionsForm.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Snackbar, Typography } from '@mui/material';
+import { Alert, AlertTitle, Button, Snackbar, Typography } from '@mui/material';
 import { Stack } from '@mui/system';
 import { useMemo, useState } from 'react';
 import type {
@@ -95,8 +95,8 @@ export const RenderingOptionsForm = ({ originalItem }: Props) => {
 			setItem(response.data);
 			setRenderingOptions(response.data.renderingOptions);
 			setSubset({
-				category: item.category,
-				seriesTag: item.seriesTag,
+				category: response.data.category,
+				seriesTag: response.data.seriesTag,
 			});
 			setWaitingForResponse(false);
 			setConfirmationMessage('rendering options updated!');
@@ -118,9 +118,8 @@ export const RenderingOptionsForm = ({ originalItem }: Props) => {
 
 	return (
 		<>
-			<Typography variant="h2">
-				Rendering Options: {originalItem.name}
-			</Typography>
+			<Typography variant="h2">{item.name}</Typography>
+			<Typography variant="subtitle1">email-rendering settings</Typography>
 
 			<Typography variant="h3">Category and series tag</Typography>
 			<StateEditForm
@@ -131,6 +130,19 @@ export const RenderingOptionsForm = ({ originalItem }: Props) => {
 				formData={subset}
 				setFormData={setSubset}
 			/>
+
+			<Alert severity={item.seriesTag ? 'info' : 'warning'}>
+				<AlertTitle>Series Tags</AlertTitle>
+				<Typography>
+					The email-rendering service will the rendering options below when
+					asked to render an article that has the specified series tag.{' '}
+				</Typography>
+				<Typography>
+					If no valid series tag is specified, email-rendering service cannot
+					tell that an article belongs to the series for this newsletter an will
+					use the generic template.
+				</Typography>
+			</Alert>
 
 			{renderingOptions && (
 				<>

--- a/apps/newsletters-ui/src/app/components/SchemaForm/SchemaRecordArrayInput.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/SchemaRecordArrayInput.tsx
@@ -96,8 +96,8 @@ export const SchemaRecordArrayInput: FunctionComponent<
 									display: 'flex',
 									alignItems: 'center',
 									marginBottom: '22px',
+									flexDirection: 'row',
 								}}
-								direction={'row'}
 							>
 								<Button
 									size="small"

--- a/apps/newsletters-ui/src/app/components/views/RenderingOptionsView.tsx
+++ b/apps/newsletters-ui/src/app/components/views/RenderingOptionsView.tsx
@@ -1,0 +1,28 @@
+import { Box } from '@mui/material';
+import { useLoaderData } from 'react-router-dom';
+import { isNewsletterData } from '@newsletters-nx/newsletters-data-client';
+import { ContentWrapper } from '../../ContentWrapper';
+import { NavigateButton } from '../NavigateButton';
+import { RenderingOptionsForm } from '../RenderingOptionsForm';
+
+export const RenderingOptionsView = () => {
+	const matchedItem = useLoaderData();
+	if (!matchedItem) {
+		return <article>NOT FOUND!</article>;
+	}
+
+	if (!isNewsletterData(matchedItem)) {
+		return <article>NOT VALID DATA!</article>;
+	}
+
+	return (
+		<ContentWrapper>
+			<Box marginBottom={2}>
+				<NavigateButton href="../" variant="outlined">
+					Back to List
+				</NavigateButton>
+			</Box>
+			<RenderingOptionsForm originalItem={matchedItem} />
+		</ContentWrapper>
+	);
+};

--- a/apps/newsletters-ui/src/app/routes/newsletters.tsx
+++ b/apps/newsletters-ui/src/app/routes/newsletters.tsx
@@ -3,6 +3,7 @@ import { NewsletterDetailView } from '../components/views/NewsletterDetailView';
 import { NewsletterEditView } from '../components/views/NewsletterEditView';
 import { NewsletterJsonEditView } from '../components/views/NewsletterJsonEditView';
 import { NewslettersListView } from '../components/views/NewslettersListView';
+import { RenderingOptionsView } from '../components/views/RenderingOptionsView';
 import { WizardContainer } from '../components/WizardContainer';
 import { ErrorPage } from '../ErrorPage';
 import { Layout } from '../Layout';
@@ -26,6 +27,11 @@ export const newslettersRoute: RouteObject = {
 		{
 			path: 'edit/:id',
 			element: <NewsletterEditView />,
+			loader: detailLoader,
+		},
+		{
+			path: 'rendering-options/:id',
+			element: <RenderingOptionsView />,
 			loader: detailLoader,
 		},
 		{

--- a/libs/newsletters-data-client/src/index.ts
+++ b/libs/newsletters-data-client/src/index.ts
@@ -16,3 +16,4 @@ export * from './lib/transformWizardData';
 export * from './lib/user-profile';
 export * from './lib/wizard-button-type';
 export * from './lib/zod-helpers';
+export * from './lib/json-undefined-null-conversions';

--- a/libs/newsletters-data-client/src/lib/json-undefined-null-conversions.spec.ts
+++ b/libs/newsletters-data-client/src/lib/json-undefined-null-conversions.spec.ts
@@ -1,4 +1,7 @@
-import { replaceNullWithUndefined } from './json-undefined-null-conversions';
+import {
+	replaceNullWithUndefinedForUnknown,
+	replaceNullWithUndefinedInFormDataRecord,
+} from './json-undefined-null-conversions';
 import type { FormDataRecord } from './transformWizardData';
 
 const SIMPLE_IN: FormDataRecord = {
@@ -55,17 +58,73 @@ const OBJECT_ARRAY_OUT: FormDataRecord = {
 	],
 };
 
-describe('replaceNullWithUndefined', () => {
+describe('replaceNullWithUndefinedInFormDataRecord', () => {
 	it('will handle simple cases', () => {
-		const result = replaceNullWithUndefined({ ...SIMPLE_IN });
+		const result = replaceNullWithUndefinedInFormDataRecord({ ...SIMPLE_IN });
 		expect(result).toEqual(SIMPLE_OUT);
 	});
 	it('will handle nulls in nested objects', () => {
-		const result = replaceNullWithUndefined({ ...OBJECT_IN });
+		const result = replaceNullWithUndefinedInFormDataRecord({ ...OBJECT_IN });
 		expect(result).toEqual(OBJECT_OUT);
 	});
 	it('will handle nulls in arrays of object', () => {
-		const result = replaceNullWithUndefined({ ...OBJECT_ARRAY_IN });
+		const result = replaceNullWithUndefinedInFormDataRecord({
+			...OBJECT_ARRAY_IN,
+		});
 		expect(result).toEqual(OBJECT_ARRAY_OUT);
+	});
+});
+
+describe('replaceNullWithUndefinedForUnknown', () => {
+	it('will handle simple cases', () => {
+		const result = replaceNullWithUndefinedForUnknown({ ...SIMPLE_IN });
+		expect(result).toEqual(SIMPLE_OUT);
+	});
+	it('will handle nulls in nested objects', () => {
+		const result = replaceNullWithUndefinedForUnknown({ ...OBJECT_IN });
+		expect(result).toEqual(OBJECT_OUT);
+	});
+	it('will handle nulls in arrays of object', () => {
+		const result = replaceNullWithUndefinedForUnknown({
+			...OBJECT_ARRAY_IN,
+		});
+		expect(result).toEqual(OBJECT_ARRAY_OUT);
+	});
+
+	it('will convert null primitives to undefined', () => {
+		const result = replaceNullWithUndefinedForUnknown(null);
+		expect(result).toEqual(undefined);
+	});
+	it('will convert null primitives to in an array to undefined', () => {
+		const result = replaceNullWithUndefinedForUnknown([
+			1,
+			null,
+			'this is a string',
+		]);
+		expect(result).toEqual([1, undefined, 'this is a string']);
+	});
+	it('will convert null deeply nested nulls to in an object to undefined', () => {
+		const result = replaceNullWithUndefinedForUnknown({
+			a: {
+				value: null,
+				b: {
+					value: 'test',
+					c: {
+						value: null,
+					},
+				},
+			},
+		});
+		expect(result).toEqual({
+			a: {
+				value: undefined,
+				b: {
+					value: 'test',
+					c: {
+						value: undefined,
+					},
+				},
+			},
+		});
 	});
 });

--- a/libs/newsletters-data-client/src/lib/json-undefined-null-conversions.spec.ts
+++ b/libs/newsletters-data-client/src/lib/json-undefined-null-conversions.spec.ts
@@ -1,30 +1,30 @@
-import type { WizardFormData } from './types';
-import { replaceNullWithUndefined } from './utility';
+import { replaceNullWithUndefined } from './json-undefined-null-conversions';
+import type { FormDataRecord } from './transformWizardData';
 
-const SIMPLE_IN: WizardFormData = {
+const SIMPLE_IN: FormDataRecord = {
 	name: 'Bill',
 	petsName: null,
 };
-const SIMPLE_OUT: WizardFormData = {
+const SIMPLE_OUT: FormDataRecord = {
 	name: 'Bill',
 	petsName: undefined,
 };
 
-const OBJECT_IN: WizardFormData = {
+const OBJECT_IN: FormDataRecord = {
 	name: 'Bill',
 	pet: {
 		name: 'Marvin the fish',
 		collarSize: null as unknown as undefined,
 	},
 };
-const OBJECT_OUT: WizardFormData = {
+const OBJECT_OUT: FormDataRecord = {
 	name: 'Bill',
 	pet: {
 		name: 'Marvin the fish',
 		collarSize: undefined,
 	},
 };
-const OBJECT_ARRAY_IN: WizardFormData = {
+const OBJECT_ARRAY_IN: FormDataRecord = {
 	name: 'Bill',
 	children: [
 		{
@@ -39,7 +39,7 @@ const OBJECT_ARRAY_IN: WizardFormData = {
 		},
 	],
 };
-const OBJECT_ARRAY_OUT: WizardFormData = {
+const OBJECT_ARRAY_OUT: FormDataRecord = {
 	name: 'Bill',
 	children: [
 		{

--- a/libs/newsletters-data-client/src/lib/json-undefined-null-conversions.ts
+++ b/libs/newsletters-data-client/src/lib/json-undefined-null-conversions.ts
@@ -87,16 +87,6 @@ export const replaceNullWithUndefinedInFormDataRecord = (
 	return formData;
 };
 
-/** replace any value of `null` in a string record with `undefined` */
-const replaceNullWithUndefinedForRecord = (
-	record: Record<string, unknown>,
-): Record<string, unknown> => {
-	Object.keys(record).forEach((key) => {
-		record[key] = replaceNullWithUndefinedForUnknown(record[key]);
-	});
-	return record;
-};
-
 /** Recursively replace any null propery with `undefined` */
 export const replaceNullWithUndefinedForUnknown = (value: unknown): unknown => {
 	if (value === null) {
@@ -108,7 +98,10 @@ export const replaceNullWithUndefinedForUnknown = (value: unknown): unknown => {
 	}
 
 	if (isStringRecord(value)) {
-		return replaceNullWithUndefinedForRecord(value);
+		Object.keys(value).forEach((key) => {
+			value[key] = replaceNullWithUndefinedForUnknown(value[key]);
+		});
+		return value;
 	}
 	return value;
 };

--- a/libs/newsletters-data-client/src/lib/json-undefined-null-conversions.ts
+++ b/libs/newsletters-data-client/src/lib/json-undefined-null-conversions.ts
@@ -52,7 +52,7 @@ const isArrayOfPrimitiveRecordsAllowingNull = (
 	return value.every(isPrimitiveRecordAllowingNull);
 };
 
-/** recursively replace any `null` with `undefined` */
+/** replace any value of `null` in a FormDataRecord with `undefined` */
 export const replaceNullWithUndefined = (
 	formData: FormDataRecord,
 ): FormDataRecord => {
@@ -84,4 +84,38 @@ export const replaceNullWithUndefined = (
 		}
 	});
 	return formData;
+};
+
+/** replace any value of `null` in a string record with `undefined` */
+export const replaceNullWithUndefinedForRecord = (
+	record: Record<string, unknown>,
+): Record<string, unknown> => {
+	Object.keys(record).forEach((key) => {
+		const value = record[key];
+
+		if (value === null) {
+			record[key] = undefined;
+		}
+
+		if (isPrimitiveRecordAllowingNull(value)) {
+			Object.keys(value).forEach((nestedkey) => {
+				const nestedValue = value[nestedkey];
+				if ((nestedValue as unknown) === null) {
+					value[nestedkey] = undefined;
+				}
+			});
+		}
+
+		if (isArrayOfPrimitiveRecordsAllowingNull(value)) {
+			value.forEach((objectInArray) => {
+				Object.keys(objectInArray).forEach((keyOfObjectInArray) => {
+					const valueOfObjectInArray = objectInArray[keyOfObjectInArray];
+					if ((valueOfObjectInArray as unknown) === null) {
+						objectInArray[keyOfObjectInArray] = undefined;
+					}
+				});
+			});
+		}
+	});
+	return record;
 };

--- a/libs/newsletters-data-client/src/lib/json-undefined-null-conversions.ts
+++ b/libs/newsletters-data-client/src/lib/json-undefined-null-conversions.ts
@@ -1,0 +1,21 @@
+/**
+ * Replacer function for JSON,stringify - recursively changes values explictly set
+ * to `undefined` with `null` values.
+ *
+ * If explicit 'undefined' values are excluded from the data, it is impossible for
+ * the client to "unset" a previously set value on the server by making it "undefined".
+ *
+ * see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
+ *
+ * Since `undefined` is not value JSON and gets ommitted from the string.
+ * Server-side, the `null`s can be replaced back to `undefined`.
+ */
+export const replaceUndefinedWithNull = (
+	key: string,
+	value: unknown,
+): unknown => {
+	if (value === undefined) {
+		return null;
+	}
+	return value;
+};

--- a/libs/newsletters-data-client/src/lib/zod-helpers/index.ts
+++ b/libs/newsletters-data-client/src/lib/zod-helpers/index.ts
@@ -3,3 +3,4 @@ export * from './recursiveUnwrap';
 export * from './schema-helpers';
 export * from './validation';
 export * from './getFieldKeyNames';
+export * from './isRecord';

--- a/libs/newsletters-data-client/src/lib/zod-helpers/isRecord.ts
+++ b/libs/newsletters-data-client/src/lib/zod-helpers/isRecord.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+
+const stringRecordSchema = z.record(z.string(), z.any());
+
+export const isStringRecord = (v: unknown): v is Record<string, unknown> =>
+	stringRecordSchema.safeParse(v).success;

--- a/libs/state-machine/src/lib/handleWizardRequest.ts
+++ b/libs/state-machine/src/lib/handleWizardRequest.ts
@@ -1,3 +1,4 @@
+import { replaceNullWithUndefined } from '@newsletters-nx/newsletters-data-client';
 import { makeResponse } from './makeResponse';
 import { setupInitialState } from './setupInitialState';
 import { stateMachineButtonPressed } from './stateMachineButtonPressed';
@@ -10,7 +11,6 @@ import type {
 	WizardLayout,
 	WizardStepLayout,
 } from './types';
-import { replaceNullWithUndefined } from './utility';
 
 /**
  * Execute the changes to state (if any) in response to a

--- a/libs/state-machine/src/lib/handleWizardRequest.ts
+++ b/libs/state-machine/src/lib/handleWizardRequest.ts
@@ -1,4 +1,4 @@
-import { replaceNullWithUndefined } from '@newsletters-nx/newsletters-data-client';
+import { replaceNullWithUndefinedInFormDataRecord } from '@newsletters-nx/newsletters-data-client';
 import { makeResponse } from './makeResponse';
 import { setupInitialState } from './setupInitialState';
 import { stateMachineButtonPressed } from './stateMachineButtonPressed';
@@ -35,7 +35,7 @@ export async function handleWizardRequestAndReturnWizardResponse<
 ): Promise<CurrentStepRouteResponse> {
 	try {
 		if (requestBody.formData) {
-			replaceNullWithUndefined(requestBody.formData);
+			replaceNullWithUndefinedInFormDataRecord(requestBody.formData);
 		}
 
 		const stepData =

--- a/libs/state-machine/src/lib/utility.ts
+++ b/libs/state-machine/src/lib/utility.ts
@@ -1,41 +1,6 @@
 import type { FormDataRecord } from '@newsletters-nx/newsletters-data-client';
 import type { ZodIssue } from 'zod';
-import type {
-	FailureDetails,
-	WizardFormData,
-	WizardStepData,
-	WizardStepLayout,
-} from './types';
-
-type PrimitiveRecordWithNull = Partial<
-	Record<string, string | number | boolean | null>
->;
-const isPrimitiveRecordAllowingNull = (
-	value: unknown,
-): value is PrimitiveRecordWithNull => {
-	if (!value || typeof value !== 'object') {
-		return false;
-	}
-	if (Array.isArray(value)) {
-		return false;
-	}
-	return Object.values(value).every(
-		(propertyValue) =>
-			typeof propertyValue === 'boolean' ||
-			typeof propertyValue === 'number' ||
-			typeof propertyValue === 'string' ||
-			(typeof propertyValue === 'object' && !propertyValue),
-	);
-};
-
-const isArrayOfPrimitiveRecordsAllowingNull = (
-	value: unknown,
-): value is PrimitiveRecordWithNull[] => {
-	if (!Array.isArray(value)) {
-		return false;
-	}
-	return value.every(isPrimitiveRecordAllowingNull);
-};
+import type { FailureDetails, WizardStepData, WizardStepLayout } from './types';
 
 export const makeStepDataWithErrorMessage = (
 	errorMessage: string,
@@ -76,38 +41,4 @@ export const validateIncomingFormData = (
 	}
 
 	return undefined;
-};
-
-/** recursively replace any `null` with `undefined` */
-export const replaceNullWithUndefined = (
-	formData: WizardFormData,
-): WizardFormData => {
-	Object.keys(formData).forEach((key) => {
-		const value = formData[key];
-
-		if (value === null) {
-			formData[key] = undefined;
-		}
-
-		if (isPrimitiveRecordAllowingNull(value)) {
-			Object.keys(value).forEach((nestedkey) => {
-				const nestedValue = value[nestedkey];
-				if ((nestedValue as unknown) === null) {
-					value[nestedkey] = undefined;
-				}
-			});
-		}
-
-		if (isArrayOfPrimitiveRecordsAllowingNull(value)) {
-			value.forEach((objectInArray) => {
-				Object.keys(objectInArray).forEach((keyOfObjectInArray) => {
-					const valueOfObjectInArray = objectInArray[keyOfObjectInArray];
-					if ((valueOfObjectInArray as unknown) === null) {
-						objectInArray[keyOfObjectInArray] = undefined;
-					}
-				});
-			});
-		}
-	});
-	return formData;
 };


### PR DESCRIPTION

## What does this change?

 - add a page for setting or editing the `renderingOptions`, and the `SeriesTag` and `Category` on a launched newsletter.
 - adapts the undefined -> null -> undefined mechanism used by the state machine to allow defined values on a newsletters to be changed to `undefined` with a json post to the API (`undefined` is not valid data, so key-value pairs with a value of `undefined` are omitted by JSON.stringify)


## How to test

The form pages  can be access from the "set rendering options" button on the homepage.

Setting series tag to an empty string and submitting will 'unset' the value on the server to undefined.

## How can we measure success?
Launched newsletters can be "relaunched" article-based by adding the rendering options.
Editorial could use the form to adjust the options for an existing newsletter design.

## Have we considered potential risks?

Maybe we should 'hide' this page until email rendering is using the API to render emails?

## Images

<img width="801" alt="Screenshot 2023-07-05 at 15 37 46" src="https://github.com/guardian/newsletters-nx/assets/30567854/c5eb040a-f46a-40f1-a241-12b2f1941334">

