### PR TITLE
Update illustration card to match the rest of the steps

### DIFF
--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/illustrationCardLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/illustrationCardLayout.ts
@@ -26,7 +26,7 @@ const staticMarkdown = markdownTemplate.replace(
 export const illustrationCardLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown,
 	label: 'Illustration Card',
-	dynamicMarkdown(requestData, responseData) {
+	dynamicMarkdown(_, responseData) {
 		if (!responseData) {
 			return staticMarkdown;
 		}
@@ -36,13 +36,13 @@ export const illustrationCardLayout: WizardStepLayout<DraftService> = {
 	buttons: {
 		back: {
 			buttonType: 'PREVIOUS',
-			label: 'Back',
+			label: 'Back to previous step',
 			stepToMoveTo: getNextStepId,
-			executeStep: executeModify,
+			executeStep: executeSkip,
 		},
 		finish: {
 			buttonType: 'NEXT',
-			label: 'Next',
+			label: 'Save and continue',
 			stepToMoveTo: getNextStepId,
 			executeStep: executeModify,
 		},


### PR DESCRIPTION
## What does this change?

The illustration card was added before the merge of the update to the rest of the buttons in the data collection workflow. Its buttons use the old labels and back still persists changes. This PR makes it consistent with the rest

## How to test

Visual code check sufficient

## How can we measure success?

Labels & behaviour  match

## Have we considered potential risks?

Yep

## Images

| Before | After |
|--------|--------|
| <img width="1218" alt="Screenshot 2023-09-19 at 09 10 50" src="https://github.com/guardian/newsletters-nx/assets/3277259/b97534b6-27bb-4f8a-a553-327b5f3ae31f"> | <img width="1209" alt="Screenshot 2023-09-19 at 09 10 15" src="https://github.com/guardian/newsletters-nx/assets/3277259/c1e5c53a-67b6-4537-8df9-a7b3ce86aedf">
 | 