### PR TITLE
Tweak to permissions to group tags and signup page for CP

### DIFF
--- a/apps/newsletters-api/env.local.example.txt
+++ b/apps/newsletters-api/env.local.example.txt
@@ -33,7 +33,7 @@ LOCAL_USER_PROFILE_EMAIL=software.developer@guardian.co.uk
 
 # allows local running with developer permissions without needing to login
 # Update the access level as required:
-# 0 - Developer, 1 - Editor, 2 - Drafter, 3 - Viewer, 4 - TagEditor, 5 - BrazeEditor, 6 - OphanEditor, 7 - SignUpPageEditor
+# 0 - Developer, 1 - Editor, 2 - Drafter, 3 - Viewer, 4 - CentralProduction, 5 - BrazeEditor, 6 - OphanEditor
 USER_PERMISSIONS={"software.developer@guardian.co.uk": 0}
 
 # whether to fetch from a local instance of email rendering on port 3010

--- a/apps/newsletters-api/src/apiDeploymentSettings.ts
+++ b/apps/newsletters-api/src/apiDeploymentSettings.ts
@@ -87,8 +87,7 @@ export const getLocalUserProfiles = (): Record<string, UserAccessLevel> => {
 				case UserAccessLevel.Viewer:
 				case UserAccessLevel.OphanEditor:
 				case UserAccessLevel.BrazeEditor:
-				case UserAccessLevel.TagEditor:
-				case UserAccessLevel.SignUpPageEditor:
+				case UserAccessLevel.CentralProduction:
 					output[key] = value;
 					break;
 			}

--- a/libs/newsletters-data-client/src/lib/user-profile.ts
+++ b/libs/newsletters-data-client/src/lib/user-profile.ts
@@ -29,10 +29,9 @@ export enum UserAccessLevel {
 	Editor,
 	Drafter,
 	Viewer,
-	TagEditor,
+	CentralProduction,
 	BrazeEditor,
 	OphanEditor,
-	SignUpPageEditor,
 }
 
 export type UserPermissions = {
@@ -63,16 +62,15 @@ export const levelToPermissions = (
 			UserAccessLevel.Developer,
 			UserAccessLevel.Editor,
 			UserAccessLevel.Drafter,
-			UserAccessLevel.TagEditor,
+			UserAccessLevel.CentralProduction,
 			UserAccessLevel.BrazeEditor,
 			UserAccessLevel.OphanEditor,
-			UserAccessLevel.SignUpPageEditor,
 		].includes(accessLevel),
 		viewMetaData: [UserAccessLevel.Developer].includes(accessLevel),
 		useJsonEditor: [UserAccessLevel.Developer].includes(accessLevel),
 		editBraze: [UserAccessLevel.BrazeEditor].includes(accessLevel),
 		editOphan: [UserAccessLevel.OphanEditor].includes(accessLevel),
-		editTags: [UserAccessLevel.TagEditor].includes(accessLevel),
-		editSignUpPage: [UserAccessLevel.SignUpPageEditor].includes(accessLevel),
+		editTags: [UserAccessLevel.CentralProduction].includes(accessLevel),
+		editSignUpPage: [UserAccessLevel.CentralProduction].includes(accessLevel),
 	};
 };

--- a/libs/newsletters-data-client/src/lib/zod-helpers/user-data-schema.ts
+++ b/libs/newsletters-data-client/src/lib/zod-helpers/user-data-schema.ts
@@ -44,16 +44,12 @@ export const getUserEditSchema = (
 			ophanCampaignCreationStatus: true,
 		});
 	}
-	if (editTags) {
+	if (editTags && editSignUpPage) {
 		return newsletterDataSchema.pick({
 			tagCreationStatus: true,
 			seriesTag: true,
 			composerTag: true,
 			composerCampaignTag: true,
-		});
-	}
-	if (editSignUpPage) {
-		return newsletterDataSchema.pick({
 			signupPageCreationStatus: true,
 			signupPage: true,
 			signUpDescription: true,


### PR DESCRIPTION
## What does this change?

Removed the separate tag and signUp page editor levels and replaces them with a single CentralProduction one with the group permissions as this is in fact what we need. We might revisit this as part of the permission model update but this will allow us to test with CP in the next couple of days

## How to test

Set your local permisison to 4, verify that permisisons are limited to the signUp page & tags elements (and that these can be updated)

## How can we measure success?

Edit fincitonality limited as intended

## Have we considered potential risks?

Should be OK

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

![Screenshot 2023-09-18 at 14 49 36](https://github.com/guardian/newsletters-nx/assets/3277259/751e6f19-1d0c-4e82-b29d-b8849ff16b93)
