### PR TITLE
Tiered Edit Access

### DIFF
--- a/apps/newsletters-api/env.local.example.txt
+++ b/apps/newsletters-api/env.local.example.txt
@@ -33,7 +33,7 @@ LOCAL_USER_PROFILE_EMAIL=software.developer@guardian.co.uk
 
 # allows local running with developer permissions without needing to login
 # Update the access level as required:
-# 0 - Developer, 1 - Editor, 2 - Drafter, 3 - Viewer
+# 0 - Developer, 1 - Editor, 2 - Drafter, 3 - Viewer, 4 - TagEditor, 5 - BrazeEditor, 6 - OphanEditor, 7 - SignUpPageEditor
 USER_PERMISSIONS={"software.developer@guardian.co.uk": 0}
 
 # whether to fetch from a local instance of email rendering on port 3010

--- a/apps/newsletters-api/src/apiDeploymentSettings.ts
+++ b/apps/newsletters-api/src/apiDeploymentSettings.ts
@@ -88,6 +88,7 @@ export const getLocalUserProfiles = (): Record<string, UserAccessLevel> => {
 				case UserAccessLevel.OphanEditor:
 				case UserAccessLevel.BrazeEditor:
 				case UserAccessLevel.TagEditor:
+				case UserAccessLevel.SignUpPageEditor:
 					output[key] = value;
 					break;
 			}

--- a/apps/newsletters-api/src/apiDeploymentSettings.ts
+++ b/apps/newsletters-api/src/apiDeploymentSettings.ts
@@ -85,6 +85,9 @@ export const getLocalUserProfiles = (): Record<string, UserAccessLevel> => {
 				case UserAccessLevel.Editor:
 				case UserAccessLevel.Drafter:
 				case UserAccessLevel.Viewer:
+				case UserAccessLevel.OphanEditor:
+				case UserAccessLevel.BrazeEditor:
+				case UserAccessLevel.TagEditor:
 					output[key] = value;
 					break;
 			}

--- a/apps/newsletters-api/src/app/authorisation.ts
+++ b/apps/newsletters-api/src/app/authorisation.ts
@@ -1,0 +1,43 @@
+import type { FastifyRequest } from 'fastify/types/request';
+import type { UserProfile } from '@newsletters-nx/newsletters-data-client';
+import {
+	getUserEditSchema,
+	isPartialNewsletterData,
+} from '@newsletters-nx/newsletters-data-client';
+import { permissionService } from '../services/permissions';
+
+export const hasEditAccess = async (
+	profile: UserProfile | undefined,
+): Promise<boolean> => {
+	if (!profile) return false;
+	const permissions = await permissionService.get(profile);
+	const { editTags, editNewsletters, editSignUpPage, editBraze, editOphan } =
+		permissions;
+	return [editTags, editNewsletters, editSignUpPage, editBraze, editOphan].some(
+		(permission) => permission,
+	);
+};
+
+export const isAuthorisedToUpdateNewsletter = async (
+	profile: UserProfile | undefined,
+	request: FastifyRequest,
+): Promise<boolean> => {
+	// get the users permissions and check if they have editNewsletters permission - if so, return true (because they can do whatever they want)
+	// if not, check what edit permission they have and then check the keys in the payload to see if they are allowed to update them
+	// if they are allowed to update them, return true, otherwise return false
+	if (!profile) return false;
+	const permissions = await permissionService.get(profile);
+	const { editNewsletters } = permissions;
+	if (editNewsletters) return true;
+
+	const { body: modifications } = request;
+
+	if (!isPartialNewsletterData(modifications))  {
+		throw new Error('Invalid newsletter data');
+	}
+	const updateKeys = Object.keys(modifications);
+
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-call
+	const userEditSchema = Object.keys(getUserEditSchema(permissions));
+	return updateKeys.every((key) => userEditSchema.includes(key));
+};

--- a/apps/newsletters-api/src/app/authorisation.ts
+++ b/apps/newsletters-api/src/app/authorisation.ts
@@ -37,7 +37,9 @@ export const isAuthorisedToUpdateNewsletter = async (
 	}
 	const updateKeys = Object.keys(modifications);
 
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-call
+
+	// @typescript-eslint/no-unsafe-call -- this is safe
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-argument -- this is safe
 	const userEditSchema = Object.keys(getUserEditSchema(permissions));
 	return updateKeys.every((key) => userEditSchema.includes(key));
 };

