### PR TITLE
remove amiTags from riff-raff.yaml

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -8,9 +8,9 @@ templates:
     parameters:
       cloudFormationStackByTags: false
       prependStackToCloudFormationStackName: false
-      amiTags:
-        Recipe: newsletters-node
-        AmigoStage: PROD
+      # amiTags:
+      #   Recipe: newsletters-node
+      #   AmigoStage: PROD
   autoscaling-template:
     type: autoscaling
     parameters:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -8,9 +8,6 @@ templates:
     parameters:
       cloudFormationStackByTags: false
       prependStackToCloudFormationStackName: false
-      # amiTags:
-      #   Recipe: newsletters-node
-      #   AmigoStage: PROD
   autoscaling-template:
     type: autoscaling
     parameters:


### PR DESCRIPTION
## What does this change?

We use both `amiTags` and `amiParametersToTags ` in our riff-raff.yaml - it seems only one is required. The riffraff error output is making me sad. Hoping this makes that look less grumpy 🤞 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Less fail in the output and a successful deploy

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

We'll see

## Images

Before (Boooo 😞 )
<img width="651" alt="Screenshot 2023-07-11 at 21 32 45" src="https://github.com/guardian/newsletters-nx/assets/3277259/e5222ef9-36fa-44b3-a6e6-47bfbc2785f9">

After (Woooo 🎉 )
<img width="1215" alt="Screenshot 2023-07-11 at 21 58 16" src="https://github.com/guardian/newsletters-nx/assets/3277259/a21b15e1-3555-472b-acc3-f09c9f83cf7a">

