### PR TITLE
Update launch layout to use "request launch" language

### DIFF
--- a/libs/newsletter-workflow/src/lib/executeLaunch.ts
+++ b/libs/newsletter-workflow/src/lib/executeLaunch.ts
@@ -17,6 +17,14 @@ const DERIVED_FIELD_KEYS: Array<keyof NewsletterData> = [
 	'campaignCode',
 ];
 
+// TODO: determine the correct statuses for this properties based on the type of the newsletter and the success of a call to the email service
+const asyncWorkflowRequestStatusDefaults: Partial<NewsletterData> = {
+	brazeCampaignCreationsStatus: 'REQUESTED',
+	ophanCampaignCreationsStatus: 'REQUESTED',
+	signupPageCreationsStatus: 'REQUESTED',
+	tagCreationsStatus: 'REQUESTED',
+};
+
 const getExtraValuesFromFormData = (
 	formData: FormDataRecord = {},
 ): Partial<NewsletterData> => {
@@ -49,10 +57,10 @@ export const executeLaunch: AsyncExecution<LaunchService> = async (
 		return { isFailure: true, message: 'ERROR: no launch service available' };
 	}
 
-	const response = await launchService.launchDraft(
-		draftId,
-		getExtraValuesFromFormData(stepData.formData),
-	);
+	const response = await launchService.launchDraft(draftId, {
+		...getExtraValuesFromFormData(stepData.formData),
+		...asyncWorkflowRequestStatusDefaults,
+	});
 	if (!response.ok) {
 		return { isFailure: true, message: response.message };
 	}

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/doLaunchLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/doLaunchLayout.ts
@@ -4,12 +4,10 @@ import { executeLaunch } from '../../executeLaunch';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 
-// TODO - this page is a placeholder until we implement automation
-// I have added it so that both Ophan and Edit Ophan point to a single place from which to call the Launch functionality
 const markdownTemplate = `
-## {{name}} is ready to launch
+## {{name}} is ready for a launch request
 
-All the steps have been completed, so please press the Launch button when you're ready to continue.
+All the data collection steps have now been completed. By requesting a launch for this newsletter, the teams responsible for creating tags, sign-up pages, the Braze campaign and tracking the newsletter will be notified. Once these tasks have been completed, the newsletter will be ready to send.
 
 `.trim();
 
@@ -36,7 +34,7 @@ export const doLaunchLayout: WizardStepLayout<LaunchService> = {
 		},
 		next: {
 			buttonType: 'LAUNCH',
-			label: 'Launch',
+			label: 'Request Launch',
 			stepToMoveTo: 'finish',
 			executeStep: executeLaunch,
 		},

--- a/libs/newsletters-data-client/src/lib/launch-service/index.ts
+++ b/libs/newsletters-data-client/src/lib/launch-service/index.ts
@@ -22,13 +22,13 @@ export class LaunchService {
 		draftStorage: DraftStorage,
 		newsletterStorage: NewsletterStorage,
 		userProfile: UserProfile,
-		emailClent: SESClient,
+		emailClient: SESClient,
 		emailEnvInfo: EmailEnvInfo,
 	) {
 		this.draftStorage = draftStorage;
 		this.newsletterStorage = newsletterStorage;
 		this.userProfile = userProfile;
-		this.emailClent = emailClent;
+		this.emailClent = emailClient;
 		this.emailEnvInfo = emailEnvInfo;
 	}
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Sets launch layout to "Request launch" rather than launch as this is an async workflow

Sets the async workflow statuses to`REQUESTED`. That logic will be refined in a later PR. (Ticket https://trello.com/c/DUzHS602/578-email-groups-with-links-for-edit-form-on-launch) by determining the set of async workflows require and then on the success of email via the messaging client. 

## How to test

Chech the copy in the launch workflow & button. errify statuses have been updated.


## Have we considered potential risks?

Should be fine

## Images

<img width="811" alt="Screenshot 2023-09-04 at 08 27 54" src="https://github.com/guardian/newsletters-nx/assets/3277259/879460bc-d7df-4ec1-93e8-13be30aac525">

<img width="1027" alt="Screenshot 2023-09-04 at 08 44 08" src="https://github.com/guardian/newsletters-nx/assets/3277259/c7982b38-6e61-40b6-a949-c904cca56794">

