### PR TITLE
make async workflow properties required

### DIFF
--- a/libs/newsletters-data-client/src/fixtures/newsletter-fixtures.ts
+++ b/libs/newsletters-data-client/src/fixtures/newsletter-fixtures.ts
@@ -39,6 +39,10 @@ export const TECHSCAPE_IN_NEW_FORMAT: NewsletterData = {
 	thrasherDate: new Date(87678876),
 	privateUntilLaunch: false,
 	onlineArticle: 'Web for all sends',
+	brazeCampaignCreationsStatus: 'NOT_REQUESTED',
+	ophanCampaignCreationsStatus: 'NOT_REQUESTED',
+	signupPageCreationsStatus: 'NOT_REQUESTED',
+	tagCreationsStatus: 'NOT_REQUESTED',
 };
 
 export const TECHSCAPE_IN_NEW_FORMAT_WITH_DATA_COLLECTION_FIELDS: NewsletterData =

--- a/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-data-type.ts
@@ -199,10 +199,10 @@ export const newsletterDataSchema = z.object({
 	renderingOptions: renderingOptionsSchema.optional(),
 	thrasherOptions: thrasherOptionsSchema.optional(),
 	mailSuccessDescription: z.string().optional(),
-	brazeCampaignCreationsStatus: workflowStatusEnumSchema.optional(),
-	ophanCampaignCreationsStatus: workflowStatusEnumSchema.optional(),
-	signupPageCreationsStatus: workflowStatusEnumSchema.optional(),
-	tagCreationsStatus: workflowStatusEnumSchema.optional(),
+	brazeCampaignCreationsStatus: workflowStatusEnumSchema,
+	ophanCampaignCreationsStatus: workflowStatusEnumSchema,
+	signupPageCreationsStatus: workflowStatusEnumSchema,
+	tagCreationsStatus: workflowStatusEnumSchema,
 });
 
 /** NOT FINAL - this type a placeholder to test the data transformation structure */


### PR DESCRIPTION
## What does this change?

Sets the async workflow modelling properties to non-optional.

## How to test

Sense check of the app. Nothing should change as a result of this. There is no UI for these values just yet but using the JSON editor on an existing newsletter & removing any of the new props - should fail validation.


## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

Yep - backfil has already been run on CODE & PROD so we should be ok. 

