### PR TITLE
Update language around launch to make it clear that the launch is a request

### DIFF
--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/doLaunchLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/doLaunchLayout.ts
@@ -25,7 +25,7 @@ export const doLaunchLayout: WizardStepLayout<LaunchService> = {
 		const [name = 'NAME'] = getStringValuesFromRecord(responseData, ['name']);
 		return markdownTemplate.replace(regExPatterns.name, name);
 	},
-	label: 'Launch',
+	label: 'Request launch',
 	buttons: {
 		cancel: {
 			buttonType: 'CANCEL',

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/finishLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/finishLayout.ts
@@ -5,11 +5,13 @@ import { regExPatterns } from '../../regExPatterns';
 
 const markdownTemplate = `## Finished
 
-You have reached the end of the wizard. **{{name}}** has been launched!
+You have requested the launch of **{{name}}**
 
 It has id {{listId}}.
 
 You can see its details on the [details page](/launched/{{identityName}})
+
+Once the teams responsible for creating tags, sign-up pages, the Braze campaign and tracking the newsletter have completed their tasks, the newsletter will be ready to mark as live.
 
 `.trim();
 


### PR DESCRIPTION
## What does this change?

Updates step name and copy to make it clear that launch is a  request and that other teams need to do something

## How to test

Visual code check

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Happiness with language

## Have we considered potential risks?

yep

## Images

| Before | After |
|--------|--------|
| <img width="1034" alt="Screenshot 2023-09-21 at 12 04 48" src="https://github.com/guardian/newsletters-nx/assets/3277259/a1d7b737-c889-46d0-be74-22531e4a26b8"> | <img width="1111" alt="Screenshot 2023-09-21 at 11 56 34" src="https://github.com/guardian/newsletters-nx/assets/3277259/5af3bf16-67b8-446b-bf7d-4457ac428526"> |
| <img width="1080" alt="Screenshot 2023-09-21 at 12 04 56" src="https://github.com/guardian/newsletters-nx/assets/3277259/f850fbfa-c4b6-42fc-8e58-9619a377a9f0"> | <img width="1073" alt="Screenshot 2023-09-21 at 11 56 46" src="https://github.com/guardian/newsletters-nx/assets/3277259/05ad03d3-2cc4-404f-b1ca-c3676a9f6084"> | 

## Accessibility



<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
