### PR TITLE
no meta route, only register patch endpoint in read/write mode

### DIFF
--- a/apps/newsletters-api/src/app/routes/newsletters.ts
+++ b/apps/newsletters-api/src/app/routes/newsletters.ts
@@ -54,33 +54,6 @@ export function registerNewsletterRoutes(app: FastifyInstance) {
 		},
 	);
 
-	app.get<{ Params: { newsletterId: string } }>(
-		'/api/newsletters/meta/:newsletterId',
-		async (req, res) => {
-			const user = getUserProfile(req);
-			const accessDeniedError = await makeAccessDeniedApiResponse(
-				user.profile,
-				'viewMetaData',
-			);
-			if (accessDeniedError) {
-				return res.status(403).send(accessDeniedError);
-			}
-
-			const { newsletterId } = req.params;
-			const storageResponse = await newsletterStore.readByNameWithMeta(
-				newsletterId,
-			);
-
-			if (!storageResponse.ok) {
-				return res
-					.status(mapStorageFailureReasonToStatusCode(storageResponse.reason))
-					.send(makeErrorResponse(storageResponse.message));
-			}
-
-			return makeSuccessResponse(storageResponse.data);
-		},
-	);
-
 	app.patch<{
 		Params: { newsletterId: string };
 		Body: unknown;

--- a/apps/newsletters-api/src/app/routes/newsletters.ts
+++ b/apps/newsletters-api/src/app/routes/newsletters.ts
@@ -13,7 +13,7 @@ import {
 	mapStorageFailureReasonToStatusCode,
 } from '../responses';
 
-export function registerNewsletterRoutes(app: FastifyInstance) {
+export function registerReadNewsletterRoutes(app: FastifyInstance) {
 	// not using the makeSuccess function on this route as
 	// we are emulating the response of the legacy API
 	app.get('/api/legacy/newsletters', async (req, res) => {
@@ -53,7 +53,9 @@ export function registerNewsletterRoutes(app: FastifyInstance) {
 			return makeSuccessResponse(storageResponse.data);
 		},
 	);
+}
 
+export function registerReadWriteNewsletterRoutes(app: FastifyInstance) {
 	app.patch<{
 		Params: { newsletterId: string };
 		Body: unknown;

--- a/apps/newsletters-api/src/main.ts
+++ b/apps/newsletters-api/src/main.ts
@@ -7,7 +7,10 @@ import {
 import { registerCurrentStepRoute } from './app/routes/currentStep';
 import { registerDraftsRoutes } from './app/routes/drafts';
 import { registerHealthRoute } from './app/routes/health';
-import { registerNewsletterRoutes } from './app/routes/newsletters';
+import {
+	registerReadNewsletterRoutes,
+	registerReadWriteNewsletterRoutes,
+} from './app/routes/newsletters';
 import { registerRenderingTemplatesRoutes } from './app/routes/rendering-templates';
 import { registerUserRoute } from './app/routes/user';
 import { registerUIServer } from './register-ui-server';
@@ -20,9 +23,10 @@ if (isServingUI()) {
 if (isServingReadWriteEndpoints()) {
 	registerCurrentStepRoute(app);
 	registerUserRoute(app);
+	registerReadWriteNewsletterRoutes(app);
 }
 if (isServingReadEndpoints()) {
-	registerNewsletterRoutes(app);
+	registerReadNewsletterRoutes(app);
 	registerDraftsRoutes(app);
 	registerRenderingTemplatesRoutes(app);
 }


### PR DESCRIPTION

## What does this change?

https://trello.com/c/BkFUt64u/497-remove-meta-route

 - remove the "view meta" endpoint from the newsletters route
 - only register the newsletters.PATCH endpoint when environment is in read/write mode (was protected by the need for a user profile, but no need to include it at all)

## How to test

 - 404 response from /api/newsletters/meta/{identityName}

## How can we measure success?

Cuts off unnecessary access to data via API.

## Have we considered potential risks?

should be safer now