### PR TITLE
update button styling for consistent appearance. Revert ealier (bot) lib version bump that prevented the app from running locally

### DIFF
--- a/apps/newsletters-ui/src/app/components/DeleteDraftButton.tsx
+++ b/apps/newsletters-ui/src/app/components/DeleteDraftButton.tsx
@@ -1,4 +1,5 @@
-import { Alert, AlertTitle, Box, Button, ButtonGroup } from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { Alert, AlertTitle, Button, ButtonGroup } from '@mui/material';
 import { useState } from 'react';
 import type { DraftNewsletterData } from '@newsletters-nx/newsletters-data-client';
 import { requestDraftDeletion } from '../api-requests/requestDraftDeletion';
@@ -7,14 +8,12 @@ interface Props {
 	draft: DraftNewsletterData;
 	hasBeenDeleted: boolean;
 	setHasBeenDeleted: { (value: boolean): void };
-	margin?: number;
 }
 
 export const DeleteDraftButton = ({
 	draft,
 	hasBeenDeleted,
 	setHasBeenDeleted,
-	margin = 0,
 }: Props) => {
 	const [showConfirmationButton, setShowConfirmationButton] = useState(false);
 	const [deleteErrorMessage, setDeleteErrorMessage] = useState<
@@ -38,7 +37,7 @@ export const DeleteDraftButton = ({
 	};
 
 	return (
-		<Box marginTop={margin} marginBottom={margin}>
+		<>
 			{!hasBeenDeleted && !showConfirmationButton && (
 				<ButtonGroup>
 					<Button
@@ -48,6 +47,7 @@ export const DeleteDraftButton = ({
 							setDeleteErrorMessage(undefined);
 							setShowConfirmationButton(true);
 						}}
+						startIcon={<DeleteIcon />}
 					>
 						delete
 					</Button>
@@ -76,6 +76,6 @@ export const DeleteDraftButton = ({
 					<span>{deleteErrorMessage}</span>
 				</Alert>
 			)}
-		</Box>
+		</>
 	);
 };

--- a/apps/newsletters-ui/src/app/components/DraftDetails.tsx
+++ b/apps/newsletters-ui/src/app/components/DraftDetails.tsx
@@ -71,15 +71,6 @@ export const DraftDetails = ({ draft }: Props) => {
 				created: {draft.creationTimeStamp}
 			</Typography>
 
-			{userCanWriteToDrafts && (
-				<DeleteDraftButton
-					draft={draft}
-					hasBeenDeleted={hasBeenDeleted}
-					setHasBeenDeleted={setHasBeenDeleted}
-					margin={1}
-				/>
-			)}
-
 			{draft.listId && (
 				<ButtonGroup>
 					<NavigateButton
@@ -99,6 +90,13 @@ export const DraftDetails = ({ draft }: Props) => {
 						>
 							Launch
 						</NavigateButton>
+					)}
+					{userCanWriteToDrafts && (
+						<DeleteDraftButton
+							draft={draft}
+							hasBeenDeleted={hasBeenDeleted}
+							setHasBeenDeleted={setHasBeenDeleted}
+						/>
 					)}
 				</ButtonGroup>
 			)}

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -8279,7 +8279,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@guardian/prettier/-/prettier-1.0.0.tgz",
       "integrity": "sha512-srnhPn3hcSv14mDotFQN0CfN3k8MaGsXdK8BXAG95QQxM69Ybi16o4/Xqe361fwDEp7m+9jf03sETcMi8WsDlA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -9056,7 +9057,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -10084,7 +10086,8 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.7",
@@ -11413,7 +11416,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "29.2.0",


### PR DESCRIPTION
## What does this change?

Two things:

reverts a commit to bump aws sdk and other libs from dependabot which caused errors when running locally (though not when deployed which is where I tested prior to merge).

```bash
Watch error: connect ENOENT /var/folders/b5/tkg5q3jd6nz6kyxlrm7mqmhr0000gp/T/c4020b0bff3ae50b54a6/d.sock
Watch error: Daemon closed the connection
(node:49706) Warning: Closing file descriptor 23 on garbage collection
(Use `node --trace-warnings ...` to show where the warning was created)
```

This also updates the styling for the delete button as it looked a bit unusual in the deafts page:

Before

![Screenshot 2023-07-12 at 09 04 40](https://github.com/guardian/newsletters-nx/assets/3277259/b55891d6-25c0-4b00-80bd-14b12f83a5d2)

After

![Screenshot 2023-07-12 at 09 04 47](https://github.com/guardian/newsletters-nx/assets/3277259/f3091b86-2f79-4790-a5ca-9b6e4e70db7f)

