### PR TITLE
Dblatcher text areas in forms

### DIFF
--- a/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
+++ b/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
@@ -74,7 +74,7 @@ export const EditNewsletterForm = ({ originalItem }: Props) => {
 				}
 				stringConfig={{
 					signUpDescription: {
-						type: 'textArea',
+						inputType: 'textArea',
 					},
 				}}
 			/>

--- a/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
+++ b/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
@@ -72,6 +72,11 @@ export const EditNewsletterForm = ({ originalItem }: Props) => {
 						</Alert>
 					) : undefined
 				}
+				stringConfig={{
+					signUpDescription: {
+						type: 'textArea',
+					},
+				}}
 			/>
 
 			<Snackbar

--- a/apps/newsletters-ui/src/app/components/SchemaForm/FieldWrapper.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/FieldWrapper.tsx
@@ -10,7 +10,7 @@ export const defaultBoxProps: BoxProps = {
 	display: 'flex',
 	justifyContent: 'space-between',
 	marginBottom: 3,
-	maxWidth: 400,
+	maxWidth: 'sm',
 };
 
 export const FieldWrapper = ({ children }: Props) => (

--- a/apps/newsletters-ui/src/app/components/SchemaForm/SchemaField.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/SchemaField.tsx
@@ -85,7 +85,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 						<DateInput
 							{...standardProps}
 							value={value}
-							type={stringInputSettings.type}
+							type={stringInputSettings.inputType}
 						/>
 					</FieldWrapper>
 				);
@@ -100,7 +100,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 							<DateInput
 								{...standardProps}
 								value={date}
-								type={stringInputSettings.type}
+								type={stringInputSettings.inputType}
 							/>
 						</FieldWrapper>
 					);
@@ -114,7 +114,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 						<DateInput
 							{...standardProps}
 							value={value}
-							type={stringInputSettings.type}
+							type={stringInputSettings.inputType}
 						/>
 					</FieldWrapper>
 				);
@@ -150,7 +150,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 					<StringInput
 						{...standardProps}
 						value={value ?? ''}
-						type={stringInputSettings.type}
+						inputType={stringInputSettings.inputType}
 					/>
 				</FieldWrapper>
 			);

--- a/apps/newsletters-ui/src/app/components/SchemaForm/SchemaField.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/SchemaField.tsx
@@ -18,7 +18,12 @@ import { SchemaRecordArrayInput } from './SchemaRecordArrayInput';
 import { SchemaRecordInput } from './SchemaRecordInput';
 import { SelectInput } from './SelectInput';
 import { StringInput } from './StringInput';
-import type { FieldDef, FieldValue, NumberInputSettings } from './util';
+import type {
+	FieldDef,
+	FieldValue,
+	NumberInputSettings,
+	StringInputSettings,
+} from './util';
 import { fieldValueAsDisplayString } from './util';
 
 // T is the shape of the schema passed as a prop to the `SchemaForm`
@@ -28,9 +33,9 @@ interface SchemaFieldProps<T extends z.ZodRawShape> {
 	field: FieldDef;
 	change: { (value: FieldValue, field: FieldDef): void };
 	options?: string[];
-	stringInputType?: string;
 	showUnsupported?: boolean;
 	numberInputSettings?: NumberInputSettings;
+	stringInputSettings?: StringInputSettings;
 	validationWarning?: string;
 	maxOptionsForRadioButtons: number;
 }
@@ -46,9 +51,9 @@ export function SchemaField<T extends z.ZodRawShape>({
 	field,
 	change,
 	options,
-	stringInputType,
 	showUnsupported = false,
 	numberInputSettings = {},
+	stringInputSettings = {},
 	validationWarning,
 	maxOptionsForRadioButtons,
 }: SchemaFieldProps<T>) {
@@ -80,7 +85,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 						<DateInput
 							{...standardProps}
 							value={value}
-							type={stringInputType}
+							type={stringInputSettings.type}
 						/>
 					</FieldWrapper>
 				);
@@ -95,7 +100,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 							<DateInput
 								{...standardProps}
 								value={date}
-								type={stringInputType}
+								type={stringInputSettings.type}
 							/>
 						</FieldWrapper>
 					);
