### PR TITLE
fix defaulting on drafts

### DIFF
--- a/libs/newsletters-data-client/src/lib/draft-to-newsletter.spec.ts
+++ b/libs/newsletters-data-client/src/lib/draft-to-newsletter.spec.ts
@@ -6,9 +6,17 @@ import {
 import { TECHSCAPE_IN_NEW_FORMAT_WITH_DATA_COLLECTION_FIELDS } from '../fixtures/newsletter-fixtures';
 
 describe('withDefaultNewsletterValuesAndDerivedFields', () => {
-	it('sets status to pending by default', () => {
+	it('sets status to pending by default , overriding explicit undefined, but not other value', () => {
 		const fromEmpty = withDefaultNewsletterValuesAndDerivedFields({});
+		const fromUndefinedStatus = withDefaultNewsletterValuesAndDerivedFields({
+			status: undefined,
+		});
+		const fromCancelledStatus = withDefaultNewsletterValuesAndDerivedFields({
+			status: 'cancelled',
+		});
 		expect(fromEmpty.status).toBe('pending');
+		expect(fromUndefinedStatus.status).toBe('pending');
+		expect(fromCancelledStatus.status).toBe('cancelled');
 	});
 
 	it('derives the identity name from the name, unless identity name is set', () => {

--- a/libs/newsletters-data-client/src/lib/draft-to-newsletter.ts
+++ b/libs/newsletters-data-client/src/lib/draft-to-newsletter.ts
@@ -32,9 +32,6 @@ export const withDefaultNewsletterValuesAndDerivedFields = (
 ): DraftNewsletterData &
 	Pick<NewsletterData, NewsletterFieldsDerivedFromName> => {
 	const derivedFields = deriveNewsletterFieldsFromName(draft.name ?? '');
-	//prevent an explicit undefined status on the draft overriding the default
-	const getDefaultedStatus = () =>
-		draft.status ? draft.status : defaultNewsletterValues.status;
 
 	const getDefaultedRenderingOptions = () => {
 		// if the draft is article based, the rendering options must be populated
@@ -63,7 +60,8 @@ export const withDefaultNewsletterValuesAndDerivedFields = (
 		...derivedFields,
 		...draft,
 		renderingOptions: getDefaultedRenderingOptions(),
-		status: getDefaultedStatus(),
+		//prevent an explicit undefined status on the draft overriding the default
+		status: draft.status ? draft.status : defaultNewsletterValues.status,
 	};
 };
 

--- a/libs/newsletters-data-client/src/lib/draft-to-newsletter.ts
+++ b/libs/newsletters-data-client/src/lib/draft-to-newsletter.ts
@@ -33,38 +33,37 @@ export const withDefaultNewsletterValuesAndDerivedFields = (
 	Pick<NewsletterData, NewsletterFieldsDerivedFromName> => {
 	const derivedFields = deriveNewsletterFieldsFromName(draft.name ?? '');
 	//prevent an explicit undefined status on the draft overriding the default
-	const status = draft.status ? draft.status : defaultNewsletterValues.status;
+	const getDefaultedStatus = () =>
+		draft.status ? draft.status : defaultNewsletterValues.status;
 
-	if (draft.category === 'article-based') {
-		return {
-			...defaultNewsletterValues,
-			...derivedFields,
-			...draft,
-			// if the draft is article based, the rendering options must be populated
-			// use the default values, even if draft.renderingOptions is undefined
-			renderingOptions: {
+	const getDefaultedRenderingOptions = () => {
+		// if the draft is article based, the rendering options must be populated
+		// use the default values, even if draft.renderingOptions is undefined
+		if (draft.category === 'article-based') {
+			return {
 				...defaultRenderingOptionsValues,
 				...draft.renderingOptions,
-			},
-			status,
-		};
-	}
+			};
+		}
+
+		// if the draft is not article based, the rendering options are optional
+		// if set, add in the default values to draft.renderingOptions.
+		if (draft.renderingOptions) {
+			return {
+				...defaultRenderingOptionsValues,
+				...draft.renderingOptions,
+			};
+		}
+		// if value is undefined, leave as undefined
+		return undefined;
+	};
 
 	return {
 		...defaultNewsletterValues,
 		...derivedFields,
 		...draft,
-		// if the draft is not article based, the rendering options are optional
-		// if value is undefined, leave as undefined
-		// if set, add in the default values to draft.renderingOptions.
-		renderingOptions:
-			typeof draft.renderingOptions === 'undefined'
-				? draft.renderingOptions
-				: {
-						...defaultRenderingOptionsValues,
-						...draft.renderingOptions,
-				  },
-		status,
+		renderingOptions: getDefaultedRenderingOptions(),
+		status: getDefaultedStatus(),
 	};
 };
 


### PR DESCRIPTION
## What does this change?

Fixes and simplifies the logic in draft-to-newsletter so the `status` field will always be populated and the logic for 'renderingOption' is documented.
extends tests to account for the fixed bug.


## How to test

Changes have test coverage `nx run newsletters-data-client:test`


