### PR TITLE
Add optional pallette override to rendering options and include in both wizard and form

### DIFF
--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
@@ -121,6 +121,10 @@ export const formSchemas = {
 		'displayStandfirst',
 	]).describe('Input the header setup'),
 
+	newsletterPaletteOverride: pickAndPrefixRenderingOption([
+		'paletteOverride',
+	]).describe('Select a palette theme'),
+
 	footer: pickAndPrefixRenderingOption(['contactEmail']).describe(
 		'Input the footer setup',
 	),

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/index.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/index.ts
@@ -6,6 +6,7 @@ import { footerLayout } from './footerLayout';
 import { imageLayout } from './imageLayout';
 import { linkListLayout } from './linkListLayout';
 import { newsletterHeaderLayout } from './newsletterHeaderLayout';
+import { paletteOverrideLayout } from './paletteOverrideLayout';
 import { podcastLayout } from './podcastLayout';
 import { readMoreLayout } from './readMoreLayout';
 import { startLayout } from './startLayout';
@@ -14,6 +15,7 @@ export const renderingOptionsLayout: WizardLayout<DraftService> = {
 	start: startLayout,
 	newsletterHeader: newsletterHeaderLayout,
 	image: imageLayout,
+	paletteOverride: paletteOverrideLayout,
 	readMore: readMoreLayout,
 	linkList: linkListLayout,
 	podcast: podcastLayout,

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/paletteOverrideLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/paletteOverrideLayout.ts
@@ -1,0 +1,51 @@
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
+import type { WizardStepLayout } from '@newsletters-nx/state-machine';
+import {
+	getNextStepId,
+	getPreviousOrEditStartStepId,
+} from '@newsletters-nx/state-machine';
+import { executeModify } from '../../executeModify';
+import { getStringValuesFromRecord } from '../../getValuesFromRecord';
+import { regExPatterns } from '../../regExPatterns';
+import { formSchemas } from '../newsletterData/formSchemas';
+
+const markdownTemplate = `
+## Palette override for {{name}}
+
+The Palette for a newsletter is usually driven by the Pillar it appears under, but that can be overridden here.
+
+`.trim();
+
+const staticMarkdown = markdownTemplate.replace(
+	regExPatterns.name,
+	'the newsletter',
+);
+
+export const paletteOverrideLayout: WizardStepLayout<DraftService> = {
+	staticMarkdown,
+	label: 'Palette Setup',
+	dynamicMarkdown(requestData, responseData) {
+		if (!responseData) {
+			return staticMarkdown;
+		}
+		const [name = 'NAME'] = getStringValuesFromRecord(responseData, ['name']);
+		return markdownTemplate.replace(regExPatterns.name, name);
+	},
+	buttons: {
+		back: {
+			buttonType: 'PREVIOUS',
+			label: 'Back',
+			stepToMoveTo: getPreviousOrEditStartStepId,
+			executeStep: executeModify,
+		},
+		finish: {
+			buttonType: 'NEXT',
+			label: 'Next',
+			stepToMoveTo: getNextStepId,
+			executeStep: executeModify,
+		},
+	},
+	schema: formSchemas.newsletterPaletteOverride,
+	canSkipTo: true,
+	executeSkip: executeModify,
+};

--- a/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
@@ -37,6 +37,7 @@ export const renderingOptionsSchema = z.object({
 	displayStandfirst: z.boolean().describe('display standfirst?'),
 	contactEmail: z.string().email().describe('contact email'),
 	displayImageCaptions: z.boolean().describe('display image captions?'),
+	paletteOverride: themeEnumSchema.optional().describe('palette override'),
 	linkListSubheading: z
 		.array(z.string())
 		.optional()


### PR DESCRIPTION
## What does this change?

We intend to allow limited control of the palette options for newsletters rendering from the tool. This will be driven by the Pillar to Newsletter is under however, we want to allow this to be overridden.

This change introdices a new element to the rendering options in newsletters of `paletteOverride`. We will check for this value in the email rendering service and, where it is present, use that in place of the pillar to determine palette options for the Newsletter HTML. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Verify that the fisly is there, CRUD works and the value is visible int he API response, 

## Have we considered potential risks?

Should be OK - Th value is optional and does not do anything yet. 


## Images

## Form

![Screenshot 2023-07-17 at 15 04 37](https://github.com/guardian/newsletters-nx/assets/3277259/60b8589f-e1df-408d-8c44-b7faa05fca3f)

## Wizard

![Screenshot 2023-07-17 at 15 05 56](https://github.com/guardian/newsletters-nx/assets/3277259/fd6b5038-4b74-4b48-9ff8-24dfeabfd174)

##API:

![Screenshot 2023-07-17 at 15 12 29](https://github.com/guardian/newsletters-nx/assets/3277259/adae71f1-08ad-4635-9ba8-113e3e6f3828)