### PR TITLE
update schema for dark theme readmore's

### DIFF
--- a/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
@@ -57,6 +57,10 @@ export const renderingOptionsSchema = z.object({
 					subheading: nonEmptyString().describe('read more subheading'),
 					wording: nonEmptyString().describe('read more wording'),
 					url: z.string().url().describe('read more url'),
+					isDarkTheme: z
+						.boolean()
+						.optional()
+						.describe('use dark theme for section'),
 				})
 				.describe('Read more section configuration'),
 		)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds an `isDarkTheme` property to the `RenderingOptions.readMoreSections` to support the email rendering change here: https://github.com/guardian/email-rendering/pull/344

## How to test

Try the edit rendering options form and the set rendering options wizards to see the UI updated to use the new property.

Use the USE_LOCAL_EMAIL_RENDERING env var and have email rendering locally (on port 3010, with the branch  above) to see the live preview with dark theme readmore sections.

## How can we measure success?

Users can use the new option

## Have we considered potential risks?

Should be safe - the schema change is an optional property on an optional object on the data model. No existing newsletters will fail validation.

## Images

<img width="964" alt="Screenshot 2023-07-28 at 14 24 21" src="https://github.com/guardian/newsletters-nx/assets/30567854/20b6abb3-deb4-4ceb-be41-8488baf4f2a2">

<img width="850" alt="Screenshot 2023-07-28 at 14 18 40" src="https://github.com/guardian/newsletters-nx/assets/30567854/8759c63a-50be-4435-8682-bf288a428184">
