### PR TITLE
Show pending statuses in table

### DIFF
--- a/apps/newsletters-ui/src/app/components/Cell.tsx
+++ b/apps/newsletters-ui/src/app/components/Cell.tsx
@@ -44,7 +44,7 @@ export const formatStatusCell = ({
 	if (!value) return <span></span>;
 
 	const status = value.toLowerCase();
-	const statusClass =
+	const statusCell =
 		status === 'pending' ? (
 			<Tooltip title={statuses}>
 				<span style={{ cursor: 'pointer', display: 'flex' }}>
@@ -54,5 +54,5 @@ export const formatStatusCell = ({
 		) : (
 			status
 		);
-	return <span>{statusClass}</span>;
+	return <span>{statusCell}</span>;
 };

--- a/apps/newsletters-ui/src/app/components/Cell.tsx
+++ b/apps/newsletters-ui/src/app/components/Cell.tsx
@@ -1,6 +1,10 @@
+import InfoIcon from '@mui/icons-material/Info';
+import Tooltip from '@mui/material/Tooltip';
+import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
 import { renderYesNo } from '../util';
 
-export type Cell<T> = { cell: { value: T } };
+export type Cell<T> = { cell: { value: T; row: { original: NewsletterData } } };
+
 export const MIGRATION_TIMESTAMP_VALUE = 946684800;
 export const formatCellBoolean = ({ cell: { value } }: Cell<boolean>) => (
 	<span>{renderYesNo(value)}</span>
@@ -13,4 +17,42 @@ export const formatCellDate = ({ cell: { value } }: Cell<number>) => {
 	const isValid = !isNaN(date.valueOf());
 	const output = isValid ? date.toDateString() : '[INVALID DATE]';
 	return <span>{output}</span>;
+};
+
+const formatStatus = (status: string) => status.toLowerCase().replace('_', ' ');
+
+export const formatStatusCell = ({
+	cell: {
+		value,
+		row: { original },
+	},
+}: Cell<string>) => {
+	const {
+		brazeCampaignCreationsStatus,
+		ophanCampaignCreationsStatus,
+		signupPageCreationsStatus,
+		tagCreationsStatus,
+	} = original;
+
+	const statuses = `Braze status: ${formatStatus(
+		brazeCampaignCreationsStatus,
+	)}, Ophan status: ${formatStatus(
+		ophanCampaignCreationsStatus,
+	)}, Signup page status: ${formatStatus(
+		signupPageCreationsStatus,
+	)}, Tag status: ${formatStatus(tagCreationsStatus)}`;
+	if (!value) return <span></span>;
+
+	const status = value.toLowerCase();
+	const statusClass =
+		status === 'pending' ? (
+			<Tooltip title={statuses}>
+				<span style={{ cursor: 'pointer', display: 'flex' }}>
+					{status} <InfoIcon fontSize="small" style={{ paddingLeft: '4px' }} />
+				</span>
+			</Tooltip>
+		) : (
+			status
+		);
+	return <span>{statusClass}</span>;
 };

--- a/apps/newsletters-ui/src/app/components/NewslettersTable.tsx
+++ b/apps/newsletters-ui/src/app/components/NewslettersTable.tsx
@@ -4,7 +4,7 @@ import type { Column } from 'react-table';
 import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
 import { usePermissions } from '../hooks/user-hooks';
 import { shouldShowEditOptions } from '../services/authorisation';
-import { formatCellDate } from './Cell';
+import { formatCellDate, formatStatusCell } from './Cell';
 import { ExternalLinkButton } from './ExternalLinkButton';
 import { NavigateButton } from './NavigateButton';
 import { Table } from './Table';
@@ -58,6 +58,7 @@ export const NewslettersTable = ({ newsletters }: Props) => {
 				Header: 'Status',
 				accessor: 'status',
 				sortType: 'basic',
+				Cell: formatStatusCell,
 			},
 		];
 


### PR DESCRIPTION
## What does this change?

Where a launch has been requested for a newsletter, the status in the table view now has a tooltip which details the statuses of all the async workflows. 

## How to test

Launch a newsletter and check that the info icon is rendered in the table view and the the tooltip appears on hover

## Have we considered potential risks?

Should be fine


## Images
<img width="1183" alt="Screenshot 2023-09-04 at 13 54 15" src="https://github.com/guardian/newsletters-nx/assets/3277259/a2a818d5-f694-41f5-81f6-251f957f8c51">