@@ -109,7 +114,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 						<DateInput
 							{...standardProps}
 							value={value}
-							type={stringInputType}
+							type={stringInputSettings.type}
 						/>
 					</FieldWrapper>
 				);
@@ -145,7 +150,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 					<StringInput
 						{...standardProps}
 						value={value ?? ''}
-						type={stringInputType}
+						type={stringInputSettings.type}
 					/>
 				</FieldWrapper>
 			);

--- a/apps/newsletters-ui/src/app/components/SchemaForm/StringInput.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/StringInput.tsx
@@ -18,6 +18,7 @@ export const StringInput: FunctionComponent<
 
 	return (
 		<TextField
+			multiline={type === 'textArea'}
 			fullWidth
 			label={props.label}
 			type={type}

--- a/apps/newsletters-ui/src/app/components/SchemaForm/StringInput.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/StringInput.tsx
@@ -7,10 +7,10 @@ export const StringInput: FunctionComponent<
 	FieldProps & {
 		value: string;
 		inputHandler: { (value: string): void };
-		type?: HTMLInputElement['type'];
+		inputType?: 'textInput' | 'textArea';
 	}
 > = (props) => {
-	const { type = 'text' } = props;
+	const { inputType = 'textInput' } = props;
 
 	const sendValue: FormEventHandler<HTMLInputElement> = (event) => {
 		props.inputHandler(eventToString(event));
@@ -18,10 +18,11 @@ export const StringInput: FunctionComponent<
 
 	return (
 		<TextField
-			multiline={type === 'textArea'}
+			multiline={inputType === 'textArea'}
+			minRows={2}
 			fullWidth
 			label={props.label}
-			type={type}
+			type={inputType}
 			value={props.value}
 			onInput={sendValue}
 			helperText={props.error}

--- a/apps/newsletters-ui/src/app/components/SchemaForm/StringInput.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/StringInput.tsx
@@ -1,19 +1,30 @@
 import { TextField } from '@mui/material';
-import type { FormEventHandler, FunctionComponent } from 'react';
+import type { FormEventHandler } from 'react';
 import type { FieldProps } from './util';
 import { eventToString } from './util';
 
-export const StringInput: FunctionComponent<
-	FieldProps & {
-		value: string;
-		inputHandler: { (value: string): void };
-		inputType?: 'textInput' | 'textArea';
-	}
-> = (props) => {
+// TO DO - add allowTabAndCr prop, if we ever need
+// to collect multiline/formatted text.
+
+// Would involve extending the StringInputSettings type
+// and the WizardStepLayout type so it can be configured
+// from the layout and passed down from SchemaForm.
+
+const tabAndCrPattern = /["\n"|"\t"]/g;
+
+type Props = FieldProps & {
+	value: string;
+	inputHandler: { (value: string): void };
+	inputType?: 'textInput' | 'textArea';
+};
+
+export const StringInput = (props: Props) => {
 	const { inputType = 'textInput' } = props;
 
 	const sendValue: FormEventHandler<HTMLInputElement> = (event) => {
-		props.inputHandler(eventToString(event));
+		const inputValue = eventToString(event);
+		const processedValue = inputValue.replace(tabAndCrPattern, '');
+		props.inputHandler(processedValue);
 	};
 
 	return (

--- a/apps/newsletters-ui/src/app/components/SchemaForm/index.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/index.tsx
@@ -3,7 +3,12 @@ import { ZodArray, ZodEnum, ZodObject, ZodString } from 'zod';
 import { recursiveUnwrap } from '@newsletters-nx/newsletters-data-client';
 // eslint-disable-next-line import/no-cycle -- schemaForm renders recursively for SchemaRecordArrayInput
 import { SchemaField } from './SchemaField';
-import type { FieldDef, FieldValue, NumberInputSettings } from './util';
+import type {
+	FieldDef,
+	FieldValue,
+	NumberInputSettings,
+	StringInputSettings,
+} from './util';
 
 export * from './util';
 
@@ -13,6 +18,7 @@ interface Props<T extends z.ZodRawShape> {
 	changeValue: { (value: FieldValue, field: FieldDef): void };
 	options?: Partial<Record<keyof T, string[]>>;
 	numberConfig?: Partial<Record<keyof T, NumberInputSettings>>;
+	stringConfig?: Partial<Record<keyof T, StringInputSettings>>;
 	showUnsupported?: boolean;
 	excludedKeys?: string[];
 	readOnlyKeys?: string[];
@@ -52,6 +58,7 @@ export function SchemaForm<T extends z.ZodRawShape>({
 	changeValue,
 	options = {},
 	numberConfig = {},
+	stringConfig = {},
 	showUnsupported = false,
 	excludedKeys = [],
 	readOnlyKeys = [],
@@ -99,10 +106,10 @@ export function SchemaForm<T extends z.ZodRawShape>({
 					key={field.key}
 					options={options[field.key]}
 					numberInputSettings={numberConfig[field.key]}
+					stringInputSettings={stringConfig[field.key]}
 					change={changeValue}
 					field={field}
 					showUnsupported={showUnsupported}
-					stringInputType={field.key === 'text' ? 'textArea' : undefined}
 					validationWarning={validationWarnings[field.key]}
 					maxOptionsForRadioButtons={maxOptionsForRadioButtons}
 				/>

--- a/apps/newsletters-ui/src/app/components/SchemaForm/util.ts
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/util.ts
@@ -34,6 +34,10 @@ export type NumberInputSettings = {
 	step?: number;
 };
 
+export type StringInputSettings = {
+	type?: 'text' | 'textArea';
+};
+
 export function eventToNumber(event: FormEvent, defaultValue = 0): number {
 	const numericalValue = Number((event.target as HTMLInputElement).value);
 	return isNaN(numericalValue) ? defaultValue : numericalValue;

--- a/apps/newsletters-ui/src/app/components/SchemaForm/util.ts
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/util.ts
@@ -35,7 +35,7 @@ export type NumberInputSettings = {
 };
 
 export type StringInputSettings = {
-	type?: 'text' | 'textArea';
+	inputType?: 'textInput' | 'textArea';
 };
 
 export function eventToNumber(event: FormEvent, defaultValue = 0): number {

--- a/apps/newsletters-ui/src/app/components/SimpleForm.tsx
+++ b/apps/newsletters-ui/src/app/components/SimpleForm.tsx
@@ -2,7 +2,7 @@ import { Box, Button, Paper, Typography } from '@mui/material';
 import type { ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 import type { z } from 'zod';
-import type { FieldDef, FieldValue } from './SchemaForm';
+import type { FieldDef, FieldValue, StringInputSettings } from './SchemaForm';
 import { getModification, SchemaForm } from './SchemaForm';
 
 type SchemaObjectType<T extends z.ZodRawShape> = {
@@ -22,6 +22,7 @@ interface Props<T extends z.ZodRawShape> {
 	isDisabled?: boolean;
 	message?: ReactNode;
 	maxOptionsForRadioButtons?: number;
+	stringConfig?: Partial<Record<keyof T, StringInputSettings>>;
 }
 
 /**
@@ -41,6 +42,7 @@ export function SimpleForm<T extends z.ZodRawShape>({
 	isDisabled,
 	message,
 	maxOptionsForRadioButtons,
+	stringConfig = {},
 }: Props<T>) {
 	const [parseInitialDataResult, setParseInitialDataResult] = useState<
 		z.SafeParseReturnType<typeof schema, SchemaObjectType<T>> | undefined
@@ -146,6 +148,7 @@ export function SimpleForm<T extends z.ZodRawShape>({
 				validationWarnings={warnings}
 				readOnlyKeys={isDisabled ? Object.keys(schema.shape) : undefined}
 				maxOptionsForRadioButtons={maxOptionsForRadioButtons}
+				stringConfig={stringConfig}
 			/>
 			<Box marginBottom={2}>
 				<Button

--- a/apps/newsletters-ui/src/app/components/StateEditForm.tsx
+++ b/apps/newsletters-ui/src/app/components/StateEditForm.tsx
@@ -2,7 +2,7 @@ import { Box, Paper, Typography } from '@mui/material';
 import type { z } from 'zod';
 import { getValidationWarnings } from '@newsletters-nx/newsletters-data-client';
 import type { WizardFormData } from '@newsletters-nx/state-machine';
-import type { FieldDef, FieldValue } from './SchemaForm';
+import type { FieldDef, FieldValue, StringInputSettings } from './SchemaForm';
 import { getModification, SchemaForm } from './SchemaForm';
 
 interface Props {
@@ -10,6 +10,7 @@ interface Props {
 	formData: WizardFormData;
 	setFormData: { (newData: WizardFormData): void };
 	maxOptionsForRadioButtons?: number;
+	stringConfig?: Partial<Record<string, StringInputSettings>>;
 }
 
 export const StateEditForm = ({
@@ -17,6 +18,7 @@ export const StateEditForm = ({
 	formData,
 	setFormData,
 	maxOptionsForRadioButtons,
+	stringConfig = {},
 }: Props) => {
 	const changeFormData = (value: FieldValue, field: FieldDef) => {
 		const mod = getModification(value, field);
@@ -45,6 +47,7 @@ export const StateEditForm = ({
 				validationWarnings={getValidationWarnings(formData, formSchema)}
 				changeValue={changeFormData}
 				maxOptionsForRadioButtons={maxOptionsForRadioButtons}
+				stringConfig={stringConfig}
 			/>
 		</Box>
 	);

--- a/apps/newsletters-ui/src/app/components/Wizard.tsx
+++ b/apps/newsletters-ui/src/app/components/Wizard.tsx
@@ -160,7 +160,7 @@ export const Wizard: React.FC<WizardProps> = ({
 		const [key, value] = nextEntry;
 		if (value.textArea) {
 			config[key] = {
-				type: 'textArea',
+				inputType: 'textArea',
 			};
 		}
 		return config;

--- a/apps/newsletters-ui/src/app/components/Wizard.tsx
+++ b/apps/newsletters-ui/src/app/components/Wizard.tsx
@@ -2,6 +2,7 @@ import { Alert, Box, Stack, Typography } from '@mui/material';
 import { useCallback, useEffect, useState } from 'react';
 import type { WizardId } from '@newsletters-nx/newsletter-workflow';
 import {
+	getFieldDisplayOptions,
 	getFormSchema,
 	getStartStepId,
 	getStepperConfig,
@@ -14,6 +15,7 @@ import type {
 } from '@newsletters-nx/state-machine';
 import { makeWizardStepRequest } from '../api-requests/make-wizard-step-request';
 import { MarkdownView } from './MarkdownView';
+import type { StringInputSettings } from './SchemaForm';
 import { SkipConfirmationDialog } from './SkipConfirmationDialog';
 import { StateEditForm } from './StateEditForm';
 import { StepNav } from './StepNav';
@@ -147,6 +149,22 @@ export const Wizard: React.FC<WizardProps> = ({
 	const currentStepListing = stepperConfig.steps.find(
 		(step) => step.id === serverData.currentStepId,
 	);
+	const fieldDisplayOptions = getFieldDisplayOptions(
+		wizardId,
+		serverData.currentStepId,
+	);
+
+	const stringConfig = Object.entries(fieldDisplayOptions ?? {}).reduce<
+		Record<string, StringInputSettings>
+	>((config, nextEntry) => {
+		const [key, value] = nextEntry;
+		if (value.textArea) {
+			config[key] = {
+				type: 'textArea',
+			};
+		}
+		return config;
+	}, {});
 
 	const handleFormChange = (updatedLocalState: WizardFormData): void => {
 		if (showSkipModalFor) {
@@ -224,6 +242,7 @@ export const Wizard: React.FC<WizardProps> = ({
 					formData={formData}
 					setFormData={handleFormChange}
 					maxOptionsForRadioButtons={5}
+					stringConfig={stringConfig}
 				/>
 			)}
 

--- a/libs/newsletter-workflow/src/lib/newsletter-workflow.ts
+++ b/libs/newsletter-workflow/src/lib/newsletter-workflow.ts
@@ -1,6 +1,7 @@
 import type {
 	StepperConfig,
 	WizardLayout,
+	WizardStepLayout,
 } from '@newsletters-nx/state-machine';
 import {
 	getStartStepAndId,
@@ -50,4 +51,16 @@ export const getStartStepId = (
 		return undefined;
 	}
 	return getStartStepAndId(layout, isEdit).id;
+};
+
+export const getFieldDisplayOptions = (
+	wizardId: keyof typeof newslettersWorkflowStepLayout,
+	stepId: string,
+): WizardStepLayout['fieldDisplayOptions'] => {
+	const wizard = newslettersWorkflowStepLayout[wizardId];
+	if (!wizard) {
+		return undefined;
+	}
+	const step = wizard[stepId];
+	return step?.fieldDisplayOptions;
 };

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/signUpEmbedLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/signUpEmbedLayout.ts
@@ -49,6 +49,11 @@ export const signUpEmbedLayout: WizardStepLayout<DraftService> = {
 		},
 	},
 	schema: formSchemas.signUpEmbed,
+	fieldDisplayOptions: {
+		signUpEmbedDescription: {
+			textArea: true,
+		},
+	},
 	canSkipTo: true,
 	executeSkip: executeSkip,
 };

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/signUpPageLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/signUpPageLayout.ts
@@ -49,6 +49,11 @@ export const signUpPageLayout: WizardStepLayout<DraftService> = {
 		},
 	},
 	schema: formSchemas.signUpPage,
+	fieldDisplayOptions: {
+		signUpDescription: {
+			textArea: true,
+		},
+	},
 	canSkipTo: true,
 	executeSkip: executeSkip,
 };

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/signUpPageLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/signUpPageLayout.ts
@@ -53,6 +53,9 @@ export const signUpPageLayout: WizardStepLayout<DraftService> = {
 		signUpDescription: {
 			textArea: true,
 		},
+		signUpHeadline: {
+			textArea: true,
+		},
 	},
 	canSkipTo: true,
 	executeSkip: executeSkip,

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/singleThrasherLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/singleThrasherLayout.ts
@@ -86,6 +86,11 @@ export const singleThrasherLayout: WizardStepLayout<DraftService> = {
 		},
 	},
 	schema: formSchemas.singleThrasher,
+	fieldDisplayOptions: {
+		'thrasherOptions.thrasherDescription': {
+			textArea: true,
+		},
+	},
 	canSkipTo: true,
 	executeSkip: executeSkip,
 };

--- a/libs/state-machine/src/lib/types.ts
+++ b/libs/state-machine/src/lib/types.ts
@@ -106,6 +106,12 @@ export interface WizardStepLayout<T extends GenericStorageInterface = unknown> {
 	};
 	buttons: Record<string, WizardStepLayoutButton<T>>;
 	schema?: ZodObject<ZodRawShape>;
+	fieldDisplayOptions?: Record<
+		string,
+		{
+			textArea?: boolean;
+		}
+	>;
 	canSkipTo?: boolean;
 	skippingWillPersistLocalChanges?: boolean;
 	executeSkip?: AsyncExecution<T> | Execution<T>;


### PR DESCRIPTION
## What does this change?

Adds an option to have string values in a `WizardStepLayout` collected in multi-line text areas, so better support longer values like description fields, using an optional `fieldDisplayOptions` property.

The input on text areas is processed to remove any tabs or carriage returns - in effect the user cannot input formatted / multiline text, but the text will wrap, rather than be clipped. (We could add extra options to configure textArea to allow formatted text, but there is not a current need for this).

configures the steps in the main draft wizard to use the textArea for  text  fields likely to be longer (eg headlines, descriptions.

Makes the width for fields in schema forms wider - the wrapper was set to maxWidth = 400, but changed it to 'sm' (600px by default, but can be configured in the theme).



## How to test

Description fields will be multi-line, but not accept CR's or Tabs.

## How can we measure success?

Easier for user to read longer text values.

## Have we considered potential risks?

One extra thing to remember when configuring new wizards. 

## Images

<img width="872" alt="Screenshot 2023-07-11 at 12 05 09" src="https://github.com/guardian/newsletters-nx/assets/30567854/c8dde367-da47-4391-a5ce-4242e0a814e6">

