### PR TITLE
Group and Pillar Step

### DIFF
--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
@@ -90,7 +90,7 @@ export const formSchemas = {
 				'From the papers',
 			]),
 		})
-		.describe('Choose a theme and a group'),
+		.describe('Choose a pillar and a group'),
 
 	signUpPage: dataCollectionSchema
 		.pick({

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/pillarAndGroupLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/pillarAndGroupLayout.ts
@@ -13,20 +13,13 @@ import { formSchemas } from './formSchemas';
 const markdownTemplate = `
 ## Choose the Pillar and Group for {{name}}
 
-Select a pillar for the newsletter e.g. **Football Daily** sits under the **Sport** pillar.
+Select a pillar for the **{{name}}** e.g. "*Football Daily*" sits under the *Sport* pillar. The pillar is a general category for the newsletter's content and design elements that represent the newsletter can use the pillar to determine the right color scheme to use.
 
 ![Pillars](https://i.guim.co.uk/img/uploads/2023/02/21/pillarScreenshot.png?quality=85&dpr=2&width=300&s=0692a8714eaf66313fc599cb3462befd)
 
-Select a group for {{name}} to be listed under on the [All Newsletters Page](https://www.theguardian.com/email-newsletters). The current groups are:
- - News in depth
- - News in brief
- - Opinion
- - Features
- - Culture
- - Lifestyle
- - Sport
- - Work
- - From the papers
+Please then select a group for **{{name}}** to be listed under on the [Manage My Account](https://manage.theguardian.com/email-prefs) page. The current groups include ‘News in depth’, ‘News in brief’ and others.
+
+![Groups](https://i.guim.co.uk/img/uploads/2023/09/11/mma-screenshot.png?quality=85&dpr=2&width=300&s=1b7e49ebb42e9ac563da1f2afedf1c88)
 
 `.trim();
 

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/pillarAndGroupLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/pillarAndGroupLayout.ts
@@ -13,11 +13,11 @@ import { formSchemas } from './formSchemas';
 const markdownTemplate = `
 ## Choose the Pillar and Group for {{name}}
 
-Select a pillar for the **{{name}}** e.g. "*Football Daily*" sits under the *Sport* pillar. The pillar is a general category for the newsletter's content and design elements that represent the newsletter can use the pillar to determine the right color scheme to use.
+Please select a pillar (a section category) for **{{name}}** e.g. "*Football Daily*" sits under the *Sport* pillar.
 
 ![Pillars](https://i.guim.co.uk/img/uploads/2023/02/21/pillarScreenshot.png?quality=85&dpr=2&width=300&s=0692a8714eaf66313fc599cb3462befd)
 
-Please then select a group for **{{name}}** to be listed under on the [Manage My Account](https://manage.theguardian.com/email-prefs) page. The current groups include ‘News in depth’, ‘News in brief’ and others.
+Please then select a group for **{{name}}** to be listed under on the [Manage My Account](https://manage.theguardian.com/email-prefs) page e.g. *News in Depth*.
 
 ![Groups](https://i.guim.co.uk/img/uploads/2023/09/11/mma-screenshot.png?quality=85&dpr=2&width=300&s=1b7e49ebb42e9ac563da1f2afedf1c88)
 

--- a/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
@@ -92,6 +92,12 @@ export const newsletterDataSchema = z.object({
 	brazeSubscribeAttributeName: underscoreCasedString(),
 	brazeSubscribeEventNamePrefix: kebabOrUnderscoreCasedString(),
 	brazeNewsletterName: underscoreCasedString(),
+	/**
+	 * The name of the Pillar to associate this newsletter under
+	 *
+	 * Note that the display name(set using the schema description)
+	 * for this field in the tool is "pillar".
+	 * */
 	theme: themeEnumSchema,
 	group: nonEmptyString(),
 	signUpHeadline: z.string().optional().describe('sign up headline'),

--- a/libs/newsletters-data-client/src/lib/schemas/theme-enum-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/schemas/theme-enum-data-type.ts
@@ -1,12 +1,7 @@
 import { z } from 'zod';
 
-export const themeEnumSchema = z.enum([
-	'news',
-	'opinion',
-	'culture',
-	'sport',
-	'lifestyle',
-	'features',
-]);
+export const themeEnumSchema = z
+	.enum(['news', 'opinion', 'culture', 'sport', 'lifestyle', 'features'])
+	.describe('pillar');
 
 export type Theme = z.infer<typeof themeEnumSchema>;


### PR DESCRIPTION
## What does this change?

Changes the field description for "theme" to "pillar" (only effects the labelling in the tool - the field name is still "theme" in the data model)

Updates the copy on the "Pillar and Group" step to reflect that "group" is now only used for the MMA page, not the all -newsletters page.

https://trello.com/c/arpLcg98/629-update-pillar-and-group-labels

## How to test

Still works, looks right.

## How can we measure success?

UI step better describes what the fields are for to users.

## Have we considered potential risks?

only changes the UI

## Images

<img width="990" alt="Screenshot 2023-09-12 at 11 50 57" src="https://github.com/guardian/newsletters-nx/assets/30567854/c9fc6c95-7e7e-4fcb-bd9b-3db2af8b4423">

