### PR TITLE
Use modal for confirmation

### DIFF
--- a/apps/newsletters-ui/src/app/components/DeleteDraftButton.tsx
+++ b/apps/newsletters-ui/src/app/components/DeleteDraftButton.tsx
@@ -1,5 +1,15 @@
 import DeleteIcon from '@mui/icons-material/Delete';
-import { Alert, AlertTitle, Button, ButtonGroup } from '@mui/material';
+import {
+	Alert,
+	AlertTitle,
+	Button,
+	ButtonGroup,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogContentText,
+	DialogTitle,
+} from '@mui/material';
 import { useState } from 'react';
 import type { DraftNewsletterData } from '@newsletters-nx/newsletters-data-client';
 import { requestDraftDeletion } from '../api-requests/requestDraftDeletion';
@@ -38,7 +48,7 @@ export const DeleteDraftButton = ({
 
 	return (
 		<>
-			{!hasBeenDeleted && !showConfirmationButton && (
+			{!hasBeenDeleted && (
 				<ButtonGroup>
 					<Button
 						color="error"
@@ -53,23 +63,28 @@ export const DeleteDraftButton = ({
 					</Button>
 				</ButtonGroup>
 			)}
-			{!hasBeenDeleted && showConfirmationButton && (
-				<Alert severity="warning">
-					<AlertTitle>Are you sure you want to delete this draft?</AlertTitle>
-					<ButtonGroup variant="contained">
-						<Button
-							onClick={() => {
-								setShowConfirmationButton(false);
-							}}
-						>
-							CANCEL
-						</Button>
-						<Button color="error" onClick={sendDeleteRequest}>
-							CONFIRM DELETE
-						</Button>
-					</ButtonGroup>
-				</Alert>
-			)}
+
+			<Dialog open={!hasBeenDeleted && showConfirmationButton}>
+				<DialogTitle>Are you sure you want to delete this draft?</DialogTitle>
+				<DialogContent>
+					<DialogContentText>
+						Deleted drafts cannot be recovered.
+					</DialogContentText>
+				</DialogContent>
+				<DialogActions>
+					<Button
+						onClick={() => {
+							setShowConfirmationButton(false);
+						}}
+					>
+						CANCEL
+					</Button>
+					<Button color="error" onClick={sendDeleteRequest}>
+						CONFIRM DELETE
+					</Button>
+				</DialogActions>
+			</Dialog>
+
 			{!!deleteErrorMessage && (
 				<Alert severity="error">
 					<AlertTitle>Delete request failed</AlertTitle>


### PR DESCRIPTION
## What does this change?

The confirm dialog in the delete button causes the table row to resize in a slightly jarring manner. This change uses a dialog instead.

## How to test

Test it behaves as it did but with a dialog rather than in-line button.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Before
![Kapture 2023-07-12 at 19 53 54](https://github.com/guardian/newsletters-nx/assets/3277259/62001639-d870-4a03-bdf8-cee10fc80940)

After
![Kapture 2023-07-12 at 19 43 43](https://github.com/guardian/newsletters-nx/assets/3277259/e43d3f3f-2100-42b3-a101-e9997a9f749a)
