### PR TITLE
Notify user where rendering options exist in Email Rendering

### DIFF
--- a/apps/newsletters-ui/src/app/components/RenderingOptionsForm.tsx
+++ b/apps/newsletters-ui/src/app/components/RenderingOptionsForm.tsx
@@ -137,7 +137,7 @@ export const RenderingOptionsForm = ({ originalItem }: Props) => {
 
 	return (
 		<>
-			{hasEmailRenderingTemplate && <Alert severity="error">The Rendering options for this Newsletter amd managed Email Rendering and cannot be changed in this tool. To make changes to <strong>{item.name}</strong>, please contact the development team</Alert>}
+			{hasEmailRenderingTemplate && <Alert severity="error">The rendering options for this newsletter are managed in the Email Rendering project. Updates made here will not effect the emails sent to subscribers. To make changes to <strong>{item.name}</strong>, please contact the development team</Alert>}
 			<Typography variant="h2">{item.name}</Typography>
 			<Typography variant="subtitle1">email-rendering settings</Typography>
 			<Typography variant="h3">Category and series tag</Typography>

--- a/apps/newsletters-ui/src/app/components/RenderingOptionsForm.tsx
+++ b/apps/newsletters-ui/src/app/components/RenderingOptionsForm.tsx
@@ -24,7 +24,26 @@ export const RenderingOptionsForm = ({ originalItem }: Props) => {
 	>(
 		originalItem.renderingOptions ?? getEmptySchemaData(renderingOptionsSchema),
 	);
+
 	const [item, setItem] = useState<NewsletterData>(originalItem);
+	const emailRenderingManagedNewsletters = [
+		'afternoon-update',
+		'cotton-capital',
+		'the-guide-staying-in',
+		'fashion-statement',
+		'five-great-reads',
+		'morning-mail',
+		'soccer-with-jonathan-wilson',
+		'this-is-europe',
+		'moving-the-goalposts',
+		'pushing-buttons',
+		'morning-briefing',
+		'green-light',
+		'the-fiver',
+		'afternoon-update'
+	]
+	const { identityName } = originalItem;
+	const hasEmailRenderingTemplate = emailRenderingManagedNewsletters.includes(identityName);
 	const [subset, setSubset] = useState<FormDataRecord>({
 		category: item.category,
 		seriesTag: item.seriesTag,
@@ -66,13 +85,13 @@ export const RenderingOptionsForm = ({ originalItem }: Props) => {
 	};
 
 	const requestUpdate = async () => {
-		const renderingOptionsparseResult =
+		const renderingOptionsParseResult =
 			renderingOptionsSchema.safeParse(renderingOptions);
-		if (!renderingOptionsparseResult.success) {
+		if (!renderingOptionsParseResult.success) {
 			setErrorMessage('Cannot submit with validation errors');
 			return;
 		}
-		const parsedRenderingOptions = renderingOptionsparseResult.data;
+		const parsedRenderingOptions = renderingOptionsParseResult.data;
 
 		setWaitingForResponse(true);
 
@@ -118,9 +137,9 @@ export const RenderingOptionsForm = ({ originalItem }: Props) => {
 
 	return (
 		<>
+			{hasEmailRenderingTemplate && <Alert severity="error">The Rendering options for this Newsletter amd managed Email Rendering and cannot be changed in this tool. To make changes to <strong>{item.name}</strong>, please contact the development team</Alert>}
 			<Typography variant="h2">{item.name}</Typography>
 			<Typography variant="subtitle1">email-rendering settings</Typography>
-
 			<Typography variant="h3">Category and series tag</Typography>
 			<StateEditForm
 				formSchema={newsletterDataSchema.pick({

--- a/libs/newsletters-data-client/src/lib/newsletter-storage/s3-newsletter-storage.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/s3-newsletter-storage.ts
@@ -142,6 +142,7 @@ export class S3NewsletterStorage implements NewsletterStorage {
 				data: listWithoutMeta,
 			};
 		} catch (error) {
+			console.error(error);
 			return {
 				ok: false,
 				message: `failed to list newsletters`,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Rendering options set in the newsletter tool are ignored in favour of email-rendering hard-coded templates.
This change adds an array of the Newsletter identityNames which currently have a Template in email rendering. When editing the rendering options for a newsletter, we show a notification indicating that rendering options are not managed in the tool.


## How to test

Check that the notification appears for the newsletters that have a template and not for those that don't

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->


## Have we considered potential risks?

Not really a risk but a maintenance cost:
We considered making a call to email rendering and querying for the identityName. There were a couple of drawbacks to this:

1. The ids used in email rendering do hot always match the identityName so we would need to change the model in email Rendering
2. Adding in a network call introduces more opportunities for error states that we need to code for
3. Calls to email rendering can be sluggish where the Lambda is cold

The approach we have taken is to have a hard coded list in the tool. Our current view is that all / most newsletter will be migrated to data-driven / dynamically generated and that this list will reduce over time. So for this  short term problem, this approach  represents the right amount of effort. 

The key drawback is that we will have two lists to update

## Images

![Screenshot 2023-07-20 at 12 07 40](https://github.com/guardian/newsletters-nx/assets/3277259/717cc954-722c-449d-b70e-64a5bd125c39)
