### PR TITLE
remove usused column

### DIFF
--- a/apps/newsletters-ui/src/app/components/NewslettersTable.tsx
+++ b/apps/newsletters-ui/src/app/components/NewslettersTable.tsx
@@ -53,11 +53,6 @@ export const NewslettersTable = ({ newsletters }: Props) => {
 				Cell: formatCellDate,
 			},
 			{
-				Header: 'Cancelled',
-				accessor: 'cancellationTimeStamp',
-				Cell: formatCellDate,
-			},
-			{
 				Header: 'Status',
 				accessor: 'status',
 				sortType: 'basic',


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The `Cancelled` column in the launched newsletters view is never populated. There is no mechanism to populate it either - other than manually adding timestamps via the JSON editor. At present, it's not useful.

This change removes it.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Check it's gone

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

Oh yes

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![Screenshot 2023-07-21 at 08 12 04](https://github.com/guardian/newsletters-nx/assets/3277259/293f918f-f4ba-4cfc-8e21-db07ec85ec2c)
