### PR TITLE
Added replace function for JSON edit to allow removal of properties

### DIFF
--- a/apps/newsletters-api/src/app/routes/newsletters.ts
+++ b/apps/newsletters-api/src/app/routes/newsletters.ts
@@ -1,7 +1,5 @@
 import type { FastifyInstance } from 'fastify';
-import type {
-	NewsletterData,
-} from '@newsletters-nx/newsletters-data-client';
+import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
 import {
 	isNewsletterData,
 	isPartialNewsletterData,
@@ -146,7 +144,7 @@ export function registerReadWriteNewsletterRoutes(app: FastifyInstance) {
 			newsletterIdAsNumber,
 			newsletterData,
 			user.profile,
-		) ;
+		);
 
 		if (!storageResponse.ok) {
 			return res

--- a/apps/newsletters-api/src/app/routes/newsletters.ts
+++ b/apps/newsletters-api/src/app/routes/newsletters.ts
@@ -1,9 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import type {
 	NewsletterData,
-	NewsletterDataWithoutMeta,
-	SuccessfulStorageResponse,
-	UnsuccessfulStorageResponse,
 } from '@newsletters-nx/newsletters-data-client';
 import {
 	isNewsletterData,
@@ -145,14 +142,11 @@ export function registerReadWriteNewsletterRoutes(app: FastifyInstance) {
 			return res.status(403).send(makeErrorResponse('No user profile'));
 		}
 
-		//todo - figure out why the compiler does not know the response type
 		const storageResponse = await newsletterStore.replace(
 			newsletterIdAsNumber,
 			newsletterData,
 			user.profile,
-		) as
-			| SuccessfulStorageResponse<NewsletterDataWithoutMeta>
-			| UnsuccessfulStorageResponse;
+		) ;
 
 		if (!storageResponse.ok) {
 			return res

--- a/apps/newsletters-api/src/app/routes/newsletters.ts
+++ b/apps/newsletters-api/src/app/routes/newsletters.ts
@@ -7,7 +7,7 @@ import type {
 } from '@newsletters-nx/newsletters-data-client';
 import {
 	isNewsletterData,
-	isPartialNewsletterData, NewsletterStorage,
+	isPartialNewsletterData,
 	replaceNullWithUndefinedForUnknown,
 	transformDataToLegacyNewsletter,
 } from '@newsletters-nx/newsletters-data-client';
@@ -145,6 +145,7 @@ export function registerReadWriteNewsletterRoutes(app: FastifyInstance) {
 			return res.status(403).send(makeErrorResponse('No user profile'));
 		}
 
+		//todo - figure out why the compiler does not know the response type
 		const storageResponse = await newsletterStore.replace(
 			newsletterIdAsNumber,
 			newsletterData,

--- a/apps/newsletters-api/src/app/routes/newsletters.ts
+++ b/apps/newsletters-api/src/app/routes/newsletters.ts
@@ -1,5 +1,4 @@
 import type { FastifyInstance } from 'fastify';
-import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
 import {
 	isNewsletterData,
 	isPartialNewsletterData,
@@ -124,15 +123,14 @@ export function registerReadWriteNewsletterRoutes(app: FastifyInstance) {
 		const { newsletterId } = req.params;
 		const { body: newsletter } = req;
 		const newsletterIdAsNumber = Number(newsletterId);
-		const newsletterData = newsletter as NewsletterData;
 
 		if (isNaN(newsletterIdAsNumber)) {
 			return res.status(400).send(makeErrorResponse(`Non numeric id provided`));
 		}
 
-		replaceNullWithUndefinedForUnknown(newsletterData);
+		replaceNullWithUndefinedForUnknown(newsletter);
 
-		if (!isNewsletterData(newsletterData)) {
+		if (!isNewsletterData(newsletter)) {
 			return res.status(400).send(makeErrorResponse(`Not a valid newsletter`));
 		}
 
@@ -142,7 +140,7 @@ export function registerReadWriteNewsletterRoutes(app: FastifyInstance) {
 
 		const storageResponse = await newsletterStore.replace(
 			newsletterIdAsNumber,
-			newsletterData,
+			newsletter,
 			user.profile,
 		);
 

--- a/apps/newsletters-ui/src/app/api-requests/replace-newsletter.ts
+++ b/apps/newsletters-ui/src/app/api-requests/replace-newsletter.ts
@@ -4,16 +4,16 @@ import type {
 } from '@newsletters-nx/newsletters-data-client';
 import { replaceUndefinedWithNull } from '@newsletters-nx/newsletters-data-client';
 
-export const requestNewsletterEdit = async (
+export const replaceNewsletter = async (
 	listId: number,
-	modification: Partial<NewsletterData>,
+	newsletter: NewsletterData,
 ): Promise<ApiResponse<NewsletterData>> => {
 	const response = await fetch(`/api/newsletters/${listId}`, {
-		method: 'PATCH',
+		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
 		},
-		body: JSON.stringify(modification, replaceUndefinedWithNull),
+		body: JSON.stringify(newsletter, replaceUndefinedWithNull),
 	});
 
 	return (await response.json()) as ApiResponse<NewsletterData>;

--- a/apps/newsletters-ui/src/app/components/NewsletterJsonEdit.tsx
+++ b/apps/newsletters-ui/src/app/components/NewsletterJsonEdit.tsx
@@ -2,7 +2,7 @@ import { Alert, Snackbar, Typography } from '@mui/material';
 import { useState } from 'react';
 import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
 import { newsletterDataSchema } from '@newsletters-nx/newsletters-data-client';
-import { requestNewsletterEdit } from '../api-requests/request-newsletter-edit';
+import { replaceNewsletter } from '../api-requests/replace-newsletter';
 import { usePermissions } from '../hooks/user-hooks';
 import { JsonEditor } from './JsonEditor';
 
@@ -20,18 +20,13 @@ export const NewsletterJsonEdit = ({ originalItem }: Props) => {
 	const permissions = usePermissions();
 
 	const handleSubmission = async (record: NewsletterData) => {
-		const partial = {
-			...record,
-			listId: undefined,
-			identityName: undefined,
-		} as Partial<NewsletterData>;
-		const apiResonse = await requestNewsletterEdit(record.listId, partial);
-
-		if (apiResonse.ok) {
-			setItem(apiResonse.data);
+		console.log('handleSubmission', record);
+		const apiResponse = await replaceNewsletter(record.listId, record);
+		if (apiResponse.ok) {
+			setItem(apiResponse.data);
 			setShowConfirmation(true);
 		} else {
-			setErrorMessage(apiResonse.message ?? 'UNKNOWN ERROR');
+			setErrorMessage(apiResponse.message ?? 'UNKNOWN ERROR');
 		}
 	};
 

--- a/libs/newsletters-data-client/src/lib/json-undefined-null-conversions.ts
+++ b/libs/newsletters-data-client/src/lib/json-undefined-null-conversions.ts
@@ -87,7 +87,7 @@ export const replaceNullWithUndefinedInFormDataRecord = (
 	return formData;
 };
 
-/** Recursively replace any null propery with `undefined` */
+/** Recursively replace any null property with `undefined` */
 export const replaceNullWithUndefinedForUnknown = (value: unknown): unknown => {
 	if (value === null) {
 		return undefined;

--- a/libs/newsletters-data-client/src/lib/newsletter-storage/InMemoryNewsletterStorage.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/InMemoryNewsletterStorage.ts
@@ -154,6 +154,28 @@ export class InMemoryNewsletterStorage implements NewsletterStorage {
 		return Promise.resolve(response);
 	}
 
+	replace(
+		listId: number,
+		newsletter: NewsletterDataWithoutMeta,
+		user: UserProfile,
+	) {
+		const match = this.memory.find((item) => item.listId === listId);
+		if (!match) {
+			return Promise.resolve(this.buildNoItemError(listId));
+		}
+
+		const updatedItem: NewsletterDataWithMeta = {
+			...newsletter,
+			meta: this.updateMeta(match.meta, user),
+		};
+		this.memory.splice(this.memory.indexOf(match), 1, updatedItem);
+		const response: SuccessfulStorageResponse<NewsletterDataWithoutMeta> = {
+			ok: true,
+			data: this.stripMeta(updatedItem),
+		};
+		return Promise.resolve(response);
+	}
+
 	delete(listId: number) {
 		const match = this.memory.find((item) => item.listId === listId);
 

--- a/libs/newsletters-data-client/src/lib/newsletter-storage/InMemoryNewsletterStorage.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/InMemoryNewsletterStorage.ts
@@ -164,6 +164,18 @@ export class InMemoryNewsletterStorage implements NewsletterStorage {
 			return Promise.resolve(this.buildNoItemError(listId));
 		}
 
+		if (
+			newsletter.identityName !== match.identityName ||
+			newsletter.listId !== match.listId
+		) {
+			console.error(
+				`newsletter identityName or listId mismatch for newsletter with id ${listId}`,
+			);
+			throw new Error(
+				`newsletter identityName or listId mismatch for newsletter with id ${listId}`,
+			);
+		}
+
 		const updatedItem: NewsletterDataWithMeta = {
 			...newsletter,
 			meta: this.updateMeta(match.meta, user),

--- a/libs/newsletters-data-client/src/lib/newsletter-storage/InMemoryNewsletterStorage.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/InMemoryNewsletterStorage.ts
@@ -154,7 +154,7 @@ export class InMemoryNewsletterStorage implements NewsletterStorage {
 		return Promise.resolve(response);
 	}
 
-	replace(
+	async replace(
 		listId: number,
 		newsletter: NewsletterDataWithoutMeta,
 		user: UserProfile,

--- a/libs/newsletters-data-client/src/lib/newsletter-storage/NewsletterStorage.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/NewsletterStorage.ts
@@ -49,16 +49,18 @@ export abstract class NewsletterStorage {
 		| UnsuccessfulStorageResponse
 	>;
 
-	abstract readByNameWithMeta(
-		identityName: string,
-	): Promise<
-		| SuccessfulStorageResponse<NewsletterDataWithMeta>
-		| UnsuccessfulStorageResponse
-	>;
-
 	abstract update(
 		listId: number,
 		modifications: Partial<NewsletterData>,
+		user: UserProfile,
+	): Promise<
+		| SuccessfulStorageResponse<NewsletterDataWithoutMeta>
+		| UnsuccessfulStorageResponse
+	>;
+
+	abstract replace(
+		listId: number,
+		newsletter: NewsletterData,
 		user: UserProfile,
 	): Promise<
 		| SuccessfulStorageResponse<NewsletterDataWithoutMeta>

--- a/libs/newsletters-data-client/src/lib/newsletter-storage/s3-newsletter-storage.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/s3-newsletter-storage.ts
@@ -296,6 +296,19 @@ export class S3NewsletterStorage implements NewsletterStorage {
 				message: `failed to read newsletter with id ${listId}`,
 			};
 		}
+
+		if (
+			newsletter.identityName !== newsletterToUpdate.identityName ||
+			newsletter.listId !== newsletterToUpdate.listId
+		) {
+			console.error(
+				`newsletter identityName or listId mismatch for newsletter with id ${listId}`,
+			);
+			throw new Error(
+				`newsletter identityName or listId mismatch for newsletter with id ${listId}`,
+			);
+		}
+
 		const { identityName } = newsletterToUpdate;
 		const updatedNewsletter: NewsletterDataWithMeta = {
 			...newsletter,

--- a/libs/newsletters-data-client/src/lib/newsletter-storage/s3-newsletter-storage.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/s3-newsletter-storage.ts
@@ -294,26 +294,30 @@ export class S3NewsletterStorage implements NewsletterStorage {
 			return {
 				ok: false,
 				message: `failed to read newsletter with id ${listId}`,
-			} as UnsuccessfulStorageResponse;
+			};
 		}
+		const { identityName } = newsletterToUpdate;
 		const updatedNewsletter: NewsletterDataWithMeta = {
 			...newsletter,
+			identityName,
+			listId,
 			meta: this.updateMeta(newsletterToUpdate.meta ?? makeBlankMeta(), user),
 		};
-		const identifier = `${updatedNewsletter.identityName}:${updatedNewsletter.listId}.json`;
+
+		const identifier = `${identityName}:${listId}.json`;
 
 		try {
 			await this.putObject(updatedNewsletter, identifier);
 			return {
 				ok: true,
 				data: this.stripMeta(updatedNewsletter),
-			} as SuccessfulStorageResponse<NewsletterDataWithoutMeta>;
+			};
 		} catch (err) {
 			return {
 				ok: false,
 				message: `failed to update newsletter with id ${listId}`,
 				reason: StorageRequestFailureReason.S3Failure,
-			} as UnsuccessfulStorageResponse;
+			};
 		}
 	}
 


### PR DESCRIPTION
## What does this change?

Adds a POST endpoint which allows us to replace the content of a launched Newletter. This means we can remove properties (something not currently possible in the JSON editor as we merge edxisting state)

## How to test

Check it out, removed a property from a launched newsletter (`exampleUrl` is an option) , now update and verify the value is removed and that the item is still available from the API.

## Have we considered potential risks?

Should be Ok though we might want to consider access to this element of the app

