### PR TITLE
add support for darktheme in rendering options

### DIFF
--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
@@ -146,15 +146,19 @@ export const formSchemas = {
 		.describe('Select from the drop-down list'),
 
 	linkList: pickAndPrefixRenderingOption(['linkListSubheading']).describe(
-		'Input the subheading triggers',
+		'Add the subheading triggers',
+	),
+
+	darkTheme: pickAndPrefixRenderingOption(['darkThemeSubheading']).describe(
+		'Add the subheading triggers',
 	),
 
 	podcast: pickAndPrefixRenderingOption(['podcastSubheading']).describe(
-		'Input the subheading triggers',
+		'Add the subheading triggers',
 	),
 
 	readMore: pickAndPrefixRenderingOption(['readMoreSections']).describe(
-		'Input the Read More setup',
+		'Add the Read More setup',
 	),
 
 	tags: dataCollectionSchema

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/darkSectionLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/darkSectionLayout.ts
@@ -1,0 +1,56 @@
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
+import type { WizardStepLayout } from '@newsletters-nx/state-machine';
+import {
+	getNextStepId,
+	getPreviousOrEditStartStepId,
+} from '@newsletters-nx/state-machine';
+import { executeModify } from '../../executeModify';
+import { getStringValuesFromRecord } from '../../getValuesFromRecord';
+import { regExPatterns } from '../../regExPatterns';
+import { formSchemas } from '../newsletterData/formSchemas';
+
+const markdownTemplate = `
+## Rendering Dark sections in {{name}}
+
+You may want to display some elements in {{name}} as Dark sections.
+
+This will display the section with a dark background.
+
+![Dark Section](https://uploads.guim.co.uk/2023/07/18/Screenshot_2023-07-18_at_09.28.13.png)
+
+Add the subheading that trigger the display of a dark section
+`.trim();
+
+const staticMarkdown = markdownTemplate.replace(
+	regExPatterns.name,
+	'the newsletter',
+);
+
+export const darkSectionLayout: WizardStepLayout<DraftService> = {
+	staticMarkdown,
+	label: 'Dark Sections',
+	dynamicMarkdown(requestData, responseData) {
+		if (!responseData) {
+			return staticMarkdown;
+		}
+		const [name = 'NAME'] = getStringValuesFromRecord(responseData, ['name']);
+		return markdownTemplate.replace(regExPatterns.name, name);
+	},
+	buttons: {
+		back: {
+			buttonType: 'PREVIOUS',
+			label: 'Back',
+			stepToMoveTo: getPreviousOrEditStartStepId,
+			executeStep: executeModify,
+		},
+		next: {
+			buttonType: 'NEXT',
+			label: 'Next',
+			stepToMoveTo: getNextStepId,
+			executeStep: executeModify,
+		},
+	},
+	schema: formSchemas.darkTheme,
+	canSkipTo: true,
+	executeSkip: executeModify,
+};

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/index.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/index.ts
@@ -1,6 +1,7 @@
 import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardLayout } from '@newsletters-nx/state-machine';
 import { cancelLayout } from './cancelLayout';
+import { darkSectionLayout } from './darkSectionLayout';
 import { finishLayout } from './finishLayout';
 import { footerLayout } from './footerLayout';
 import { imageLayout } from './imageLayout';
@@ -19,6 +20,7 @@ export const renderingOptionsLayout: WizardLayout<DraftService> = {
 	readMore: readMoreLayout,
 	linkList: linkListLayout,
 	podcast: podcastLayout,
+	darkTheme: darkSectionLayout,
 	footer: footerLayout,
 	finish: finishLayout,
 	cancel: cancelLayout,

--- a/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
@@ -46,6 +46,10 @@ export const renderingOptionsSchema = z.object({
 		.array(z.string())
 		.optional()
 		.describe('podcast subheading'),
+	darkThemeSubheading: z
+		.array(z.string())
+		.optional()
+		.describe('dark theme subheading'),
 	readMoreSections: z
 		.array(
 			z


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Email rendering now supports DarkTheme sections. We want to expose the subheading triggers for those in the rendering options of the tool. This change adds that (optional) value.

## How to test

Test it is possible to add / update and that the value is returned in the api as expected

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

Should be fine

## Images

### Wizard
![Screenshot 2023-07-18 at 10 13 37](https://github.com/guardian/newsletters-nx/assets/3277259/8259c212-1b76-477e-9e95-f93f3148d17f)

### Form 
<img width="823" alt="Screenshot 2023-07-18 at 10 11 34" src="https://github.com/guardian/newsletters-nx/assets/3277259/bee95889-c15e-481b-8902-fca120a14bbd">
