### PR TITLE
Show edit button to users with edit permissions in the detail view

### DIFF
--- a/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
+++ b/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
@@ -1,6 +1,9 @@
 import { Badge, Box, Grid, Stack, Typography } from '@mui/material';
+import { useEffect, useState } from 'react';
 import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
 import { getPropertyDescription } from '@newsletters-nx/newsletters-data-client';
+import { usePermissions } from '../hooks/user-hooks';
+import { shouldShowEditOptions } from '../services/authorisation';
 import { DetailAccordian } from './DetailAccordian';
 import { higherLevelDataPoint } from './higher-level-data-point';
 import { Illustration } from './Illustration';
@@ -13,6 +16,15 @@ interface Props {
 
 export const NewsletterDataDetails = ({ newsletter }: Props) => {
 	const { status, name } = newsletter;
+	const permissions = usePermissions();
+	const [showEditButton, setShowEditButton] = useState(false);
+
+	useEffect(() => {
+		if (permissions) {
+			setShowEditButton(shouldShowEditOptions(permissions) ?? false);
+		}
+	}, [permissions]);
+
 	const DataPoint = higherLevelDataPoint(newsletter);
 
 	return (
@@ -35,6 +47,14 @@ export const NewsletterDataDetails = ({ newsletter }: Props) => {
 						>
 							View rendering preview
 						</NavigateButton>
+						{showEditButton && (
+							<NavigateButton
+								href={`/launched/edit/${newsletter.identityName}`}
+								variant="outlined"
+							>
+								Edit Newsletter
+							</NavigateButton>
+						)}
 					</Box>
 				</Grid>
 				<Grid item>


### PR DESCRIPTION
## What does this change?

There is no fast route to edit when viewing details for a  newsletter. This PR adds a button for users with edit permissions to save their having to navigate back to the list of all newsletters and then clicking the edit link after refinding newsletter they want to edit

## How to test

Check edit button available to editor types and not viewers


## How can we measure success?

Rendering of the button

## Have we considered potential risks?

Low risk change

## Images

![Screenshot 2023-09-18 at 09 05 03](https://github.com/guardian/newsletters-nx/assets/3277259/dee218dc-5558-4aa9-88ae-dc42517ec14e)
