### PR TITLE
Dblatcher add pending status

### DIFF
--- a/apps/newsletters-api/src/services/storage/inMemoryStorageInstance.ts
+++ b/apps/newsletters-api/src/services/storage/inMemoryStorageInstance.ts
@@ -8,7 +8,6 @@ export const makeInMemoryStorageInstance = () =>
 			signUpDescription:
 				'Quod nobis aperiam aperiam ipsum nobis officiis explicabo molestias quibusdam.',
 			frequency: 'Weekly',
-			status: 'paused',
 			restricted: false,
 			emailConfirmation: false,
 			signUpEmbedDescription: "We'll send you Avon Recumbent weekly",
@@ -34,10 +33,10 @@ export const makeInMemoryStorageInstance = () =>
 			signUpDescription:
 				'This draft has the same name as a launched newsletters and might cause problems at launch!',
 			frequency: 'Weekly',
-			status: 'paused',
 			restricted: false,
 			emailConfirmation: false,
 			signUpEmbedDescription: "We'll send you it",
+			signUpHeadline: 'this is the headline',
 			theme: 'culture',
 			group: 'Work',
 			regionFocus: 'UK',

--- a/apps/newsletters-api/static/newsletters.local.json
+++ b/apps/newsletters-api/static/newsletters.local.json
@@ -89,7 +89,7 @@
 		"description": "Magni hic eos natus. possimus cupiditate quia commodi id totam ad officia. incidunt nobis deleniti assumenda corrupti. aperiam quaerat cupiditate. excepturi et id voluptatum voluptatem quidem magnam saepe maiores a.",
 		"signUpDescription": "Nostrum sint doloremque dolores pariatur deserunt nisi.",
 		"frequency": "Weekly",
-		"status": "paused",
+		"status": "pending",
 		"restricted": false,
 		"emailConfirmation": false,
 		"brazeNewsletterName": "Editorial_DramSecurity",

--- a/libs/newsletters-data-client/src/fixtures/newsletter-fixtures.ts
+++ b/libs/newsletters-data-client/src/fixtures/newsletter-fixtures.ts
@@ -41,6 +41,18 @@ export const TECHSCAPE_IN_NEW_FORMAT: NewsletterData = {
 	onlineArticle: 'Web for all sends',
 };
 
