### PR TITLE
main nav refactor

### DIFF
--- a/apps/newsletters-ui/src/app/components/MainNav.tsx
+++ b/apps/newsletters-ui/src/app/components/MainNav.tsx
@@ -70,7 +70,6 @@ export function MainNav({ isOnCode }: Props) {
 		<AppBar position="fixed" component={'header'}>
 			<Container maxWidth="xl">
 				<Toolbar disableGutters>
-					{/* Mobile menu */}
 					<Box sx={{ flexGrow: 1, display: { xs: 'flex', md: 'none' } }}>
 						<IconButton
 							size="large"
@@ -115,10 +114,8 @@ export function MainNav({ isOnCode }: Props) {
 						</Menu>
 					</Box>
 
-					<NewslettersBrandHeading mobile={false} />
-					<NewslettersBrandHeading mobile={true} />
+					<NewslettersBrandHeading />
 
-					{/* desktop menu */}
 					<Box sx={{ flexGrow: 1, display: { xs: 'none', md: 'flex' } }}>
 						{navLinks.map(({ path, label }) => (
 							<Button

--- a/apps/newsletters-ui/src/app/components/MainNav.tsx
+++ b/apps/newsletters-ui/src/app/components/MainNav.tsx
@@ -52,12 +52,36 @@ const ToolBarIcon = (props: {
 	</Box>
 );
 
-export function MainNav({ isOnCode }: Props) {
+const DesktopNavLinks = () => {
+	const navigate = useNavigate();
+	return (
+		<Box sx={{ flexGrow: 1, display: { xs: 'none', md: 'flex' } }}>
+			{navLinks.map(({ path, label }) => (
+				<Button
+					key={label}
+					onClick={() => {
+						navigate(path);
+					}}
+					sx={{
+						my: 2,
+						color: 'white',
+						fontWeight: menuItemIsSelected(path) ? 'bold' : 'normal',
+						display: 'block',
+						borderBottomStyle: menuItemIsSelected(path) ? 'solid' : 'none',
+						borderBottomWidth: '2px',
+						borderRadius: '0',
+					}}
+				>
+					{label}
+				</Button>
+			))}
+		</Box>
+	);
+};
+
+const MobileBurgerNav = () => {
 	const [anchorElNav, setAnchorElNav] = useState<null | HTMLElement>(null);
 	const navigate = useNavigate();
-	const userProfile = useProfile();
-	const userName = userProfile?.name ?? 'Logged in user';
-
 	const handleOpenNavMenu = (event: React.MouseEvent<HTMLElement>) => {
 		setAnchorElNav(event.currentTarget);
 	};
@@ -67,78 +91,63 @@ export function MainNav({ isOnCode }: Props) {
 	};
 
 	return (
+		<Box sx={{ display: { xs: 'flex', md: 'none' } }}>
+			<IconButton
+				size="large"
+				aria-label="account of current user"
+				aria-controls="menu-appbar"
+				aria-haspopup="true"
+				onClick={handleOpenNavMenu}
+				color="inherit"
+			>
+				<MenuIcon />
+			</IconButton>
+			<Menu
+				id="menu-appbar"
+				anchorEl={anchorElNav}
+				anchorOrigin={{
+					vertical: 'bottom',
+					horizontal: 'left',
+				}}
+				keepMounted
+				transformOrigin={{
+					vertical: 'top',
+					horizontal: 'left',
+				}}
+				open={Boolean(anchorElNav)}
+				onClose={handleCloseNavMenu}
+				sx={{
+					display: { xs: 'block', md: 'none' },
+				}}
+			>
+				{navLinks.map(({ path, label }) => (
+					<MenuItem
+						key={label}
+						onClick={() => {
+							navigate(path);
+							handleCloseNavMenu();
+						}}
+						selected={menuItemIsSelected(path)}
+					>
+						<Typography textAlign="center">{label}</Typography>
+					</MenuItem>
+				))}
+			</Menu>
+		</Box>
+	);
+};
+
+export function MainNav({ isOnCode }: Props) {
+	const userProfile = useProfile();
+	const userName = userProfile?.name ?? 'Logged in user';
+
+	return (
 		<AppBar position="fixed" component={'header'}>
 			<Container maxWidth="xl">
 				<Toolbar disableGutters>
-					<Box sx={{ display: { xs: 'flex', md: 'none' } }}>
-						<IconButton
-							size="large"
-							aria-label="account of current user"
-							aria-controls="menu-appbar"
-							aria-haspopup="true"
-							onClick={handleOpenNavMenu}
-							color="inherit"
-						>
-							<MenuIcon />
-						</IconButton>
-						<Menu
-							id="menu-appbar"
-							anchorEl={anchorElNav}
-							anchorOrigin={{
-								vertical: 'bottom',
-								horizontal: 'left',
-							}}
-							keepMounted
-							transformOrigin={{
-								vertical: 'top',
-								horizontal: 'left',
-							}}
-							open={Boolean(anchorElNav)}
-							onClose={handleCloseNavMenu}
-							sx={{
-								display: { xs: 'block', md: 'none' },
-							}}
-						>
-							{navLinks.map(({ path, label }) => (
-								<MenuItem
-									key={label}
-									onClick={() => {
-										navigate(path);
-										handleCloseNavMenu();
-									}}
-									selected={menuItemIsSelected(path)}
-								>
-									<Typography textAlign="center">{label}</Typography>
-								</MenuItem>
-							))}
-						</Menu>
-					</Box>
-
+					<MobileBurgerNav />
 					<NewslettersBrandHeading />
-
-					<Box sx={{ flexGrow: 1, display: { xs: 'none', md: 'flex' } }}>
-						{navLinks.map(({ path, label }) => (
-							<Button
-								key={label}
-								onClick={() => {
-									navigate(path);
-								}}
-								sx={{
-									my: 2,
-									color: 'white',
-									fontWeight: menuItemIsSelected(path) ? 'bold' : 'normal',
-									display: 'block',
-									borderBottomStyle: menuItemIsSelected(path)
-										? 'solid'
-										: 'none',
-									borderBottomWidth: '2px',
-									borderRadius: '0',
-								}}
-							>
-								{label}
-							</Button>
-						))}
-					</Box>
+					<DesktopNavLinks />
 
 					{isOnCode && (
 						<ToolBarIcon

--- a/apps/newsletters-ui/src/app/components/MainNav.tsx
+++ b/apps/newsletters-ui/src/app/components/MainNav.tsx
@@ -70,7 +70,7 @@ export function MainNav({ isOnCode }: Props) {
 		<AppBar position="fixed" component={'header'}>
 			<Container maxWidth="xl">
 				<Toolbar disableGutters>
-					<Box sx={{ flexGrow: 1, display: { xs: 'flex', md: 'none' } }}>
+					<Box sx={{ display: { xs: 'flex', md: 'none' } }}>
 						<IconButton
 							size="large"
 							aria-label="account of current user"

--- a/apps/newsletters-ui/src/app/components/MainNav.tsx
+++ b/apps/newsletters-ui/src/app/components/MainNav.tsx
@@ -1,5 +1,4 @@
 import CodeIcon from '@mui/icons-material/Code';
-import MailOutlineIcon from '@mui/icons-material/MailOutline';
 import MenuIcon from '@mui/icons-material/Menu';
 import AppBar from '@mui/material/AppBar';
 import type { AvatarProps } from '@mui/material/Avatar';
@@ -17,6 +16,7 @@ import * as React from 'react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useProfile } from '../hooks/user-hooks';
+import { NewslettersBrandHeading } from './NewslettersBrandHeading';
 
 interface Props {
 	isOnCode: boolean;
@@ -70,30 +70,7 @@ export function MainNav({ isOnCode }: Props) {
 		<AppBar position="fixed" component={'header'}>
 			<Container maxWidth="xl">
 				<Toolbar disableGutters>
-					<MailOutlineIcon
-						sx={{ display: { xs: 'none', md: 'flex' }, mr: 1 }}
-					/>
-					<div
-						role={'link'}
-						onClick={() => navigate('/')}
-						style={{
-							cursor: 'pointer',
-						}}
-					>
-						<Typography
-							variant="h1"
-							noWrap
-							component="a"
-							sx={{
-								mr: 2,
-								display: { xs: 'none', md: 'flex' },
-								color: 'inherit',
-								textDecoration: 'none',
-							}}
-						>
-							Newsletters
-						</Typography>
-					</div>
+					{/* Mobile menu */}
 					<Box sx={{ flexGrow: 1, display: { xs: 'flex', md: 'none' } }}>
 						<IconButton
 							size="large"
@@ -137,26 +114,11 @@ export function MainNav({ isOnCode }: Props) {
 							))}
 						</Menu>
 					</Box>
-					<MailOutlineIcon
-						sx={{ display: { xs: 'flex', md: 'none' }, mr: 1 }}
-					/>
-					<Typography
-						variant="h1"
-						noWrap
-						component="a"
-						href=""
-						sx={{
-							mr: 2,
-							display: { xs: 'flex', md: 'none' },
-							flexGrow: 1,
-							color: 'inherit',
-							textDecoration: 'none',
-							fontSize: '1.5rem',
-							lineHeight: '1.334',
-						}}
-					>
-						Newsletters
-					</Typography>
+
+					<NewslettersBrandHeading mobile={false} />
+					<NewslettersBrandHeading mobile={true} />
+
+					{/* desktop menu */}
 					<Box sx={{ flexGrow: 1, display: { xs: 'none', md: 'flex' } }}>
 						{navLinks.map(({ path, label }) => (
 							<Button

--- a/apps/newsletters-ui/src/app/components/NavigateButton.tsx
+++ b/apps/newsletters-ui/src/app/components/NavigateButton.tsx
@@ -26,7 +26,7 @@ export const NavigateButton = (props: Props) => {
 	};
 
 	return (
-		<Button {...props} onClick={onClick}>
+		<Button {...props} role="link" onClick={onClick}>
 			{children}
 		</Button>
 	);

--- a/apps/newsletters-ui/src/app/components/NewslettersBrandHeading.tsx
+++ b/apps/newsletters-ui/src/app/components/NewslettersBrandHeading.tsx
@@ -1,46 +1,47 @@
 import MailOutlineIcon from '@mui/icons-material/MailOutline';
-import type { TypographyProps } from '@mui/material';
 import { Box, Typography } from '@mui/material';
-import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-const titleSx: TypographyProps['sx'] = {
-	mr: 2,
-	display: 'flex',
-	color: 'inherit',
-	textDecoration: 'none',
-	fontSize: { xs: '1.5rem', md: '1.25rem' },
-	lineHeight: { xs: '1.334', md: '1.6' },
-};
-
-const LinkWrap = ({ children }: { children: ReactNode }) => {
-	const navigate = useNavigate();
-	return (
-		<Box
-			role={'link'}
-			onClick={() => navigate('/')}
-			sx={{
-				cursor: 'pointer',
-				flexGrow: {
-					xs: 1,
-					md: 0,
-				},
-			}}
-		>
-			{children}
-		</Box>
-	);
-};
-
 export const NewslettersBrandHeading = () => {
+	const navigate = useNavigate();
+
 	return (
 		<>
 			<MailOutlineIcon sx={{ display: 'flex', mr: 1 }} />
-			<LinkWrap>
-				<Typography variant="h1" noWrap component="a" sx={titleSx}>
+			<Box
+				role={'link'}
+				onClick={(event) => {
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call -- is a sythetic pointer event
+					event.preventDefault();
+					navigate('/');
+				}}
+				sx={{
+					cursor: 'pointer',
+					margin: 0,
+					flexGrow: {
+						xs: 1,
+						md: 0,
+					},
+					color: 'inherit',
+					textDecoration: 'none',
+				}}
+				href="#"
+				component={'a'}
+			>
+				<Typography
+					variant="h1"
+					noWrap
+					sx={{
+						margin: 0,
+						mr: 2,
+						display: 'flex',
+						fontSize: { xs: '1.5rem', md: '1.25rem' },
+						lineHeight: { xs: '1.334', md: '1.6' },
+					}}
+				>
 					Newsletters
 				</Typography>
-			</LinkWrap>
+			</Box>
 		</>
 	);
 };

--- a/apps/newsletters-ui/src/app/components/NewslettersBrandHeading.tsx
+++ b/apps/newsletters-ui/src/app/components/NewslettersBrandHeading.tsx
@@ -1,0 +1,56 @@
+import MailOutlineIcon from '@mui/icons-material/MailOutline';
+import type { TypographyProps } from '@mui/material';
+import { Typography } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+
+interface Props {
+	mobile: boolean;
+}
+
+export const NewslettersBrandHeading = ({ mobile }: Props) => {
+	const navigate = useNavigate();
+
+	const titleSx: TypographyProps['sx'] = mobile
+		? {
+				mr: 2,
+				display: { xs: 'flex', md: 'none' },
+				color: 'inherit',
+				textDecoration: 'none',
+				fontSize: '1.5rem',
+				lineHeight: '1.334',
+		  }
+		: {
+				mr: 2,
+				display: { xs: 'none', md: 'flex' },
+				color: 'inherit',
+				textDecoration: 'none',
+		  };
+
+	const iconSx = mobile
+		? {
+				display: { xs: 'flex', md: 'none' },
+				mr: 1,
+		  }
+		: {
+				display: { xs: 'none', md: 'flex' },
+				mr: 1,
+		  };
+
+	return (
+		<>
+			<MailOutlineIcon sx={iconSx} />
+			<div
+				role={'link'}
+				onClick={() => navigate('/')}
+				style={{
+					cursor: 'pointer',
+					flexGrow: mobile ? 1 : undefined,
+				}}
+			>
+				<Typography variant="h1" noWrap component="a" sx={titleSx}>
+					Newsletters
+				</Typography>
+			</div>
+		</>
+	);
+};

--- a/apps/newsletters-ui/src/app/components/NewslettersBrandHeading.tsx
+++ b/apps/newsletters-ui/src/app/components/NewslettersBrandHeading.tsx
@@ -1,47 +1,39 @@
 import MailOutlineIcon from '@mui/icons-material/MailOutline';
-import { Box, Typography } from '@mui/material';
-import { useNavigate } from 'react-router-dom';
+import { Typography } from '@mui/material';
+import { NavigateButton } from './NavigateButton';
 
 export const NewslettersBrandHeading = () => {
-	const navigate = useNavigate();
-
 	return (
-		<>
+		<NavigateButton
+			href="/"
+			sx={{
+				cursor: 'pointer',
+				margin: 0,
+				flexGrow: {
+					xs: 1,
+					md: 0,
+				},
+				color: 'inherit',
+				textDecoration: 'none',
+				textTransform: 'none',
+				padding: 0,
+				minWidth: 'unset',
+			}}
+		>
 			<MailOutlineIcon sx={{ display: 'flex', mr: 1 }} />
-			<Box
-				role={'link'}
-				onClick={(event) => {
-					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call -- is a sythetic pointer event
-					event.preventDefault();
-					navigate('/');
-				}}
+			<Typography
+				variant="h1"
+				noWrap
 				sx={{
-					cursor: 'pointer',
 					margin: 0,
-					flexGrow: {
-						xs: 1,
-						md: 0,
-					},
-					color: 'inherit',
-					textDecoration: 'none',
+					mr: 2,
+					display: 'flex',
+					fontSize: { xs: '1.5rem', md: '1.25rem' },
+					lineHeight: { xs: '1.334', md: '1.6' },
 				}}
-				href="#"
-				component={'a'}
 			>
-				<Typography
-					variant="h1"
-					noWrap
-					sx={{
-						margin: 0,
-						mr: 2,
-						display: 'flex',
-						fontSize: { xs: '1.5rem', md: '1.25rem' },
-						lineHeight: { xs: '1.334', md: '1.6' },
-					}}
-				>
-					Newsletters
-				</Typography>
-			</Box>
-		</>
+				Newsletters
+			</Typography>
+		</NavigateButton>
 	);
 };

--- a/apps/newsletters-ui/src/app/components/NewslettersBrandHeading.tsx
+++ b/apps/newsletters-ui/src/app/components/NewslettersBrandHeading.tsx
@@ -1,56 +1,46 @@
 import MailOutlineIcon from '@mui/icons-material/MailOutline';
 import type { TypographyProps } from '@mui/material';
-import { Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
+import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-interface Props {
-	mobile: boolean;
-}
+const titleSx: TypographyProps['sx'] = {
+	mr: 2,
+	display: 'flex',
+	color: 'inherit',
+	textDecoration: 'none',
+	fontSize: { xs: '1.5rem', md: '1.25rem' },
+	lineHeight: { xs: '1.334', md: '1.6' },
+};
 
-export const NewslettersBrandHeading = ({ mobile }: Props) => {
+const LinkWrap = ({ children }: { children: ReactNode }) => {
 	const navigate = useNavigate();
+	return (
+		<Box
+			role={'link'}
+			onClick={() => navigate('/')}
+			sx={{
+				cursor: 'pointer',
+				flexGrow: {
+					xs: 1,
+					md: 0,
+				},
+			}}
+		>
+			{children}
+		</Box>
+	);
+};
 
-	const titleSx: TypographyProps['sx'] = mobile
-		? {
-				mr: 2,
-				display: { xs: 'flex', md: 'none' },
-				color: 'inherit',
-				textDecoration: 'none',
-				fontSize: '1.5rem',
-				lineHeight: '1.334',
-		  }
-		: {
-				mr: 2,
-				display: { xs: 'none', md: 'flex' },
-				color: 'inherit',
-				textDecoration: 'none',
-		  };
-
-	const iconSx = mobile
-		? {
-				display: { xs: 'flex', md: 'none' },
-				mr: 1,
-		  }
-		: {
-				display: { xs: 'none', md: 'flex' },
-				mr: 1,
-		  };
-
+export const NewslettersBrandHeading = () => {
 	return (
 		<>
-			<MailOutlineIcon sx={iconSx} />
-			<div
-				role={'link'}
-				onClick={() => navigate('/')}
-				style={{
-					cursor: 'pointer',
-					flexGrow: mobile ? 1 : undefined,
-				}}
-			>
+			<MailOutlineIcon sx={{ display: 'flex', mr: 1 }} />
+			<LinkWrap>
 				<Typography variant="h1" noWrap component="a" sx={titleSx}>
 					Newsletters
 				</Typography>
-			</div>
+			</LinkWrap>
 		</>
 	);
 };


### PR DESCRIPTION
## What does this change?

Refactors the elements on the main nav so that:
 - there is only one version of the main title link and email icon, not a mobile and desktop version
 - the main title link is keyboard navigable with sensible mark-up ( ```<a><svg/><h1>Newsletters</h1></a>```)
 - the `MainNav` component is easier to understand

## How to test

Still looks the same,  but press tab to highlight the "newsletters" link with the button focus effect


## How can we measure success?

better markup, slightly more accessible.
Will be easier to improve the design of the nav bar

## Have we considered potential risks?

should be safe

## Images

<img width="1005" alt="Screenshot 2023-09-21 at 14 15 48" src="https://github.com/guardian/newsletters-nx/assets/30567854/9724282d-1603-4be8-b3d7-4377709e659e">

