### PR TITLE
load user permissions data from config-service 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ See the documentation for the [API](apps/newsletters-api/README.md) for the conf
 
 **NOTE** Any changes to the legacy API data structure should be communicated to the [Data Design](mailto:data.design@theguardian.com) **before** merging to main.
 
-## UI Tool Deployment and Access
+## UI Tool Deployment
 
 The newsletters-tool is deployed to PROD
 https://newsletters-tool.gutools.co.uk/
@@ -41,5 +41,19 @@ https://newsletters-tool.code.dev-gutools.co.uk/
 
 Continuous Integration (CI) is configured on this Repo. Merging to main will trigger redeployment to of PROD using [RiffRaff](https://riffraff.gutools.co.uk/). To deploy a build to CODE, push your branch to github and create a PR (draft will do). The build can be selected and deployed from [RiffRaff's deploy page](https://riffraff.gutools.co.uk/deployment/request) (project=newsletters::newsletters-tool).
 
+## User Permissions for the UI Tool
+
 Users need to log to a Guardian account in using google auth to access the UI. The web application auth configuration in the google console can be accessed (requires membership of the newsletters admin group) at
 https://console.cloud.google.com/apis/credentials?project=newsletter-source-api
+
+By default, Guardian staff have "viewer" permissions, which lets them access the tool but not make any changes to the data. Spefic users can be granted extra permissions by updating the userPermissions data, which is held in the AWS Parameter store in the 'frontend' account (accessable via [Janus](https://janus.gutools.co.uk/)). There is a separate param for each stage:
+
+-   /CODE/newsletters/newsletters-tool/userPermissions
+-   /DEV/newsletters/newsletters-tool/userPermissions
+-   /PROD/newsletters/newsletters-tool/userPermissions
+
+The API application will check for updates to the data once per 15 minute interval - so updates to the data take up to 15 minutes to take effect for the user in the UI.
+
+**TO DO** - it would be peferable for access to the Tool to be managed using the existing [Permissions system](https://github.com/guardian/permissions).
+
+[![](https://mermaid.ink/img/pako:eNplUc1ugzAMfhUr5_ICHDZR6KoeNiFtPSUcMmJKNEg2J6hCpe8-U4q0ajlZ8ffjz76I2hsUqWg6f65bTRE-CuWA3xaS5Gk6BiQoyTe2wwmypZVJ-Ybn0GGMSCE5HqrqBu78CaybYCvl3vtTh5ANsa2qO-uG-fRmTCErD0D4M2CISrkWtUnh0Sp_9GDCqpPPOoWUpSbdQ4iecG0Vs8PAOgF0XWMIYHTUU34n_gu0u7R6hfIc80SW0HDZeFoHfIbrwt_NfOenF5kt4gU6i6b60x0xTHtZIjG_XwUqsRE9Uq-t4U1fZrgSscUelUi5NJq-lFDuyjg9RP8-ulqkkQbciOGbE2Bh9YnDirTRXeBfNJZjvy6nu13w-gtKPpnr?type=png)](https://mermaid.live/edit#pako:eNplUc1ugzAMfhUr5_ICHDZR6KoeNiFtPSUcMmJKNEg2J6hCpe8-U4q0ajlZ8ffjz76I2hsUqWg6f65bTRE-CuWA3xaS5Gk6BiQoyTe2wwmypZVJ-Ybn0GGMSCE5HqrqBu78CaybYCvl3vtTh5ANsa2qO-uG-fRmTCErD0D4M2CISrkWtUnh0Sp_9GDCqpPPOoWUpSbdQ4iecG0Vs8PAOgF0XWMIYHTUU34n_gu0u7R6hfIc80SW0HDZeFoHfIbrwt_NfOenF5kt4gU6i6b60x0xTHtZIjG_XwUqsRE9Uq-t4U1fZrgSscUelUi5NJq-lFDuyjg9RP8-ulqkkQbciOGbE2Bh9YnDirTRXeBfNJZjvy6nu13w-gtKPpnr)

--- a/apps/newsletters-api/env.local.example.txt
+++ b/apps/newsletters-api/env.local.example.txt
@@ -28,12 +28,27 @@ USE_DEVELOPER_PROFILE=true
 
 # the name of the local user for development
 LOCAL_USER_PROFILE_NAME="Software Developer"
+# LOCAL_USER_PROFILE_NAME="Standard User"
+# LOCAL_USER_PROFILE_NAME="Central Production User"
+
 # the Email Address of the local user for development
 LOCAL_USER_PROFILE_EMAIL=software.developer@guardian.co.uk
+# LOCAL_USER_PROFILE_EMAIL=standard.users@guardian.co.uk
+# LOCAL_USER_PROFILE_EMAIL=central.production@guardian.co.uk
+
+
+# toggle for whether to use the USER_PERMISSIONS env var instead of fetching user permissions from the parameter store
+USE_LOCAL_USER_PERMISSIONS=false
 
 # allows local running with developer permissions without needing to login
 # Update the access level as required:
-# 0 - Developer, 1 - Editor, 2 - Drafter, 3 - Viewer, 4 - CentralProduction, 5 - BrazeEditor, 6 - OphanEditor
+# 0 - Developer,
+# 1 - Editor,
+# 2 - Drafter,
+# 3 - Viewer,
+# 4 - CentralProduction,
+# 5 - BrazeEditor,
+# 6 - OphanEditor,
 USER_PERMISSIONS={"software.developer@guardian.co.uk": 0}
 
 # whether to fetch from a local instance of email rendering on port 3010

--- a/apps/newsletters-api/src/apiDeploymentSettings.ts
+++ b/apps/newsletters-api/src/apiDeploymentSettings.ts
@@ -60,6 +60,10 @@ export const getTestJwtProfileDataIfUsing = () => {
 	return process.env.USE_FAKE_JWT === 'true' ? process.env.FAKE_JWT : undefined;
 };
 
+export const isUsingLocalUserPermissions = () => {
+	return process.env.USE_LOCAL_USER_PERMISSIONS === 'true';
+};
+
 export const getLocalUserProfiles = (): Record<string, UserAccessLevel> => {
 	const json = process.env.USER_PERMISSIONS;
 	if (!json) {

--- a/apps/newsletters-api/src/services/permissions/ParamPermissions.ts
+++ b/apps/newsletters-api/src/services/permissions/ParamPermissions.ts
@@ -1,0 +1,49 @@
+import type { UserProfile } from '@newsletters-nx/newsletters-data-client';
+import {
+	levelToPermissions,
+	permissionsDataSchema,
+	UserAccessLevel,
+} from '@newsletters-nx/newsletters-data-client';
+import { getConfigValue } from '@newsletters-nx/util';
+import type { PermissionsService } from './abstract-class';
+
+/** 15 minutes*/
+const TIME_BETWEEN_PERMISSIONS_PARAM_CHECKS = 1000 * 60 * 15;
+
+const getPermissionsData = async (): Promise<
+	Partial<Record<string, UserAccessLevel>>
+> => {
+	try {
+		const value = await getConfigValue('userPermissions', {
+			maxAge: TIME_BETWEEN_PERMISSIONS_PARAM_CHECKS,
+		});
+		return permissionsDataSchema.parse(JSON.parse(value)) as Record<
+			string,
+			UserAccessLevel
+		>;
+	} catch (error) {
+		console.warn('getPermissionsData failed');
+		console.warn(error);
+		return {};
+	}
+};
+
+const defaultPermission = () => levelToPermissions(UserAccessLevel.Viewer);
+
+export class ParamPermissionService implements PermissionsService {
+	async get(user?: UserProfile) {
+		const email = user?.email;
+		if (!email) {
+			return defaultPermission();
+		}
+
+		const data = await getPermissionsData();
+
+		const accessLevel = data[email];
+		if (typeof accessLevel === 'undefined') {
+			return defaultPermission();
+		}
+
+		return levelToPermissions(accessLevel);
+	}
+}

--- a/apps/newsletters-api/src/services/permissions/index.ts
+++ b/apps/newsletters-api/src/services/permissions/index.ts
@@ -1,5 +1,10 @@
+import { isUsingLocalUserPermissions } from '../../apiDeploymentSettings';
+import type { PermissionsService } from './abstract-class';
 import { LocalPermissionService } from './LocalPermissions';
+import { ParamPermissionService } from './ParamPermissions';
 
-const permissionService = new LocalPermissionService();
+const permissionService: PermissionsService = isUsingLocalUserPermissions()
+	? new LocalPermissionService()
+	: new ParamPermissionService();
 
 export { permissionService };

--- a/libs/email-builder/src/lib/message-config.ts
+++ b/libs/email-builder/src/lib/message-config.ts
@@ -2,6 +2,9 @@ import type { EmailEnvInfo } from '@newsletters-nx/newsletters-data-client';
 import { getConfigValue } from '@newsletters-nx/util';
 import type { EmailRecipientConfiguration, MessageConfig } from './types';
 
+/** 15 minutes*/
+const TIME_BETWEEN_RECIPIENT_PARAM_CHECKS = 1000 * 60 * 15;
+
 export type NewsletterMessageId =
 	| 'NEW_DRAFT_CREATED'
 	| 'NEWSLETTER_LAUNCH'
@@ -22,7 +25,9 @@ export const getMessageConfig = async (
 		brazeRecipients,
 		launchRecipients,
 	} = JSON.parse(
-		await getConfigValue('emailRecipientConfiguration'),
+		await getConfigValue('emailRecipientConfiguration', {
+			maxAge: TIME_BETWEEN_RECIPIENT_PARAM_CHECKS,
+		}),
 	) as EmailRecipientConfiguration;
 
 	const recipientMapping: Record<NewsletterMessageId, string[]> = {

--- a/libs/newsletters-data-client/src/lib/user-profile.ts
+++ b/libs/newsletters-data-client/src/lib/user-profile.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 /**
  * The fields expected in user data obtained by the Ec2
  * load balancer when authenticating user via Google auth,
@@ -45,6 +47,11 @@ export type UserPermissions = {
 	editTags: boolean;
 	editSignUpPage: boolean;
 };
+
+export const permissionsDataSchema = z.record(
+	z.string(),
+	z.number().int().min(0),
+);
 
 export const levelToPermissions = (
 	accessLevel: UserAccessLevel,


### PR DESCRIPTION
## What does this change?

Adds an option to the config-service to request a value that was fetch from the store within a give time frame - IE that the value is not too stale.

Sets the request for the email recipient data to specify they be not more than 15 minutes old - IE the service will check for updates if it fetched the value it storer in `state` more than 15 minutes ago.

The user permissions are loaded from the param store at run time (also max age 15 minutes) in the same way as the email permissions data, instead us using the env vars - unless the new "USE_LOCAL_USER_PERMISSIONS" env var is set to 'true'

## How to test

locally 
 - set "USE_LOCAL_USER_PERMISSIONS" to "false"
 - changes in /DEV/newsletters/newsletters-tool/userPermissions will be reflected when you run the app locally
 - changes made to the param store while the app is running will take effect after the specified time (you could change the constant `TIME_BETWEEN_PERMISSIONS_PARAM_CHECKS` constant to 1 minute for the purpose of testing. 

## How can we measure success?

Able to change user permissions without redeploying by changing the param store value

## Have we considered potential risks?

 - Should test on code first.
 - The permissions for CODE and PROD are already in the store - were  being fetched to set the env vars in the stack
 - is 15 minutes too long to wait for a config update? We won't be changing these values often, but the cost of making the request to param store more often shouldn't be significant.
 - if the works, should update the cdk to not add the permissions to the env vars for CODE and PROD - won't be getting used.
