### PR TITLE
footer email and onward path

### DIFF
--- a/apps/newsletters-api/static/newsletters.local.json
+++ b/apps/newsletters-api/static/newsletters.local.json
@@ -70,10 +70,16 @@
 		"renderingOptions": {
 			"displayDate": false,
 			"displayStandfirst": false,
-			"contactEmail": "veniam@example.com",
 			"displayImageCaptions": true,
 			"mainBannerUrl": "https://assets.guim.co.uk/images/email/banners/3aaee2fd94b67953a15b4e7a795c09b8/generic.png",
-			"darkSubheadingBannerUrl": "https://i.guim.co.uk/img/uploads/2022/10/21/default-template-sub-banner.png?dpr=2&quality=100&width=600&s=41c1744d1559a535e7b7cc77f8c6e037"
+			"darkSubheadingBannerUrl": "https://i.guim.co.uk/img/uploads/2022/10/21/default-template-sub-banner.png?dpr=2&quality=100&width=600&s=41c1744d1559a535e7b7cc77f8c6e037",
+			"readMoreSections": [
+				{
+					"subheading": "section 32",
+					"wording": "more about this",
+					"onwardPath": "/uk/tv-and-radio"
+				}
+			]
 		}
 	},
 	{
@@ -112,7 +118,14 @@
 			"displayStandfirst": true,
 			"contactEmail": "necessitatibus@example.com",
 			"displayImageCaptions": true,
-			"mainBannerUrl": "https://i.guim.co.uk/img/uploads/2022/10/21/default-newsletter-main-banner.png?dpr=2&quality=100&width=600&s=618cf82b457a343bf56650ad7acaad59"
+			"mainBannerUrl": "https://i.guim.co.uk/img/uploads/2022/10/21/default-newsletter-main-banner.png?dpr=2&quality=100&width=600&s=618cf82b457a343bf56650ad7acaad59",
+			"readMoreSections": [
+				{
+					"subheading": "section 32",
+					"wording": "more about this",
+					"url": "https://www.theguardian.com/uk/tv-and-radio"
+				}
+			]
 		}
 	},
 	{

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
@@ -5,8 +5,8 @@ import type {
 	ThrasherOptions,
 } from '@newsletters-nx/newsletters-data-client';
 import {
+	dataCollectionRenderingOptionsSchema,
 	dataCollectionSchema,
-	renderingOptionsSchema,
 	thrasherOptionsSchema,
 } from '@newsletters-nx/newsletters-data-client';
 
@@ -15,7 +15,8 @@ const pickAndPrefixRenderingOption = (
 ): ZodObject<ZodRawShape> => {
 	const shape: ZodRawShape = {};
 	fieldKeys.forEach((key) => {
-		shape[`renderingOptions.${key}`] = renderingOptionsSchema.shape[key];
+		shape[`renderingOptions.${key}`] =
+			dataCollectionRenderingOptionsSchema.shape[key];
 	});
 	return z.object(shape);
 };

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/footerLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/footerLayout.ts
@@ -14,7 +14,7 @@ const markdownTemplate = `
 
 What email address would you like to display in the footer of **{{name}}**?
 
-For example: newsletters@theguardian.com
+If you leave this blank, the default contact email of **"newsletters@theguardian.com"** will be used.
 
 ![Email footer](https://i.guim.co.uk/img/uploads/2023/03/15/Email_address_contact.png?quality=85&dpr=2&width=300&s=98ce6a07791b0bfb45f2df9c732ea1d2)
 

--- a/libs/newsletters-data-client/src/lib/draft-newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/draft-newsletter-data-type.ts
@@ -4,7 +4,9 @@ import { metaDataSchema } from './meta-data-type';
 import {
 	newsletterDataSchema,
 	onlineArticleSchema,
+	readMoreSectionSchema,
 	regionFocusEnumSchema,
+	renderingOptionsSchema,
 } from './newsletter-data-type';
 import { nonEmptyString } from './zod-helpers';
 
@@ -31,6 +33,33 @@ export function isDraftNewsletterDataWithMeta(
 		.extend({ meta: metaDataSchema })
 		.safeParse(subject).success;
 }
+
+/**
+ * A version of the renderingOptionsSchema
+ * for use when defining new drafts.
+ *
+ * In this version ,the readMoreSections require
+ * the `onwardPath` and  exclude the `url`.
+ * both are optional in the 'real 'schema.
+ */
+export const dataCollectionRenderingOptionsSchema =
+	renderingOptionsSchema.merge(
+		z.object({
+			readMoreSections: readMoreSectionSchema
+				.pick({
+					subheading: true,
+					wording: true,
+					onwardPath: true,
+				})
+				.merge(
+					z.object({
+						onwardPath: nonEmptyString(),
+					}),
+				)
+				.array()
+				.optional(),
+		}),
+	);
 
 /**
  * The schema for collecting data for new drafts.

--- a/libs/newsletters-data-client/src/lib/draft-newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/draft-newsletter-data-type.ts
@@ -8,7 +8,7 @@ import {
 	regionFocusEnumSchema,
 	renderingOptionsSchema,
 } from './newsletter-data-type';
-import { nonEmptyString } from './zod-helpers';
+import { nonEmptyString, urlPathString } from './zod-helpers';
 
 export const draftNewsletterDataSchema = newsletterDataSchema.deepPartial();
 export type DraftNewsletterData = z.infer<typeof draftNewsletterDataSchema>;
@@ -53,7 +53,7 @@ export const dataCollectionRenderingOptionsSchema =
 				})
 				.merge(
 					z.object({
-						onwardPath: nonEmptyString(),
+						onwardPath: urlPathString(),
 					}),
 				)
 				.array()

--- a/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
@@ -32,6 +32,15 @@ export const singleThrasherLocation = z
 	.optional();
 export type SingleThrasherLocation = z.infer<typeof singleThrasherLocation>;
 
+export const readMoreSectionSchema = z
+	.object({
+		subheading: nonEmptyString().describe('read more subheading'),
+		wording: nonEmptyString().describe('read more wording'),
+		url: z.string().url().describe('read more url'),
+		onwardPath: z.string().optional(),
+	})
+	.describe('Read more section configuration');
+
 export const renderingOptionsSchema = z.object({
 	displayDate: z.boolean().describe('Display date?'),
 	displayStandfirst: z.boolean().describe('Display standfirst?'),
@@ -51,15 +60,7 @@ export const renderingOptionsSchema = z.object({
 		.optional()
 		.describe('Dark theme subheading'),
 	readMoreSections: z
-		.array(
-			z
-				.object({
-					subheading: nonEmptyString().describe('read more subheading'),
-					wording: nonEmptyString().describe('read more wording'),
-					url: z.string().url().describe('read more url'),
-				})
-				.describe('Read more section configuration'),
-		)
+		.array(readMoreSectionSchema)
 		.optional()
 		.describe('The configuration for read more sections'),
 

--- a/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
@@ -5,6 +5,7 @@ import {
 	kebabOrUnderscoreCasedString,
 	nonEmptyString,
 	underscoreCasedString,
+	urlPathString,
 } from './zod-helpers';
 
 export const themeEnumSchema = z.enum([
@@ -37,7 +38,7 @@ export const readMoreSectionSchema = z
 		subheading: nonEmptyString().describe('read more subheading'),
 		wording: nonEmptyString().describe('read more wording'),
 		url: z.string().url().describe('read more url'),
-		onwardPath: z.string().optional(),
+		onwardPath: urlPathString().optional(),
 	})
 	.describe('Read more section configuration');
 

--- a/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
@@ -35,7 +35,7 @@ export type SingleThrasherLocation = z.infer<typeof singleThrasherLocation>;
 export const renderingOptionsSchema = z.object({
 	displayDate: z.boolean().describe('Display date?'),
 	displayStandfirst: z.boolean().describe('Display standfirst?'),
-	contactEmail: z.string().email().describe('Contact email'),
+	contactEmail: z.string().email().optional().describe('Contact email'),
 	displayImageCaptions: z.boolean().describe('Display image captions?'),
 	paletteOverride: themeEnumSchema.optional().describe('Palette override'),
 	linkListSubheading: z

--- a/libs/newsletters-data-client/src/lib/zod-helpers/schema-helpers.ts
+++ b/libs/newsletters-data-client/src/lib/zod-helpers/schema-helpers.ts
@@ -16,5 +16,13 @@ export const kebabOrUnderscoreCasedString = () =>
 		.string()
 		.regex(
 			/^[a-z0-9]+(?:[-_][a-z0-9]+)*$/,
-			'Must numbers or lower-case letters only, separated by dashes or underscores',
+			'Must containt numbers or lower-case letters only, separated by dashes or underscores',
+		);
+
+export const urlPathString = () =>
+	z
+		.string()
+		.regex(
+			/^(?:[/][a-zA-Z0-9-]+)*$/,
+			'Must be collection of componets starting with slashes then containing only letters, dashes or numbers',
 		);


### PR DESCRIPTION
## What does this change?

 - Changes the schema for `renderingOptions`, so the `contactEmail` is optional and   for `readMoreSections`:
   - the "url" field is optional
   - there is a new optional "onwardPath" field (with regex validation)
 - Derives a "data collection" version of the `renderingOptions` schema, so that in `readMoreSections` for new drafts: 
   - the "url" field is excluded
   - the "onwardPath" field is required

This will allow us to change the schema used for live data without invalidating any of the existing newsletters, and also collect the 'correct' data for any new newsletters.

After this change is merged, we can:
 - update the existing data on PROD and CODE to replace the  `renderingOptions.readMoreSections[].url` values with `renderingOptions.readMoreSections[].onwardPath` values, using a custom update script in  https://github.com/guardian/newsletters-migration-tool
 - do another PR in this repo to remove `URL` and make `onwardOath` required 

## How to test

functionality - on the rendering options wizard (eg http://localhost:4200/drafts/newsletter-data-rendering/7009), the 'Read More Sections' step will prompt the user to input the 'onwardPath'. With this value populated, a completed draft can still be launched.

data integrity - deploying this branch to CODE should not change the CODE data response - IE no missing newsletters.


## How can we measure success?

The updated data model for `renderingOptions` can be consumer by email-rendering - the onwardPath will be a string in the correct format for the relative URL needed for the readmore section.

Users of the tool will no longer be required to enter a custom contact email for every new newsletter, but are informed that leaving it blank will result in the default contact email ("newsletters@thegaurdian.com") being used in email rendering.


## Have we considered potential risks?

Changing the `newsletter-data-schema` can result in data being excluded from PROD if the existing data does not match the new schema.

We could do with integration tests to mitigate this, but manual testing should be sufficient for now.