--- a/apps/newsletters-api/src/app/authorisation.ts
+++ b/apps/newsletters-api/src/app/authorisation.ts
@@ -22,9 +22,6 @@ export const isAuthorisedToUpdateNewsletter = async (
 	profile: UserProfile | undefined,
 	request: FastifyRequest,
 ): Promise<boolean> => {
-	// get the users permissions and check if they have editNewsletters permission - if so, return true (because they can do whatever they want)
-	// if not, check what edit permission they have and then check the keys in the payload to see if they are allowed to update them
-	// if they are allowed to update them, return true, otherwise return false
 	if (!profile) return false;
 	const permissions = await permissionService.get(profile);
 	const { editNewsletters } = permissions;
@@ -32,14 +29,13 @@ export const isAuthorisedToUpdateNewsletter = async (
 
 	const { body: modifications } = request;
 
+	console.log('modifications', modifications)
+	console.log('req', request)
 	if (!isPartialNewsletterData(modifications))  {
 		throw new Error('Invalid newsletter data');
 	}
 	const updateKeys = Object.keys(modifications);
 
-
-	// @typescript-eslint/no-unsafe-call -- this is safe
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-argument -- this is safe
 	const userEditSchema = Object.keys(getUserEditSchema(permissions));
 	return updateKeys.every((key) => userEditSchema.includes(key));
 };

--- a/apps/newsletters-api/src/app/authorisation.ts
+++ b/apps/newsletters-api/src/app/authorisation.ts
@@ -29,13 +29,12 @@ export const isAuthorisedToUpdateNewsletter = async (
 
 	const { body: modifications } = request;
 
-	console.log('modifications', modifications)
-	console.log('req', request)
 	if (!isPartialNewsletterData(modifications))  {
 		throw new Error('Invalid newsletter data');
 	}
 	const updateKeys = Object.keys(modifications);
 
-	const userEditSchema = Object.keys(getUserEditSchema(permissions));
-	return updateKeys.every((key) => userEditSchema.includes(key));
+	const { shape: userEditSchemaObject } = getUserEditSchema(permissions);
+	const editableProperties = Object.keys(userEditSchemaObject);
+	return updateKeys.every((key) => editableProperties.includes(key));
 };

--- a/apps/newsletters-api/src/app/authorisation.ts
+++ b/apps/newsletters-api/src/app/authorisation.ts
@@ -1,9 +1,8 @@
-import type { FastifyRequest } from 'fastify/types/request';
-import type { UserProfile } from '@newsletters-nx/newsletters-data-client';
-import {
-	getUserEditSchema,
-	isPartialNewsletterData,
+import type {
+	NewsletterData,
+	UserProfile,
 } from '@newsletters-nx/newsletters-data-client';
+import { getUserEditSchema } from '@newsletters-nx/newsletters-data-client';
 import { permissionService } from '../services/permissions';
 
 export const hasEditAccess = async (
@@ -18,9 +17,9 @@ export const hasEditAccess = async (
 	);
 };
 
-export const isAuthorisedToUpdateNewsletter = async (
+export const isAuthorisedToMakeRequestedNewsletterUpdate = async (
 	profile: UserProfile | undefined,
-	request: FastifyRequest,
+	update: Partial<NewsletterData>,
 ): Promise<boolean> => {
 	if (!profile) return false;
 	const permissions = await permissionService.get(profile);
@@ -28,13 +27,7 @@ export const isAuthorisedToUpdateNewsletter = async (
 
 	if (editNewsletters) return true;
 
-	const { body: modifications } = request;
-
-	if (!isPartialNewsletterData(modifications))  {
-		throw new Error('Invalid newsletter data');
-	}
-
-	const updateKeys = Object.keys(modifications);
+	const updateKeys = Object.keys(update);
 
 	const { shape: userEditSchemaObject } = getUserEditSchema(permissions);
 	const editableProperties = Object.keys(userEditSchemaObject);

--- a/apps/newsletters-api/src/app/authorisation.ts
+++ b/apps/newsletters-api/src/app/authorisation.ts
@@ -25,6 +25,7 @@ export const isAuthorisedToUpdateNewsletter = async (
 	if (!profile) return false;
 	const permissions = await permissionService.get(profile);
 	const { editNewsletters } = permissions;
+
 	if (editNewsletters) return true;
 
 	const { body: modifications } = request;
@@ -32,6 +33,7 @@ export const isAuthorisedToUpdateNewsletter = async (
 	if (!isPartialNewsletterData(modifications))  {
 		throw new Error('Invalid newsletter data');
 	}
+
 	const updateKeys = Object.keys(modifications);
 
 	const { shape: userEditSchemaObject } = getUserEditSchema(permissions);

--- a/apps/newsletters-api/src/app/responses.ts
+++ b/apps/newsletters-api/src/app/responses.ts
@@ -51,3 +51,19 @@ export const makeAccessDeniedApiResponse = async (
 	}
 	return undefined;
 };
+
+export const hasEditAccess = async (
+	profile: UserProfile | undefined,
+): Promise<boolean> => {
+	if (!profile) return false;
+	const permissions = await permissionService.get(profile);
+	const { editTags, editNewsletters, editSignUpPage, editBraze, editOphan } =
+		permissions;
+	return !!(
+		editOphan ||
+		editTags ||
+		editNewsletters ||
+		editSignUpPage ||
+		editBraze
+	);
+};

--- a/apps/newsletters-api/src/app/responses.ts
+++ b/apps/newsletters-api/src/app/responses.ts
@@ -59,11 +59,7 @@ export const hasEditAccess = async (
 	const permissions = await permissionService.get(profile);
 	const { editTags, editNewsletters, editSignUpPage, editBraze, editOphan } =
 		permissions;
-	return !!(
-		editOphan ||
-		editTags ||
-		editNewsletters ||
-		editSignUpPage ||
-		editBraze
+	return [editTags, editNewsletters, editSignUpPage, editBraze, editOphan].some(
+		(permission) => permission,
 	);
 };

--- a/apps/newsletters-api/src/app/responses.ts
+++ b/apps/newsletters-api/src/app/responses.ts
@@ -51,15 +51,3 @@ export const makeAccessDeniedApiResponse = async (
 	}
 	return undefined;
 };
-
-export const hasEditAccess = async (
-	profile: UserProfile | undefined,
-): Promise<boolean> => {
-	if (!profile) return false;
-	const permissions = await permissionService.get(profile);
-	const { editTags, editNewsletters, editSignUpPage, editBraze, editOphan } =
-		permissions;
-	return [editTags, editNewsletters, editSignUpPage, editBraze, editOphan].some(
-		(permission) => permission,
-	);
-};

--- a/apps/newsletters-api/src/app/routes/newsletters.ts
+++ b/apps/newsletters-api/src/app/routes/newsletters.ts
@@ -104,7 +104,7 @@ export function registerReadWriteNewsletterRoutes(app: FastifyInstance) {
 		Body: unknown;
 	}>(
 		'/api/newsletters/:newsletterId',
-		{ onRequest: hasAccessHook },
+		{ preValidation: hasAccessHook },
 		async (req, res) => {
 			const user = getUserProfile(req);
 

--- a/apps/newsletters-api/src/app/routes/newsletters.ts
+++ b/apps/newsletters-api/src/app/routes/newsletters.ts
@@ -10,6 +10,7 @@ import { signTemplateImages } from '../../services/image/image-signer';
 import { newsletterStore } from '../../services/storage';
 import { getUserProfile } from '../get-user-profile';
 import {
+	hasEditAccess,
 	makeAccessDeniedApiResponse,
 	makeErrorResponse,
 	makeSuccessResponse,
@@ -84,12 +85,11 @@ export function registerReadWriteNewsletterRoutes(app: FastifyInstance) {
 		Body: unknown;
 	}>('/api/newsletters/:newsletterId', async (req, res) => {
 		const user = getUserProfile(req);
-		const accessDeniedError = await makeAccessDeniedApiResponse(
-			user.profile,
-			'editNewsletters',
-		);
-		if (accessDeniedError) {
-			return res.status(403).send(accessDeniedError);
+
+		const isAuthorised = await hasEditAccess(user.profile); // todo - refine and move to middleware
+
+		if (!isAuthorised) {
+			return res.status(403).send({ no: 'access' });
 		}
 
 		const { newsletterId } = req.params;

--- a/apps/newsletters-api/src/app/routes/newsletters.ts
+++ b/apps/newsletters-api/src/app/routes/newsletters.ts
@@ -153,7 +153,7 @@ export function registerReadWriteNewsletterRoutes(app: FastifyInstance) {
 		Body: unknown;
 	}>(
 		'/api/newsletters/:newsletterId',
-		{ onRequest: hasAccessHook },
+		{ preValidation: hasAccessHook },
 		async (req, res) => {
 			const user = getUserProfile(req);
 			const accessDeniedError = await makeAccessDeniedApiResponse(

--- a/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
+++ b/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
@@ -55,7 +55,7 @@ export const EditNewsletterForm = ({ originalItem }: Props) => {
 
 	if (permissions === undefined) return null;
 
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-call -- this is safe
 	const userSchema = getUserEditSchema(
 		permissions,
 	) as typeof newsletterDataSchema;

--- a/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
+++ b/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
@@ -2,9 +2,9 @@ import { Alert, Snackbar } from '@mui/material';
 import { useState } from 'react';
 import type {
 	NewsletterData,
-	UserPermissions,
+	newsletterDataSchema,
 } from '@newsletters-nx/newsletters-data-client';
-import { newsletterDataSchema } from '@newsletters-nx/newsletters-data-client';
+import { getUserEditSchema } from '@newsletters-nx/newsletters-data-client';
 import { requestNewsletterEdit } from '../api-requests/request-newsletter-edit';
 import { usePermissions } from '../hooks/user-hooks';
 import { SimpleForm } from './SimpleForm';
@@ -22,50 +22,6 @@ export const EditNewsletterForm = ({ originalItem }: Props) => {
 		string | undefined
 	>();
 
-	const userEditSchema = (permissions: UserPermissions) => {
-		const { editBraze, editOphan, editTags, editSignUpPage, editNewsletters } =
-			permissions;
-		if (editNewsletters) {
-			return newsletterDataSchema.pick({
-				tagCreationsStatus: true,
-				brazeCampaignCreationsStatus: true,
-				ophanCampaignCreationsStatus: true,
-				signupPageCreationsStatus: true,
-				signupPage: true,
-				signUpDescription: true,
-			});
-		}
-		if (editBraze) {
-			return newsletterDataSchema.pick({
-				brazeCampaignCreationsStatus: true,
-				brazeNewsletterName: true,
-				brazeSubscribeAttributeName: true,
-				brazeSubscribeEventNamePrefix: true,
-				brazeSubscribeAttributeNameAlternate: true,
-			});
-		}
-		if (editOphan) {
-			return newsletterDataSchema.pick({
-				ophanCampaignCreationsStatus: true,
-			});
-		}
-		if (editTags) {
-			return newsletterDataSchema.pick({
-				tagCreationsStatus: true,
-				seriesTag: true,
-				composerTag: true,
-				composerCampaignTag: true,
-			});
-		}
-		if (editSignUpPage) {
-			return newsletterDataSchema.pick({
-				signupPageCreationsStatus: true,
-				signupPage: true,
-				signUpDescription: true,
-			});
-		}
-		throw new Error('No permissions found');
-	};
 	const requestUpdate = async (modification: Partial<NewsletterData>) => {
 		if (waitingForResponse) {
 			return;
@@ -97,15 +53,19 @@ export const EditNewsletterForm = ({ originalItem }: Props) => {
 		}
 	};
 
-	if (!permissions) return null;
+	if (permissions === undefined) return null;
 
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+	const userSchema = getUserEditSchema(
+		permissions,
+	) as typeof newsletterDataSchema;
 	return (
 		<>
 			<SimpleForm
 				title={`Edit ${originalItem.identityName}`}
 				initialData={item}
 				submit={requestUpdate}
-				schema={userEditSchema(permissions) as typeof newsletterDataSchema}
+				schema={userSchema}
 				submitButtonText="Update Newsletter"
 				isDisabled={waitingForResponse}
 				maxOptionsForRadioButtons={5}

--- a/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
+++ b/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
@@ -2,7 +2,6 @@ import { Alert, Snackbar } from '@mui/material';
 import { useState } from 'react';
 import type {
 	NewsletterData,
-	newsletterDataSchema,
 } from '@newsletters-nx/newsletters-data-client';
 import { getUserEditSchema } from '@newsletters-nx/newsletters-data-client';
 import { requestNewsletterEdit } from '../api-requests/request-newsletter-edit';
@@ -55,10 +54,9 @@ export const EditNewsletterForm = ({ originalItem }: Props) => {
 
 	if (permissions === undefined) return null;
 
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-call -- this is safe
 	const userSchema = getUserEditSchema(
 		permissions,
-	) as typeof newsletterDataSchema;
+	);
 	return (
 		<>
 			<SimpleForm

--- a/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
+++ b/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
@@ -1,8 +1,6 @@
 import { Alert, Snackbar } from '@mui/material';
 import { useState } from 'react';
-import type {
-	NewsletterData,
-} from '@newsletters-nx/newsletters-data-client';
+import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
 import { getUserEditSchema } from '@newsletters-nx/newsletters-data-client';
 import { requestNewsletterEdit } from '../api-requests/request-newsletter-edit';
 import { usePermissions } from '../hooks/user-hooks';
@@ -54,9 +52,7 @@ export const EditNewsletterForm = ({ originalItem }: Props) => {
 
 	if (permissions === undefined) return null;
 
-	const userSchema = getUserEditSchema(
-		permissions,
-	);
+	const userSchema = getUserEditSchema(permissions);
 	return (
 		<>
 			<SimpleForm

--- a/apps/newsletters-ui/src/app/components/HomeMenu.tsx
+++ b/apps/newsletters-ui/src/app/components/HomeMenu.tsx
@@ -10,6 +10,7 @@ import { useNavigate } from 'react-router';
 import { useLoaderData } from 'react-router-dom';
 import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
 import { usePermissions } from '../hooks/user-hooks';
+import { shouldShowEditOptions } from '../services/authorisation';
 import { ScrollingMenuButton } from './ScrollingMenuButton';
 
 const ButtonGridItem = ({
@@ -58,6 +59,10 @@ export function HomeMenu() {
 	const permissions = usePermissions();
 	const navigate = useNavigate();
 
+	if (!permissions) return null;
+
+	const showEditOptions = shouldShowEditOptions(permissions);
+
 	return (
 		<Container maxWidth={'lg'}>
 			<Grid container spacing={3} rowSpacing={6} paddingY={4}>
@@ -67,7 +72,7 @@ export function HomeMenu() {
 				/>
 				<ButtonGridItem path="/drafts" content={'View draft newsletters'} />
 
-				{permissions?.writeToDrafts && (
+				{permissions.writeToDrafts && (
 					<ButtonGridItem
 						path="/drafts/newsletter-data"
 						content={'Create newsletter wizard'}
@@ -75,7 +80,7 @@ export function HomeMenu() {
 					/>
 				)}
 
-				{permissions?.editNewsletters && (
+				{showEditOptions && (
 					<Grid item xs={6} sm={4} display={'flex'}>
 						<ScrollingMenuButton
 							buttonText="update newsletter"
@@ -97,7 +102,7 @@ export function HomeMenu() {
 					</Grid>
 				)}
 
-				{permissions?.editNewsletters && (
+				{permissions.editNewsletters && (
 					<Grid item xs={6} sm={4} display={'flex'}>
 						<ScrollingMenuButton
 							buttonText="set rendering options"

--- a/apps/newsletters-ui/src/app/components/NewslettersTable.tsx
+++ b/apps/newsletters-ui/src/app/components/NewslettersTable.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import type { Column } from 'react-table';
 import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
 import { usePermissions } from '../hooks/user-hooks';
+import { shouldShowEditOptions } from '../services/authorisation';
 import { formatCellDate } from './Cell';
 import { ExternalLinkButton } from './ExternalLinkButton';
 import { NavigateButton } from './NavigateButton';
@@ -13,7 +14,8 @@ interface Props {
 }
 
 export const NewslettersTable = ({ newsletters }: Props) => {
-	const { editNewsletters } = usePermissions() ?? {};
+	const permissions = usePermissions();
+	const showEditOptions = shouldShowEditOptions(permissions);
 	const data = newsletters;
 
 	const columns = useMemo<Column[]>(() => {
@@ -67,7 +69,7 @@ export const NewslettersTable = ({ newsletters }: Props) => {
 				return (
 					<NavigateButton
 						href={
-							editNewsletters
+							showEditOptions
 								? `/launched/edit/${newsletter.identityName}`
 								: undefined
 						}
@@ -78,7 +80,7 @@ export const NewslettersTable = ({ newsletters }: Props) => {
 			},
 		};
 
-		return editNewsletters ? [...infoColumns, editColumn] : infoColumns;
-	}, [editNewsletters]);
+		return showEditOptions ? [...infoColumns, editColumn] : infoColumns;
+	}, [showEditOptions]);
 	return <Table data={data} columns={columns} defaultSortId="identityName" />;
 };

--- a/apps/newsletters-ui/src/app/services/authorisation.ts
+++ b/apps/newsletters-ui/src/app/services/authorisation.ts
@@ -1,0 +1,12 @@
+import type { UserPermissions } from '@newsletters-nx/newsletters-data-client';
+
+export const shouldShowEditOptions = (
+	permissions: UserPermissions | undefined,
+) => {
+	if (!permissions) return null;
+	const { editTags, editNewsletters, editSignUpPage, editBraze, editOphan } =
+		permissions;
+	return [editTags, editNewsletters, editSignUpPage, editBraze, editOphan].some(
+		(permission) => permission === true,
+	);
+};

--- a/apps/newsletters-ui/src/app/services/authorisation.ts
+++ b/apps/newsletters-ui/src/app/services/authorisation.ts
@@ -7,6 +7,6 @@ export const shouldShowEditOptions = (
 	const { editTags, editNewsletters, editSignUpPage, editBraze, editOphan } =
 		permissions;
 	return [editTags, editNewsletters, editSignUpPage, editBraze, editOphan].some(
-		(permission) => permission === true,
+		(permission) => permission,
 	);
 };

--- a/libs/newsletters-data-client/src/index.ts
+++ b/libs/newsletters-data-client/src/index.ts
@@ -21,3 +21,4 @@ export * from './lib/user-profile';
 export * from './lib/wizard-button-type';
 export * from './lib/zod-helpers';
 export * from './lib/json-undefined-null-conversions';
+export * from './lib/zod-helpers/user-data-schema';

--- a/libs/newsletters-data-client/src/lib/newsletter-storage/s3-functions.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-storage/s3-functions.ts
@@ -53,10 +53,11 @@ export const getNextId = async (
 };
 
 const getStringId = (key: string): string => {
-	// todo - deal with unexpected formats
 	const filenameWithExtension = key.split(':').pop();
-	const stringId = filenameWithExtension!.split('.')[0];
-	return stringId!;
+	if (!filenameWithExtension) throw new Error('Unexpected key format');
+	const stringId = filenameWithExtension.split('.')[0];
+	if (!stringId) throw new Error('Unexpected key format');
+	return stringId;
 };
 
 export const putObject =

--- a/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
@@ -139,7 +139,7 @@ export const newsletterDataSchema = z.object({
 	thrasherOptions: thrasherOptionsSchema.optional(),
 	mailSuccessDescription: z.string().optional(),
 	brazeCampaignCreationsStatus: workflowStatusEnumSchema.describe(
-	 	'Braze campaign creation status',
+		'Braze campaign creation status',
 	),
 	ophanCampaignCreationsStatus: workflowStatusEnumSchema.describe(
 		'Ophan campaign creation status',

--- a/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
@@ -139,7 +139,7 @@ export const newsletterDataSchema = z.object({
 	thrasherOptions: thrasherOptionsSchema.optional(),
 	mailSuccessDescription: z.string().optional(),
 	brazeCampaignCreationsStatus: workflowStatusEnumSchema.describe(
-		'Braze campaign creation status',
+	 	'Braze campaign creation status',
 	),
 	ophanCampaignCreationsStatus: workflowStatusEnumSchema.describe(
 		'Ophan campaign creation status',

--- a/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
@@ -138,10 +138,16 @@ export const newsletterDataSchema = z.object({
 	renderingOptions: renderingOptionsSchema.optional(),
 	thrasherOptions: thrasherOptionsSchema.optional(),
 	mailSuccessDescription: z.string().optional(),
-	brazeCampaignCreationsStatus: workflowStatusEnumSchema,
-	ophanCampaignCreationsStatus: workflowStatusEnumSchema,
-	signupPageCreationsStatus: workflowStatusEnumSchema,
-	tagCreationsStatus: workflowStatusEnumSchema,
+	brazeCampaignCreationsStatus: workflowStatusEnumSchema.describe(
+		'Braze campaign creation status',
+	),
+	ophanCampaignCreationsStatus: workflowStatusEnumSchema.describe(
+		'Ophan campaign creation status',
+	),
+	signupPageCreationsStatus: workflowStatusEnumSchema.describe(
+		'Sign up creation status',
+	),
+	tagCreationsStatus: workflowStatusEnumSchema.describe('Tag creation status'),
 });
 
 /** NOT FINAL - this type a placeholder to test the data transformation structure */

--- a/libs/newsletters-data-client/src/lib/user-profile.ts
+++ b/libs/newsletters-data-client/src/lib/user-profile.ts
@@ -29,6 +29,10 @@ export enum UserAccessLevel {
 	Editor,
 	Drafter,
 	Viewer,
+	TagEditor,
+	BrazeEditor,
+	OphanEditor,
+	SignUpPageEditor,
 }
 
 export type UserPermissions = {
@@ -37,6 +41,10 @@ export type UserPermissions = {
 	launchNewsletters: boolean;
 	writeToDrafts: boolean;
 	viewMetaData: boolean;
+	editBraze: boolean;
+	editOphan: boolean;
+	editTags: boolean;
+	editSignUpPage: boolean;
 };
 
 export const levelToPermissions = (
@@ -55,8 +63,16 @@ export const levelToPermissions = (
 			UserAccessLevel.Developer,
 			UserAccessLevel.Editor,
 			UserAccessLevel.Drafter,
+			UserAccessLevel.TagEditor,
+			UserAccessLevel.BrazeEditor,
+			UserAccessLevel.OphanEditor,
+			UserAccessLevel.SignUpPageEditor,
 		].includes(accessLevel),
 		viewMetaData: [UserAccessLevel.Developer].includes(accessLevel),
 		useJsonEditor: [UserAccessLevel.Developer].includes(accessLevel),
+		editBraze: [UserAccessLevel.BrazeEditor].includes(accessLevel),
+		editOphan: [UserAccessLevel.OphanEditor].includes(accessLevel),
+		editTags: [UserAccessLevel.TagEditor].includes(accessLevel),
+		editSignUpPage: [UserAccessLevel.SignUpPageEditor].includes(accessLevel),
 	};
 };

--- a/libs/newsletters-data-client/src/lib/zod-helpers/user-data-schema.ts
+++ b/libs/newsletters-data-client/src/lib/zod-helpers/user-data-schema.ts
@@ -1,0 +1,47 @@
+import { newsletterDataSchema } from '../newsletter-data-type';
+import type { UserPermissions } from '../user-profile';
+
+export const getUserEditSchema = (permissions: UserPermissions) => {
+	const { editBraze, editOphan, editTags, editSignUpPage, editNewsletters } =
+		permissions;
+	if (editNewsletters) {
+		return newsletterDataSchema.pick({
+			tagCreationsStatus: true,
+			brazeCampaignCreationsStatus: true,
+			ophanCampaignCreationsStatus: true,
+			signupPageCreationsStatus: true,
+			signupPage: true,
+			signUpDescription: true,
+		}) as typeof newsletterDataSchema;
+	}
+	if (editBraze) {
+		return newsletterDataSchema.pick({
+			brazeCampaignCreationsStatus: true,
+			brazeNewsletterName: true,
+			brazeSubscribeAttributeName: true,
+			brazeSubscribeEventNamePrefix: true,
+			brazeSubscribeAttributeNameAlternate: true,
+		}) as typeof newsletterDataSchema;
+	}
+	if (editOphan) {
+		return newsletterDataSchema.pick({
+			ophanCampaignCreationsStatus: true,
+		}) as typeof newsletterDataSchema;
+	}
+	if (editTags) {
+		return newsletterDataSchema.pick({
+			tagCreationsStatus: true,
+			seriesTag: true,
+			composerTag: true,
+			composerCampaignTag: true,
+		}) as typeof newsletterDataSchema;
+	}
+	if (editSignUpPage) {
+		return newsletterDataSchema.pick({
+			signupPageCreationsStatus: true,
+			signupPage: true,
+			signUpDescription: true,
+		}) as typeof newsletterDataSchema;
+	}
+	throw new Error('No permissions found');
+};

--- a/libs/newsletters-data-client/src/lib/zod-helpers/user-data-schema.ts
+++ b/libs/newsletters-data-client/src/lib/zod-helpers/user-data-schema.ts
@@ -1,7 +1,8 @@
+import type {ZodObject, ZodRawShape} from "zod";
 import { newsletterDataSchema } from '../newsletter-data-type';
 import type { UserPermissions } from '../user-profile';
 
-export const getUserEditSchema = (permissions: UserPermissions) => {
+export const getUserEditSchema = (permissions: UserPermissions): ZodObject<ZodRawShape> => {
 	const { editBraze, editOphan, editTags, editSignUpPage, editNewsletters } =
 		permissions;
 	if (editNewsletters) {
@@ -12,7 +13,7 @@ export const getUserEditSchema = (permissions: UserPermissions) => {
 			signupPageCreationsStatus: true,
 			signupPage: true,
 			signUpDescription: true,
-		}) as typeof newsletterDataSchema;
+		});
 	}
 	if (editBraze) {
 		return newsletterDataSchema.pick({
@@ -21,12 +22,12 @@ export const getUserEditSchema = (permissions: UserPermissions) => {
 			brazeSubscribeAttributeName: true,
 			brazeSubscribeEventNamePrefix: true,
 			brazeSubscribeAttributeNameAlternate: true,
-		}) as typeof newsletterDataSchema;
+		});
 	}
 	if (editOphan) {
 		return newsletterDataSchema.pick({
 			ophanCampaignCreationsStatus: true,
-		}) as typeof newsletterDataSchema;
+		});
 	}
 	if (editTags) {
 		return newsletterDataSchema.pick({
@@ -34,14 +35,14 @@ export const getUserEditSchema = (permissions: UserPermissions) => {
 			seriesTag: true,
 			composerTag: true,
 			composerCampaignTag: true,
-		}) as typeof newsletterDataSchema;
+		});
 	}
 	if (editSignUpPage) {
 		return newsletterDataSchema.pick({
 			signupPageCreationsStatus: true,
 			signupPage: true,
 			signUpDescription: true,
-		}) as typeof newsletterDataSchema;
+		});
 	}
 	throw new Error('No permissions found');
 };

--- a/libs/newsletters-data-client/src/lib/zod-helpers/user-data-schema.ts
+++ b/libs/newsletters-data-client/src/lib/zod-helpers/user-data-schema.ts
@@ -1,5 +1,5 @@
 import type {ZodObject, ZodRawShape} from "zod";
-import { newsletterDataSchema } from '../newsletter-data-type';
+import {newsletterDataSchema} from "../schemas/newsletter-data-type";
 import type { UserPermissions } from '../user-profile';
 
 export const getUserEditSchema = (permissions: UserPermissions): ZodObject<ZodRawShape> => {

--- a/libs/newsletters-data-client/src/lib/zod-helpers/user-data-schema.ts
+++ b/libs/newsletters-data-client/src/lib/zod-helpers/user-data-schema.ts
@@ -1,8 +1,10 @@
-import type {ZodObject, ZodRawShape} from "zod";
-import {newsletterDataSchema} from "../schemas/newsletter-data-type";
+import type { ZodObject, ZodRawShape } from 'zod';
+import { newsletterDataSchema } from '../schemas/newsletter-data-type';
 import type { UserPermissions } from '../user-profile';
 
-export const getUserEditSchema = (permissions: UserPermissions): ZodObject<ZodRawShape> => {
+export const getUserEditSchema = (
+	permissions: UserPermissions,
+): ZodObject<ZodRawShape> => {
 	const { editBraze, editOphan, editTags, editSignUpPage, editNewsletters } =
 		permissions;
 	if (editNewsletters) {

--- a/libs/newsletters-data-client/src/lib/zod-helpers/user-data-schema.ts
+++ b/libs/newsletters-data-client/src/lib/zod-helpers/user-data-schema.ts
@@ -58,5 +58,5 @@ export const getUserEditSchema = (
 			signUpDescription: true,
 		});
 	}
-	throw new Error('No permissions found');
+	return newsletterDataSchema.pick({});
 };

--- a/libs/newsletters-data-client/src/lib/zod-helpers/user-data-schema.ts
+++ b/libs/newsletters-data-client/src/lib/zod-helpers/user-data-schema.ts
@@ -7,12 +7,24 @@ export const getUserEditSchema = (permissions: UserPermissions): ZodObject<ZodRa
 		permissions;
 	if (editNewsletters) {
 		return newsletterDataSchema.pick({
+			name: true,
+			frequency: true,
+			regionFocus: true,
+			theme: true,
+			status: true,
 			tagCreationsStatus: true,
-			brazeCampaignCreationsStatus: true,
+			seriesTag: true,
+			composerTag: true,
+			composerCampaignTag: true,
 			ophanCampaignCreationsStatus: true,
 			signupPageCreationsStatus: true,
 			signupPage: true,
 			signUpDescription: true,
+			brazeCampaignCreationsStatus: true,
+			brazeNewsletterName: true,
+			brazeSubscribeAttributeName: true,
+			brazeSubscribeEventNamePrefix: true,
+			brazeSubscribeAttributeNameAlternate: true,
 		});
 	}
 	if (editBraze) {


### PR DESCRIPTION
## What does this change?

This change introduces 4 new edit access levels:

- TagEditor
- BrazeEditor
- OphanEditor
- SignUpPageEditor

The edit form presented to a user in based on their access level. `TagEditors` may edit tags and the tag workflow status, `BrazeEditors` may edit the Braze values and workflow status etc.

This allows us to limit access to the edit view for a newsletter based on user context and should facilitate our async update workflows which request an update from a team to update the status of some activity outside the application. 


## How to test

- Set the access level to test in the .env.local and run the application (this file is evaluated at start time so you will need to restart for each test)
- Verify that the edit form shows the limited view (based on your selected access level)


## How can we measure success?

That views and updates are limited based on user permission status

## Have we considered potential risks?

Should be OK - tested locally

