### PR TITLE
Add navigate button nack to form

### DIFF
--- a/apps/newsletters-ui/src/app/components/views/RenderingOptionsView.tsx
+++ b/apps/newsletters-ui/src/app/components/views/RenderingOptionsView.tsx
@@ -21,6 +21,12 @@ export const RenderingOptionsView = () => {
 				<NavigateButton href="../" variant="outlined">
 					Back to List
 				</NavigateButton>
+				<NavigateButton
+					href={`/newsletters/edit/${matchedItem.identityName}`}
+					variant="outlined"
+				>
+					Edit Newsletter
+				</NavigateButton>
 			</Box>
 			<RenderingOptionsForm originalItem={matchedItem} />
 		</ContentWrapper>


### PR DESCRIPTION
## What does this change?

When a user edits rendering options, the only way to get back to the form (or to the form if they have come to rendering options directly) is to click the browser back button or to go via launched newsletters.

This fixes that by adding a nav button from the rendering options form

## How to test

Check the gif, look at the code, use your judgement

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

Always

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![navigate](https://github.com/guardian/newsletters-nx/assets/3277259/6f8ff882-459f-4905-b676-c003dd844cf6)