+export const TECHSCAPE_IN_NEW_FORMAT_WITH_DATA_COLLECTION_FIELDS: NewsletterData =
+	{
+		...TECHSCAPE_IN_NEW_FORMAT,
+		regionFocus: 'INTL',
+		signUpHeadline: 'Sign up for Techscape',
+		renderingOptions: {
+			displayDate: true,
+			displayStandfirst: true,
+			displayImageCaptions: false,
+		},
+	};
+
 export const VALID_TECHSCAPE: LegacyNewsletter = {
 	identityName: 'tech-scape',
 	name: 'TechScape',

--- a/libs/newsletters-data-client/src/lib/draft-to-newsletter.spec.ts
+++ b/libs/newsletters-data-client/src/lib/draft-to-newsletter.spec.ts
@@ -1,0 +1,97 @@
+import {
+	defaultRenderingOptionsValues,
+	getDraftNotReadyIssues,
+	withDefaultNewsletterValuesAndDerivedFields,
+} from '..';
+import { TECHSCAPE_IN_NEW_FORMAT_WITH_DATA_COLLECTION_FIELDS } from '../fixtures/newsletter-fixtures';
+
+describe('withDefaultNewsletterValuesAndDerivedFields', () => {
+	it('sets status to pending by default', () => {
+		const fromEmpty = withDefaultNewsletterValuesAndDerivedFields({});
+		expect(fromEmpty.status).toBe('pending');
+	});
+
+	it('derives the identity name from the name, unless identity name is set', () => {
+		const withDerivedId = withDefaultNewsletterValuesAndDerivedFields({
+			name: 'The Day Today',
+		});
+		const withPresetId = withDefaultNewsletterValuesAndDerivedFields({
+			name: 'The Day Today',
+			identityName: 'on-the-hour',
+		});
+		expect(withDerivedId.identityName).toBe('the-day-today');
+		expect(withPresetId.identityName).toBe('on-the-hour');
+	});
+
+	it('will merge the default rendering options, if the draft has renderingOptions,', () => {
+		const fromEmptyRenderingOptions =
+			withDefaultNewsletterValuesAndDerivedFields({
+				name: 'The Day Today',
+				renderingOptions: {},
+			});
+
+		const partialRenderingOptions = {
+			displayDate: true,
+			darkThemeSubheading: ['sports desk'],
+		};
+
+		const fromPartialRenderingOptions =
+			withDefaultNewsletterValuesAndDerivedFields({
+				name: 'The Day Today',
+				renderingOptions: partialRenderingOptions,
+			});
+
+		expect(fromEmptyRenderingOptions.renderingOptions).toEqual({
+			...defaultRenderingOptionsValues,
+		});
+		expect(fromPartialRenderingOptions.renderingOptions).toEqual({
+			...defaultRenderingOptionsValues,
+			...partialRenderingOptions,
+		});
+	});
+
+	it('will add the default rendering options if the rendering options are undefined, but only when category is article-based', () => {
+		const fromEmptyFrontsBased = withDefaultNewsletterValuesAndDerivedFields({
+			name: 'The Day Today',
+			category: 'fronts-based',
+		});
+		const fromEmptyArticleBased = withDefaultNewsletterValuesAndDerivedFields({
+			name: 'The Day Today',
+			category: 'article-based',
+		});
+
+		expect(fromEmptyFrontsBased.renderingOptions).toEqual(undefined);
+		expect(fromEmptyArticleBased.renderingOptions).toEqual(
+			defaultRenderingOptionsValues,
+		);
+	});
+});
+
+describe('getDraftNotReadyIssues', () => {
+	it('will find no errors on a draft satisfying the data collection schema', () => {
+		const outcome = getDraftNotReadyIssues(
+			TECHSCAPE_IN_NEW_FORMAT_WITH_DATA_COLLECTION_FIELDS,
+		);
+		expect(outcome).toEqual([]);
+	});
+	it('will report missing required fields', () => {
+		const outcomeWhenNameMissing = getDraftNotReadyIssues({
+			...TECHSCAPE_IN_NEW_FORMAT_WITH_DATA_COLLECTION_FIELDS,
+			name: undefined,
+		});
+		expect(outcomeWhenNameMissing[0]?.path).toEqual(['name']);
+
+		const outcomeWhenThemeMissing = getDraftNotReadyIssues({
+			...TECHSCAPE_IN_NEW_FORMAT_WITH_DATA_COLLECTION_FIELDS,
+			theme: undefined,
+		});
+		expect(outcomeWhenThemeMissing[0]?.path).toEqual(['theme']);
+
+		const outcomeWhenBothMissing = getDraftNotReadyIssues({
+			...TECHSCAPE_IN_NEW_FORMAT_WITH_DATA_COLLECTION_FIELDS,
+			name: undefined,
+			theme: undefined,
+		});
+		expect(outcomeWhenBothMissing.length).toEqual(2);
+	});
+});

--- a/libs/newsletters-data-client/src/lib/draft-to-newsletter.ts
+++ b/libs/newsletters-data-client/src/lib/draft-to-newsletter.ts
@@ -11,7 +11,7 @@ import type { NewsletterData, RenderingOptions } from './newsletter-data-type';
 const defaultNewsletterValues: DraftNewsletterData = {
 	listIdV1: -1,
 	restricted: false,
-	status: 'paused', // TODO - add step for this - maybe best in launch wizard?
+	status: 'pending',
 	emailConfirmation: false,
 	privateUntilLaunch: false,
 	figmaIncludesThrashers: false,

--- a/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
@@ -130,6 +130,14 @@ export const newsletterDataSchema = z.object({
 	name: nonEmptyString(),
 	category: newsletterCategoriesSchema,
 	restricted: z.boolean(),
+	/** The status for the newsletter:
+	 *
+	 *  - **pending**: Initial state after launch - can be promoted, not yet ready to be sent out.
+	 *    Counts as being **paused** for the same of converting to the legacy data model.
+	 *  - **live**: Able to be sent and/or currently being sent out to subscribers
+	 *  - **paused**: Currently not live, but might be restarted in future
+	 *  - **cancelled**: Permanently cancelled - must still exist in the API for referential integrity
+	 */
 	status: z.enum(['paused', 'cancelled', 'live', 'pending']),
 	emailConfirmation: z.boolean().describe('email confirmation'),
 	brazeSubscribeAttributeName: underscoreCasedString(),

--- a/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
@@ -130,7 +130,7 @@ export const newsletterDataSchema = z.object({
 	name: nonEmptyString(),
 	category: newsletterCategoriesSchema,
 	restricted: z.boolean(),
-	status: z.enum(['paused', 'cancelled', 'live']),
+	status: z.enum(['paused', 'cancelled', 'live', 'pending']),
 	emailConfirmation: z.boolean().describe('email confirmation'),
 	brazeSubscribeAttributeName: underscoreCasedString(),
 	brazeSubscribeEventNamePrefix: kebabOrUnderscoreCasedString(),

--- a/libs/newsletters-data-client/src/lib/transformDataToLegacyNewsletter.spec.ts
+++ b/libs/newsletters-data-client/src/lib/transformDataToLegacyNewsletter.spec.ts
@@ -38,6 +38,10 @@ describe('transformNewToOld', () => {
 			...TECHSCAPE_IN_NEW_FORMAT,
 			status: 'paused',
 		};
+		const pendingTechscape: NewsletterData = {
+			...TECHSCAPE_IN_NEW_FORMAT,
+			status: 'pending',
+		};
 
 		const cancelledNewsletter =
 			transformDataToLegacyNewsletter(cancelledTechscape);
@@ -47,5 +51,9 @@ describe('transformNewToOld', () => {
 		const pausedNewsletter = transformDataToLegacyNewsletter(pausedTechscape);
 		expect(pausedNewsletter.cancelled).toBe(false);
 		expect(pausedNewsletter.paused).toBe(true);
+
+		const pendingNewsletter = transformDataToLegacyNewsletter(pendingTechscape);
+		expect(pendingNewsletter.cancelled).toBe(false);
+		expect(pendingNewsletter.paused).toBe(true);
 	});
 });

--- a/libs/newsletters-data-client/src/lib/transformDataToLegacyNewsletter.ts
+++ b/libs/newsletters-data-client/src/lib/transformDataToLegacyNewsletter.ts
@@ -16,7 +16,7 @@ const deriveBooleansFromStatus = (
 ): { cancelled: boolean; paused: boolean } => {
 	return {
 		cancelled: status === 'cancelled',
-		paused: status === 'paused',
+		paused: status === 'paused' || status === 'pending',
 	};
 };
 

--- a/tools/scripts/deno/generate-newsletters.js
+++ b/tools/scripts/deno/generate-newsletters.js
@@ -52,6 +52,7 @@ const generateNewsletter = () => {
 	const status = faker.helpers.arrayElement([
 		'paused',
 		'cancelled',
+		'pending',
 		'live',
 		'live',
 	]);


### PR DESCRIPTION
## What does this change?

 - adds new value of 'pending' to the `status` enum
 - makes 'pending' the default initial status after newsletters are launched
 - updates `deriveLegacyNewsletter` to set `paused` to false on the legacy newsletters if the `newsletterData.status` is 'pending
 - adds more test coverage


## How to test

locally:
 - the status for the hard-coded test newsletter [dram-security](http://localhost:4200/launched/dram-security) has it's status set to "pending" - the [legacy API page](http://localhost:4200/api/legacy/newsletters) will show the boolean "paused" as true for dram-security
 - create a new draft and launch it - initial status will be 'pending' and the [legacy API page](http://localhost:4200/api/legacy/newsletters) will show the boolean "paused" as true for your new draft
 - the "pending" status can be selected from the status options on the edit newsletter page, eg http://localhost:4200/launched/edit/electric-bicycle


## How can we measure success?

Initial status of any new newsletters should be more informative - we can distinguish 'paused' and 'pending'.

Allows further work relating to recording async tasks being made to the newsletter (eg tag set-up, Braze campaigns) before status can move from 'pending' to 'live.

## Have we considered potential risks?

The UI is not being used by external stakeholder in production and the new data model in only consumed by email-rendering (for which the `status` field is not relevant), so should be no risk.
