### PR TITLE
Dynamic Image Signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ To run the UI and API locally with the default options:
 
 ### Run the app
 
+fetch some `frontend` credentials from [Janus](https://janus.gutools.co.uk/credentials?permissionId=frontend-dev&tzOffset=1) 
+
 `npm run dev`
 
 See the documentation for the [API](apps/newsletters-api/README.md) for the configuration options.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To run the UI and API locally with the default options:
 
 ### Run the app
 
-fetch some `frontend` credentials from [Janus](https://janus.gutools.co.uk/credentials?permissionId=frontend-dev&tzOffset=1) 
+fetch some `frontend` credentials from [Janus](https://janus.gutools.co.uk/credentials?permissionId=frontend-dev&tzOffset=1)
 
 `npm run dev`
 

--- a/apps/newsletters-api/env.local.example.txt
+++ b/apps/newsletters-api/env.local.example.txt
@@ -20,6 +20,9 @@ STAGE=DEV
 STACK=newsletters
 APP=newsletters-api
 
+# toggle for whether to use sign images
+ENABLE_DYNAMIC_IMAGE_SIGNING=true
+
 # toggle for whether to use the developer profile for local development
 USE_DEVELOPER_PROFILE=true
 

--- a/apps/newsletters-api/env.local.example.txt
+++ b/apps/newsletters-api/env.local.example.txt
@@ -20,7 +20,7 @@ STAGE=DEV
 STACK=newsletters
 APP=newsletters-api
 
-# toggle for whether to use dynamic image signing. This allow us to optionally sign uploader image assets for email rendering
+# toggle for whether to use dynamic image signing. This allow us to optionally sign uploaded image assets for email rendering
 ENABLE_DYNAMIC_IMAGE_SIGNING=false
 
 # toggle for whether to use the developer profile for local development

--- a/apps/newsletters-api/env.local.example.txt
+++ b/apps/newsletters-api/env.local.example.txt
@@ -20,8 +20,8 @@ STAGE=DEV
 STACK=newsletters
 APP=newsletters-api
 
-# toggle for whether to use sign images
-ENABLE_DYNAMIC_IMAGE_SIGNING=true
+# toggle for whether to use dynamic image signing. This allow us to optionally sign uploader image assets for email rendering
+ENABLE_DYNAMIC_IMAGE_SIGNING=false
 
 # toggle for whether to use the developer profile for local development
 USE_DEVELOPER_PROFILE=true

--- a/apps/newsletters-api/env.local.example.txt
+++ b/apps/newsletters-api/env.local.example.txt
@@ -16,7 +16,9 @@ S3_PROFILE=developerPlayground
 NEWSLETTERS_UI_SERVE=true
 
 # required to determine the environment the app in running in
-STAGE=local
+STAGE=DEV
+STACK=newsletters
+APP=newsletters-api
 
 # toggle for whether to use the developer profile for local development
 USE_DEVELOPER_PROFILE=true

--- a/apps/newsletters-api/src/apiDeploymentSettings.ts
+++ b/apps/newsletters-api/src/apiDeploymentSettings.ts
@@ -37,6 +37,13 @@ export const isServingReadWriteEndpoints = () => {
 	return undefinedAndNotProduction || isApiReadWrite;
 };
 
+export const isDynamicImageSigningEnabled = () => {
+	const { ENABLE_DYNAMIC_IMAGE_SIGNING } = process.env;
+	return (
+		ENABLE_DYNAMIC_IMAGE_SIGNING && ENABLE_DYNAMIC_IMAGE_SIGNING === 'true'
+	);
+};
+
 export const isServingReadEndpoints = () => {
 	const undefinedAndNotProduction = isUndefinedAndNotProduction(
 		process.env.NEWSLETTERS_API_READ,

--- a/apps/newsletters-api/src/apiDeploymentSettings.ts
+++ b/apps/newsletters-api/src/apiDeploymentSettings.ts
@@ -1,7 +1,7 @@
 /**
  * This file contains the settings for the deployment of the API.
  * The API is deployed in 3 ways.
- *  Serving the UI which can be check with isServingUI
+ *  Serving the UI which can be checked with isServingUI
  *  Serving the read endpoints which can be checked with isServingReadEndpoints
  *  Serving the read and write endpoints which can be checked with isServingReadWriteEndpoints
  * This is read in main.ts to enable/disable the endpoints

--- a/apps/newsletters-api/src/app/routes/newsletters.ts
+++ b/apps/newsletters-api/src/app/routes/newsletters.ts
@@ -5,7 +5,7 @@ import {
 	replaceNullWithUndefinedForUnknown,
 	transformDataToLegacyNewsletter,
 } from '@newsletters-nx/newsletters-data-client';
-import { isServingReadWriteEndpoints } from "../../apiDeploymentSettings";
+import { isDynamicImageSigningEnabled } from '../../apiDeploymentSettings';
 import { signImages } from '../../services/image/image-signer';
 import { newsletterStore } from '../../services/storage';
 import { getUserProfile } from '../get-user-profile';
@@ -38,7 +38,7 @@ export function registerReadNewsletterRoutes(app: FastifyInstance) {
 				.status(mapStorageFailureReasonToStatusCode(storageResponse.reason))
 				.send(makeErrorResponse(storageResponse.message));
 		}
-		if (!isServingReadWriteEndpoints()) {
+		if (isDynamicImageSigningEnabled()) {
 			const newsletterDataWithSignedImages = await Promise.all(
 				storageResponse.data.map(signImages),
 			);
@@ -59,7 +59,7 @@ export function registerReadNewsletterRoutes(app: FastifyInstance) {
 					.send(makeErrorResponse(storageResponse.message));
 			}
 
-			if (!isServingReadWriteEndpoints()) {
+			if (isDynamicImageSigningEnabled()) {
 				const newsletterDataWithSignedImages = await signImages(
 					storageResponse.data,
 				);

--- a/apps/newsletters-api/src/app/routes/newsletters.ts
+++ b/apps/newsletters-api/src/app/routes/newsletters.ts
@@ -6,7 +6,7 @@ import {
 	transformDataToLegacyNewsletter,
 } from '@newsletters-nx/newsletters-data-client';
 import { isDynamicImageSigningEnabled } from '../../apiDeploymentSettings';
-import { signImages } from '../../services/image/image-signer';
+import { signTemplateImages } from '../../services/image/image-signer';
 import { newsletterStore } from '../../services/storage';
 import { getUserProfile } from '../get-user-profile';
 import {
@@ -30,44 +30,52 @@ export function registerReadNewsletterRoutes(app: FastifyInstance) {
 		return storageResponse.data.map(transformDataToLegacyNewsletter);
 	});
 
-	app.get('/api/newsletters', async (req, res) => {
-		const storageResponse = await newsletterStore.list();
+	interface IQuerystring {
+		signImages: boolean;
+	}
 
-		if (!storageResponse.ok) {
-			return res
-				.status(mapStorageFailureReasonToStatusCode(storageResponse.reason))
-				.send(makeErrorResponse(storageResponse.message));
-		}
-		if (isDynamicImageSigningEnabled()) {
-			const newsletterDataWithSignedImages = await Promise.all(
-				storageResponse.data.map(signImages),
-			);
-			return makeSuccessResponse(newsletterDataWithSignedImages);
-		}
-		return makeSuccessResponse(storageResponse.data);
-	});
-
-	app.get<{ Params: { newsletterId: string } }>(
-		'/api/newsletters/:newsletterId',
+	app.get<{ Querystring: IQuerystring }>(
+		'/api/newsletters',
 		async (req, res) => {
-			const { newsletterId } = req.params;
-			const storageResponse = await newsletterStore.readByName(newsletterId);
+			const storageResponse = await newsletterStore.list();
 
 			if (!storageResponse.ok) {
 				return res
 					.status(mapStorageFailureReasonToStatusCode(storageResponse.reason))
 					.send(makeErrorResponse(storageResponse.message));
 			}
-
-			if (isDynamicImageSigningEnabled()) {
-				const newsletterDataWithSignedImages = await signImages(
-					storageResponse.data,
+			const { signImages } = req.query;
+			if (isDynamicImageSigningEnabled() && signImages) {
+				const newsletterDataWithSignedImages = await Promise.all(
+					storageResponse.data.map(signTemplateImages),
 				);
 				return makeSuccessResponse(newsletterDataWithSignedImages);
 			}
 			return makeSuccessResponse(storageResponse.data);
 		},
 	);
+
+	app.get<{
+		Params: { newsletterId: string };
+		Querystring: IQuerystring;
+	}>('/api/newsletters/:newsletterId', async (req, res) => {
+		const { newsletterId } = req.params;
+		const storageResponse = await newsletterStore.readByName(newsletterId);
+
+		if (!storageResponse.ok) {
+			return res
+				.status(mapStorageFailureReasonToStatusCode(storageResponse.reason))
+				.send(makeErrorResponse(storageResponse.message));
+		}
+		const { signImages } = req.query;
+		if (isDynamicImageSigningEnabled() && signImages) {
+			const newsletterDataWithSignedImages = await signTemplateImages(
+				storageResponse.data,
+			);
+			return makeSuccessResponse(newsletterDataWithSignedImages);
+		}
+		return makeSuccessResponse(storageResponse.data);
+	});
 }
 
 export function registerReadWriteNewsletterRoutes(app: FastifyInstance) {

--- a/apps/newsletters-api/src/app/routes/newsletters.ts
+++ b/apps/newsletters-api/src/app/routes/newsletters.ts
@@ -5,6 +5,7 @@ import {
 	replaceNullWithUndefinedForUnknown,
 	transformDataToLegacyNewsletter,
 } from '@newsletters-nx/newsletters-data-client';
+import { signImages } from '../../services/image/image-signer';
 import { newsletterStore } from '../../services/storage';
 import { getUserProfile } from '../get-user-profile';
 import {
@@ -35,8 +36,10 @@ export function registerReadNewsletterRoutes(app: FastifyInstance) {
 				.status(mapStorageFailureReasonToStatusCode(storageResponse.reason))
 				.send(makeErrorResponse(storageResponse.message));
 		}
-
-		return makeSuccessResponse(storageResponse.data);
+		const newsletterDataWithSignedImages = await Promise.all(
+			storageResponse.data.map(signImages),
+		);
+		return makeSuccessResponse(newsletterDataWithSignedImages);
 	});
 
 	app.get<{ Params: { newsletterId: string } }>(

--- a/apps/newsletters-api/src/services/configuration/config-service.ts
+++ b/apps/newsletters-api/src/services/configuration/config-service.ts
@@ -1,21 +1,4 @@
-import { SharedIniFileCredentials, SSM } from 'aws-sdk';
-
-const getSsmClient = () => {
-	const { STAGE, AWS_PROFILE } = process.env;
-
-	const shouldUseProfileCredentials = !!(STAGE && STAGE === 'DEV');
-	if (shouldUseProfileCredentials) {
-		const profile = AWS_PROFILE ?? 'frontend';
-
-		return new SSM({
-			region: 'eu-west-1',
-			credentials: new SharedIniFileCredentials({ profile }),
-		});
-	}
-	return new SSM({
-		region: 'eu-west-1',
-	});
-};
+import { getSsmClient } from './ssm-client-factory';
 
 type Config = Record<string, string>;
 
@@ -33,11 +16,11 @@ export const getConfigValue = async (
 	defaultValue?: string,
 ): Promise<string> => {
 	if (state?.[key]) {
-		console.info(`returning cached value for getConfigValue ${key}`);
+		console.log(`returning cached value for getConfigValue ${key}`);
 		return state[key] as string;
 	}
 
-	console.info(
+	console.log(
 		`getConfigValue for ${key}, defaultValue: ${defaultValue ?? 'undefined'}`,
 	);
 	const ssmClient = getSsmClient();

--- a/apps/newsletters-api/src/services/configuration/config-service.ts
+++ b/apps/newsletters-api/src/services/configuration/config-service.ts
@@ -32,11 +32,8 @@ export const getConfigValue = async (
 	key: string,
 	defaultValue?: string,
 ): Promise<string> => {
-
 	if (state?.[key]) {
-		console.info(
-			`returning cached value for getConfigValue ${key}`
-		);
+		console.info(`returning cached value for getConfigValue ${key}`);
 		return state[key] as string;
 	}
 
@@ -56,7 +53,7 @@ export const getConfigValue = async (
 		state = {
 			...state,
 			[key]: value.Parameter.Value,
-		}
+		};
 		return value.Parameter.Value;
 	}
 	if (defaultValue) {

--- a/apps/newsletters-api/src/services/configuration/config-service.ts
+++ b/apps/newsletters-api/src/services/configuration/config-service.ts
@@ -1,0 +1,50 @@
+import { SharedIniFileCredentials, SSM } from 'aws-sdk';
+
+const getSsmClient = () => {
+	const { STAGE, AWS_PROFILE } = process.env;
+
+	const shouldUseProfileCredentials = !!(STAGE && STAGE === 'DEV');
+	if (shouldUseProfileCredentials) {
+		const profile = AWS_PROFILE ?? 'frontend';
+
+		return new SSM({
+			region: 'eu-west-1',
+			credentials: new SharedIniFileCredentials({ profile }),
+		});
+	}
+	return new SSM({
+		region: 'eu-west-1',
+	});
+};
+
+const getPath = (key: string) => {
+	const { STAGE, STACK, APP } = process.env;
+	if (!STAGE || !STACK || !APP) {
+		throw new Error('Missing environment variables');
+	}
+	return `/${STAGE}/${STACK}/${APP}/${key}`;
+};
+export const getConfigValue = async (
+	key: string,
+	defaultValue?: string,
+): Promise<string> => {
+	console.info(
+		`getConfigValue for ${key}, defaultValue: ${defaultValue ?? 'undefined'}`,
+	);
+	const ssmClient = getSsmClient();
+	const path = getPath(key);
+	console.info(`path: ${path}`);
+	const value = await ssmClient
+		.getParameter({
+			Name: path,
+			WithDecryption: true,
+		})
+		.promise();
+	if (value.Parameter?.Value) {
+		return value.Parameter.Value;
+	}
+	if (defaultValue) {
+		return defaultValue;
+	}
+	throw new Error(`Config value for ${key} not found`);
+};

--- a/apps/newsletters-api/src/services/configuration/ssm-client-factory.ts
+++ b/apps/newsletters-api/src/services/configuration/ssm-client-factory.ts
@@ -1,0 +1,19 @@
+import { SharedIniFileCredentials, SSM } from 'aws-sdk';
+
+export const getSsmClient = () => {
+	const { STAGE, AWS_PROFILE } = process.env;
+
+	const shouldUseProfileCredentials = !!(STAGE && STAGE === 'DEV');
+
+	if (shouldUseProfileCredentials) {
+		const profile = AWS_PROFILE ?? 'frontend';
+
+		return new SSM({
+			region: 'eu-west-1',
+			credentials: new SharedIniFileCredentials({ profile }),
+		});
+	}
+	return new SSM({
+		region: 'eu-west-1',
+	});
+};

--- a/apps/newsletters-api/src/services/image/image-signer.ts
+++ b/apps/newsletters-api/src/services/image/image-signer.ts
@@ -27,12 +27,11 @@ export const signImage = async (
 export const signImages = async (
 	newsletterData: NewsletterDataWithoutMeta,
 ): Promise<NewsletterData> => {
-	const isAlreadySigned = (imageUrl: string): boolean =>
-		imageUrl.includes('dpr='); //todo: improve this check
+
 	let signedImages = {};
-	const { renderingOptions } = newsletterData;
+	const {renderingOptions} = newsletterData;
 	if (!renderingOptions) return newsletterData;
-	const { mainBannerUrl, subheadingBannerUrl, darkSubheadingBannerUrl } =
+	const {mainBannerUrl, subheadingBannerUrl, darkSubheadingBannerUrl} =
 		renderingOptions;
 
 	for await (const imageUrl of [
@@ -41,12 +40,12 @@ export const signImages = async (
 		darkSubheadingBannerUrl,
 	]) {
 		if (imageUrl) {
-			signedImages = isAlreadySigned(imageUrl)
-				? { ...signedImages, mainBannerUrl }
-				: {
-						...signedImages,
-						mainBannerUrl: await signImage(imageUrl, { dpr: 2, width: 650 }),
-				  };
+			signedImages = shouldSignImage(imageUrl)
+				? {
+					...signedImages,
+					mainBannerUrl: await signImage(imageUrl, {dpr: 2, width: 650}),
+				}
+				: {...signedImages, mainBannerUrl};
 		}
 	}
 	return {
@@ -57,3 +56,9 @@ export const signImages = async (
 		},
 	};
 };
+
+const supportedSigningDomains = ['uploads.guim.co.uk'];
+export const shouldSignImage = (imageUrl: string): boolean => {
+	const asUrl = new URL(imageUrl);
+	return supportedSigningDomains.includes(asUrl.hostname);
+}

--- a/apps/newsletters-api/src/services/image/image-signer.ts
+++ b/apps/newsletters-api/src/services/image/image-signer.ts
@@ -1,0 +1,75 @@
+import { format } from '@guardian/image';
+import type {
+	NewsletterData,
+	NewsletterDataWithoutMeta,
+} from '@newsletters-nx/newsletters-data-client';
+import { getConfigValue } from '../configuration/config-service';
+
+interface Props {
+	dpr?: number;
+	width: number;
+}
+
+export const signImage = async (
+	src: string,
+	{ width = 650, dpr = 2 }: Props,
+): Promise<string> => {
+	const salt = await getConfigValue('imageSalt');
+	if (!salt) throw new Error(`imageSalt not found`);
+
+	return format(src, salt, {
+		quality: 85,
+		dpr,
+		width,
+	});
+};
+
+export const signImages = async (
+	newsletterData: NewsletterDataWithoutMeta,
+): Promise<NewsletterData> => {
+	const isAlreadySigned = (imageUrl: string): boolean =>
+		imageUrl.includes('dpr=');
+	let signedImages = {};
+	const { renderingOptions } = newsletterData;
+	if (!renderingOptions) return newsletterData;
+	const { mainBannerUrl, subheadingBannerUrl, darkSubheadingBannerUrl } =
+		renderingOptions;
+	if (mainBannerUrl) {
+		signedImages = isAlreadySigned(mainBannerUrl)
+			? { ...signedImages, mainBannerUrl }
+			: {
+					...signedImages,
+					mainBannerUrl: await signImage(mainBannerUrl, { dpr: 2, width: 650 }),
+			  };
+	}
+	if (subheadingBannerUrl) {
+		signedImages = isAlreadySigned(subheadingBannerUrl)
+			? { ...signedImages, subheadingBannerUrl }
+			: {
+					...signedImages,
+					subheadingBannerUrl: await signImage(subheadingBannerUrl, {
+						dpr: 2,
+						width: 650,
+					}),
+			  };
+	}
+	if (darkSubheadingBannerUrl) {
+		signedImages = isAlreadySigned(darkSubheadingBannerUrl)
+			? { ...signedImages, darkSubheadingBannerUrl }
+			: {
+					...signedImages,
+					darkSubheadingBannerUrl: await signImage(darkSubheadingBannerUrl, {
+						dpr: 2,
+						width: 650,
+					}),
+			  };
+	}
+
+	return {
+		...newsletterData,
+		renderingOptions: {
+			...renderingOptions,
+			...signedImages,
+		},
+	};
+};

--- a/apps/newsletters-api/src/services/image/image-signer.ts
+++ b/apps/newsletters-api/src/services/image/image-signer.ts
@@ -24,28 +24,28 @@ export const signImage = async (
 	});
 };
 
-export const signImages = async (
+export const signTemplateImages = async (
 	newsletterData: NewsletterDataWithoutMeta,
 ): Promise<NewsletterData> => {
-
 	let signedImages = {};
-	const {renderingOptions} = newsletterData;
+	const { renderingOptions } = newsletterData;
 	if (!renderingOptions) return newsletterData;
-	const {mainBannerUrl, subheadingBannerUrl, darkSubheadingBannerUrl} =
+	const { mainBannerUrl, subheadingBannerUrl, darkSubheadingBannerUrl } =
 		renderingOptions;
-
-	for await (const imageUrl of [
-		mainBannerUrl,
-		subheadingBannerUrl,
-		darkSubheadingBannerUrl,
-	]) {
+	const imageKeyValueMapping = [
+		{ key: 'mainBannerUrl', imageUrl: mainBannerUrl },
+		{ key: 'subheadingBannerUrl', imageUrl: subheadingBannerUrl },
+		{ key: 'darkSubheadingBannerUrl', imageUrl: darkSubheadingBannerUrl },
+	];
+	for await (const image of imageKeyValueMapping) {
+		const { key, imageUrl } = image;
 		if (imageUrl) {
 			signedImages = shouldSignImage(imageUrl)
 				? {
-					...signedImages,
-					mainBannerUrl: await signImage(imageUrl, {dpr: 2, width: 650}),
-				}
-				: {...signedImages, mainBannerUrl};
+						...signedImages,
+						[key]: await signImage(imageUrl, { dpr: 2, width: 650 }),
+				  }
+				: { ...signedImages, [key]: imageUrl };
 		}
 	}
 	return {
@@ -61,4 +61,4 @@ const supportedSigningDomains = ['uploads.guim.co.uk'];
 export const shouldSignImage = (imageUrl: string): boolean => {
 	const asUrl = new URL(imageUrl);
 	return supportedSigningDomains.includes(asUrl.hostname);
-}
+};

--- a/apps/newsletters-api/src/services/image/image-signer.ts
+++ b/apps/newsletters-api/src/services/image/image-signer.ts
@@ -28,43 +28,27 @@ export const signImages = async (
 	newsletterData: NewsletterDataWithoutMeta,
 ): Promise<NewsletterData> => {
 	const isAlreadySigned = (imageUrl: string): boolean =>
-		imageUrl.includes('dpr=');
+		imageUrl.includes('dpr='); //todo: improve this check
 	let signedImages = {};
 	const { renderingOptions } = newsletterData;
 	if (!renderingOptions) return newsletterData;
 	const { mainBannerUrl, subheadingBannerUrl, darkSubheadingBannerUrl } =
 		renderingOptions;
-	if (mainBannerUrl) {
-		signedImages = isAlreadySigned(mainBannerUrl)
-			? { ...signedImages, mainBannerUrl }
-			: {
-					...signedImages,
-					mainBannerUrl: await signImage(mainBannerUrl, { dpr: 2, width: 650 }),
-			  };
-	}
-	if (subheadingBannerUrl) {
-		signedImages = isAlreadySigned(subheadingBannerUrl)
-			? { ...signedImages, subheadingBannerUrl }
-			: {
-					...signedImages,
-					subheadingBannerUrl: await signImage(subheadingBannerUrl, {
-						dpr: 2,
-						width: 650,
-					}),
-			  };
-	}
-	if (darkSubheadingBannerUrl) {
-		signedImages = isAlreadySigned(darkSubheadingBannerUrl)
-			? { ...signedImages, darkSubheadingBannerUrl }
-			: {
-					...signedImages,
-					darkSubheadingBannerUrl: await signImage(darkSubheadingBannerUrl, {
-						dpr: 2,
-						width: 650,
-					}),
-			  };
-	}
 
+	for await (const imageUrl of [
+		mainBannerUrl,
+		subheadingBannerUrl,
+		darkSubheadingBannerUrl,
+	]) {
+		if (imageUrl) {
+			signedImages = isAlreadySigned(imageUrl)
+				? { ...signedImages, mainBannerUrl }
+				: {
+						...signedImages,
+						mainBannerUrl: await signImage(imageUrl, { dpr: 2, width: 650 }),
+				  };
+		}
+	}
 	return {
 		...newsletterData,
 		renderingOptions: {

--- a/apps/newsletters-api/src/services/storage/s3-client-factory.ts
+++ b/apps/newsletters-api/src/services/storage/s3-client-factory.ts
@@ -4,7 +4,7 @@ import { fromIni } from '@aws-sdk/credential-providers';
 export const getS3Client = () => {
 	const { STAGE, AWS_PROFILE } = process.env;
 
-	const shouldUseProfileCredentials = !!(STAGE && STAGE === 'local');
+	const shouldUseProfileCredentials = !!(STAGE && STAGE === 'DEV');
 	if (shouldUseProfileCredentials) {
 		const profile = AWS_PROFILE ?? 'developerPlayground';
 		return new S3Client({

--- a/apps/newsletters-ui/src/app/components/StateEditForm.tsx
+++ b/apps/newsletters-ui/src/app/components/StateEditForm.tsx
@@ -31,12 +31,7 @@ export const StateEditForm = ({
 	};
 
 	return (
-		<Box
-			padding={1}
-			component={Paper}
-			marginBottom={2.5}
-			elevation={2}
-		>
+		<Box padding={1} component={Paper} marginBottom={2.5} elevation={2}>
 			<Typography variant="overline" component={'legend'}>
 				{formSchema.description}
 			</Typography>

--- a/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
+++ b/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
@@ -2108,7 +2108,7 @@ ExecStart=/usr/bin/node /opt/newsletters-api/dist/apps/newsletters-api/index.cjs
 Restart=on-failure
 Environment=STAGE=TEST
 Environment=STACK=newsletters
-Environment=APP=undefined
+Environment=APP=newsletters-api
 Environment=NEWSLETTERS_API_READ=true
 Environment=NEWSLETTERS_UI_SERVE=false
 Environment=NEWSLETTER_BUCKET_NAME=",
@@ -2285,7 +2285,7 @@ ExecStart=/usr/bin/node /opt/newsletters-tool/dist/apps/newsletters-api/index.cj
 Restart=on-failure
 Environment=STAGE=TEST
 Environment=STACK=newsletters
-Environment=APP=undefined
+Environment=APP=newsletters-tool
 Environment=NEWSLETTERS_API_READ=false
 Environment=NEWSLETTERS_UI_SERVE=true
 Environment=NEWSLETTER_BUCKET_NAME=",

--- a/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
+++ b/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
@@ -2107,6 +2107,8 @@ User=ubuntu
 ExecStart=/usr/bin/node /opt/newsletters-api/dist/apps/newsletters-api/index.cjs
 Restart=on-failure
 Environment=STAGE=TEST
+Environment=STACK=newsletters
+Environment=APP=undefined
 Environment=NEWSLETTERS_API_READ=true
 Environment=NEWSLETTERS_UI_SERVE=false
 Environment=NEWSLETTER_BUCKET_NAME=",
@@ -2282,6 +2284,8 @@ User=ubuntu
 ExecStart=/usr/bin/node /opt/newsletters-tool/dist/apps/newsletters-api/index.cjs
 Restart=on-failure
 Environment=STAGE=TEST
+Environment=STACK=newsletters
+Environment=APP=undefined
 Environment=NEWSLETTERS_API_READ=false
 Environment=NEWSLETTERS_UI_SERVE=true
 Environment=NEWSLETTER_BUCKET_NAME=",

--- a/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
+++ b/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
@@ -2122,6 +2122,7 @@ Environment=USER_PERMISSIONS='",
                     "Ref": "UserPermissions",
                   },
                   "'
+Environment=ENABLE_DYNAMIC_IMAGE_SIGNING=true
 [Install]
 WantedBy=multi-user.target
 EOL
@@ -2299,6 +2300,7 @@ Environment=USER_PERMISSIONS='",
                     "Ref": "UserPermissions",
                   },
                   "'
+Environment=ENABLE_DYNAMIC_IMAGE_SIGNING=false
 [Install]
 WantedBy=multi-user.target
 EOL

--- a/cdk/lib/newsletters-tool.ts
+++ b/cdk/lib/newsletters-tool.ts
@@ -74,6 +74,8 @@ User=ubuntu
 ExecStart=/usr/bin/node /opt/${app}/dist/apps/newsletters-api/index.cjs
 Restart=on-failure
 Environment=STAGE=${this.stage}
+Environment=STACK=${this.stack}
+Environment=APP=${this.app}
 Environment=NEWSLETTERS_API_READ=${readOnly ? 'true' : 'false'}
 Environment=NEWSLETTERS_UI_SERVE=${readOnly ? 'false' : 'true'}
 Environment=NEWSLETTER_BUCKET_NAME=${bucketName}

--- a/cdk/lib/newsletters-tool.ts
+++ b/cdk/lib/newsletters-tool.ts
@@ -75,7 +75,7 @@ ExecStart=/usr/bin/node /opt/${app}/dist/apps/newsletters-api/index.cjs
 Restart=on-failure
 Environment=STAGE=${this.stage}
 Environment=STACK=${this.stack}
-Environment=APP=${this.app}
+Environment=APP=${app}
 Environment=NEWSLETTERS_API_READ=${readOnly ? 'true' : 'false'}
 Environment=NEWSLETTERS_UI_SERVE=${readOnly ? 'false' : 'true'}
 Environment=NEWSLETTER_BUCKET_NAME=${bucketName}

--- a/cdk/lib/newsletters-tool.ts
+++ b/cdk/lib/newsletters-tool.ts
@@ -81,6 +81,7 @@ Environment=NEWSLETTERS_UI_SERVE=${readOnly ? 'false' : 'true'}
 Environment=NEWSLETTER_BUCKET_NAME=${bucketName}
 Environment=USE_IN_MEMORY_STORAGE=false
 Environment=USER_PERMISSIONS='${processJSONString(userPermissions)}'
+Environment=ENABLE_DYNAMIC_IMAGE_SIGNING=${readOnly ? 'true' : 'false'}
 [Install]
 WantedBy=multi-user.target
 EOL`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
 				"@emotion/react": "^11.10.5",
 				"@emotion/styled": "^11.10.5",
 				"@fastify/static": "^6.9.0",
+				"@guardian/image": "^1.1.0",
 				"@guardian/source-foundations": "^8.0.0",
 				"@mui/icons-material": "^5.11.16",
 				"@mui/material": "^5.11.10",
@@ -3904,6 +3905,14 @@
 				"eslint": ">=7.0.0"
 			}
 		},
+		"node_modules/@guardian/image": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@guardian/image/-/image-1.1.0.tgz",
+			"integrity": "sha512-EiBcBwpe1/HECBZP4BbRcBNR1SL2glrhYFsStWNCJ7rn9ixoo7+WoT23k3FSA5pqU+VVkjVEd7q6Qvaq9+hawg==",
+			"dependencies": {
+				"md5": "^2.2.1"
+			}
+		},
 		"node_modules/@guardian/prettier": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@guardian/prettier/-/prettier-2.1.5.tgz",
@@ -6209,84 +6218,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/@mui/lab": {
-			"version": "5.0.0-alpha.137",
-			"resolved": "https://registry.npmjs.org/@mui/lab/-/lab-5.0.0-alpha.137.tgz",
-			"integrity": "sha512-bHfcfti9/GnB657QpTdlK1fc9gjkP3SC+NrXyb9NCr0rT5Cq7TEkBGXyY5wGUSCyHR3CrMvchkIsfG5sH/NJ9A==",
-			"dependencies": {
-				"@babel/runtime": "^7.22.6",
-				"@mui/base": "5.0.0-beta.8",
-				"@mui/system": "^5.14.1",
-				"@mui/types": "^7.2.4",
-				"@mui/utils": "^5.14.1",
-				"clsx": "^1.2.1",
-				"prop-types": "^15.8.1",
-				"react-is": "^18.2.0"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/mui"
-			},
-			"peerDependencies": {
-				"@emotion/react": "^11.5.0",
-				"@emotion/styled": "^11.3.0",
-				"@mui/material": "^5.0.0",
-				"@types/react": "^17.0.0 || ^18.0.0",
-				"react": "^17.0.0 || ^18.0.0",
-				"react-dom": "^17.0.0 || ^18.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@emotion/react": {
-					"optional": true
-				},
-				"@emotion/styled": {
-					"optional": true
-				},
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@mui/lab/node_modules/@mui/base": {
-			"version": "5.0.0-beta.8",
-			"resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.8.tgz",
-			"integrity": "sha512-b4vVjMZx5KzzEMf4arXKoeV5ZegAMOoPwoy1vfUBwhvXc2QtaaAyBp50U7OA2L06Leubc1A+lEp3eqwZoFn87g==",
-			"dependencies": {
-				"@babel/runtime": "^7.22.6",
-				"@emotion/is-prop-valid": "^1.2.1",
-				"@mui/types": "^7.2.4",
-				"@mui/utils": "^5.14.1",
-				"@popperjs/core": "^2.11.8",
-				"clsx": "^1.2.1",
-				"prop-types": "^15.8.1",
-				"react-is": "^18.2.0"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/mui"
-			},
-			"peerDependencies": {
-				"@types/react": "^17.0.0 || ^18.0.0",
-				"react": "^17.0.0 || ^18.0.0",
-				"react-dom": "^17.0.0 || ^18.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@mui/lab/node_modules/react-is": {
-			"version": "18.2.0",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
 		},
 		"node_modules/@mui/material": {
 			"version": "5.11.10",
@@ -11214,6 +11145,14 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/check-error": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -11665,6 +11604,14 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/css": {
@@ -21205,6 +21152,21 @@
 			"dependencies": {
 				"tmpl": "1.0.5"
 			}
+		},
+		"node_modules/md5": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+			"integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+			"dependencies": {
+				"charenc": "0.0.2",
+				"crypt": "0.0.2",
+				"is-buffer": "~1.1.6"
+			}
+		},
+		"node_modules/md5/node_modules/is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"node_modules/mdast-util-definitions": {
 			"version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"@emotion/react": "^11.10.5",
 		"@emotion/styled": "^11.10.5",
 		"@fastify/static": "^6.9.0",
+		"@guardian/image": "^1.1.0",
 		"@guardian/source-foundations": "^8.0.0",
 		"@mui/icons-material": "^5.11.16",
 		"@mui/material": "^5.11.10",


### PR DESCRIPTION
## What does this change?

Allows dynamic signing of unsigned images allow us to direct users to the s3 uploader and for us to return a signed image via the readonly api. 

This also adds a config service which will fetch values from SSM. Values have been set for all environments both for the tool and api. The config service adds the values to state to prevent repeated calls to SSM

**EDIT** - the API will return the actual unsigned URLs by default. If the `ENABLE_DYNAMIC_IMAGE_SIGNING` env var is set to true, the API can be asked for the data with the supported images signed using a query parameter:
http://localhost:3000/api/newsletters?signImages=true

## How to test

Checkout the code and run the setup script to add the appropriate environment variables to your .env.local (**remember this will overwrite your config - backup if you have anything non default defined**)

Tested locally & in CODE

```bash
./scripts/setup.sh
```

- To test locally, update the `ENABLE_DYNAMIC_IMAGE_SIGNING` value to true. It is set to false by default as this is its setting in the tool. The readonly api is set to dynamically sign images. 
- Upload an asset in s3 uploader and copy the vanity url
- Run the Newsletter tool and edit the rending options of a launched newsletter
- check the api response (**EDIT**  with the query param added, ie http://localhost:3000/api/newsletters/**{identity-name}**?signImages=true )for the Newsletter after adding the image - you should see that the image has been signed 


## Have we considered potential risks?

Signing will only work for images served from Fastly (uploads.guim.co.uk) - there is logic in place to ignore all other hosts. This might need refining

### Images

#### original data
<img width="719" alt="Screenshot 2023-07-25 at 21 29 14" src="https://github.com/guardian/newsletters-nx/assets/3277259/80473a24-bc1b-4f3f-86a4-e3c804a8a47d">

#### api response with "signImages=true"
<img width="751" alt="Screenshot 2023-07-25 at 21 27 59" src="https://github.com/guardian/newsletters-nx/assets/3277259/3e326d8b-c60b-48ae-b2ec-eebba61701aa">
