### PR TITLE
Add series tag description to schema and to email and data collection

### DIFF
--- a/libs/email-builder/src/lib/components/RequestSignUpPageCreationMessage.tsx
+++ b/libs/email-builder/src/lib/components/RequestSignUpPageCreationMessage.tsx
@@ -24,7 +24,7 @@ export const RequestSignUpPageCreationMessage = ({
 		<MessageFormat
 			title={
 				<>
-					Please create a Sign up Page Article for newsletter "
+					Please create a Sign up Page Article in Composer for newsletter"
 					{newsletter.identityName}"
 				</>
 			}

--- a/libs/email-builder/src/lib/components/RequestTagCreationMessage.tsx
+++ b/libs/email-builder/src/lib/components/RequestTagCreationMessage.tsx
@@ -1,5 +1,5 @@
-import { renderToStaticMarkup } from 'react-dom/server';
 import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
+import { renderToStaticMarkup } from 'react-dom/server';
 import type { MessageContent } from '../types';
 import { MessageFormat } from './MessageFormat';
 
@@ -12,8 +12,9 @@ export const RequestTagCreationMessage = ({ pageLink, newsletter }: Props) => {
 	// message is only sent if there is a defined series tag, but composerCampaignTag could be undefined.
 	const {
 		seriesTag,
+		seriesTagDescription,
 		composerCampaignTag,
-		composerTag: tagsThatPromptRecomendationOfCampaignTag,
+		composerTag: tagsThatPromptRecommendationOfCampaignTag,
 	} = newsletter;
 	const title = composerCampaignTag
 		? `Please create a Series and Campaign Tags for newsletter " ${newsletter.identityName}"`
@@ -30,6 +31,11 @@ export const RequestTagCreationMessage = ({ pageLink, newsletter }: Props) => {
 				<li>
 					<b>Series Tag:</b> {seriesTag}
 				</li>
+				{seriesTagDescription && (
+					<li>
+						<b>Series Tag Description:</b> {seriesTagDescription}
+					</li>
+				)}
 				{composerCampaignTag && (
 					<li>
 						<b>Campaign Tag:</b> {composerCampaignTag}
@@ -37,14 +43,14 @@ export const RequestTagCreationMessage = ({ pageLink, newsletter }: Props) => {
 				)}
 			</ul>
 
-			{!!(composerCampaignTag && tagsThatPromptRecomendationOfCampaignTag) && (
+			{!!(composerCampaignTag && tagsThatPromptRecommendationOfCampaignTag) && (
 				<div>
 					<p>
 						Can the tag relationship be set up so that{' '}
 						<b>{newsletter.composerCampaignTag}</b> will be suggested when the
 						following tags are used:
 					</p>
-					<p>{tagsThatPromptRecomendationOfCampaignTag}</p>
+					<p>{tagsThatPromptRecommendationOfCampaignTag}</p>
 				</div>
 			)}
 

--- a/libs/email-builder/src/lib/components/RequestTagCreationMessage.tsx
+++ b/libs/email-builder/src/lib/components/RequestTagCreationMessage.tsx
@@ -1,5 +1,5 @@
-import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
 import { renderToStaticMarkup } from 'react-dom/server';
+import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
 import type { MessageContent } from '../types';
 import { MessageFormat } from './MessageFormat';
 

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
@@ -1,5 +1,3 @@
-import type { ZodObject, ZodRawShape } from 'zod';
-import { z } from 'zod';
 import type {
 	RenderingOptions,
 	ThrasherOptions,
@@ -9,6 +7,8 @@ import {
 	dataCollectionSchema,
 	thrasherOptionsSchema,
 } from '@newsletters-nx/newsletters-data-client';
+import type { ZodObject, ZodRawShape } from 'zod';
+import { z } from 'zod';
 
 const pickAndPrefixRenderingOption = (
 	fieldKeys: Array<keyof RenderingOptions>,
@@ -78,17 +78,19 @@ export const formSchemas = {
 			// but on the formSchema, we can use an enum to allow users to pick from the current list.
 			// In practice, we would not want users to be able to create new groups on the all-newsletters page
 			// for each newsletter.
-			group: z.enum([
-				'News in depth',
-				'News in brief',
-				'Opinion',
-				'Features',
-				'Culture',
-				'Lifestyle',
-				'Sport',
-				'Work',
-				'From the papers',
-			]).describe('Group'),
+			group: z
+				.enum([
+					'News in depth',
+					'News in brief',
+					'Opinion',
+					'Features',
+					'Culture',
+					'Lifestyle',
+					'Sport',
+					'Work',
+					'From the papers',
+				])
+				.describe('Group'),
 		})
 		.describe('Choose a pillar and a group'),
 
@@ -166,6 +168,7 @@ export const formSchemas = {
 	tags: dataCollectionSchema
 		.pick({
 			seriesTag: true,
+			seriesTagDescription: true,
 			composerTag: true,
 			composerCampaignTag: true,
 		})

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
@@ -1,3 +1,5 @@
+import type { ZodObject, ZodRawShape } from 'zod';
+import { z } from 'zod';
 import type {
 	RenderingOptions,
 	ThrasherOptions,
@@ -7,8 +9,6 @@ import {
 	dataCollectionSchema,
 	thrasherOptionsSchema,
 } from '@newsletters-nx/newsletters-data-client';
-import type { ZodObject, ZodRawShape } from 'zod';
-import { z } from 'zod';
 
 const pickAndPrefixRenderingOption = (
 	fieldKeys: Array<keyof RenderingOptions>,

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/tagsLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/tagsLayout.ts
@@ -15,7 +15,7 @@ const markdownTemplate = `
 
 ### Series Tag
 
-Please share the series tag URL for the newsletter.
+Please share the series tag URL & description for the newsletter.
 
 For example: [tv-and-radio/series/what-s-on-tv](https://www.theguardian.com/tv-and-radio/series/what-s-on-tv) for the What's On newsletter.
 
@@ -56,22 +56,28 @@ export const tagsLayout: WizardStepLayout<DraftService> = {
 			label: 'Save and Continue',
 			stepToMoveTo: getNextStepId,
 			onBeforeStepChangeValidate: (stepData) => {
-				const composerTag = stepData.formData
-					? stepData.formData['composerTag']
-					: undefined;
-				const composerCampaignTag = stepData.formData
-					? stepData.formData['composerCampaignTag']
-					: undefined;
+				if (!stepData.formData) {
+					return undefined;
+				}
+				const seriesTag = stepData.formData['seriesTag'] ?? undefined;
+				const seriesTagDescription = stepData.formData['seriesTagDescription'] ?? undefined;
+				if (seriesTag && !seriesTagDescription) {
+					return {
+						message: 'Series tag description is required if series tag specified',
+					};
+				}
+				const composerTag = stepData.formData['composerTag'] ?? undefined;
+				const composerCampaignTag = stepData.formData['composerCampaignTag'] ?? undefined;
 				if (composerTag || composerCampaignTag) {
 					if (!composerTag) {
 						return {
 							message:
-								'ENTER AT LEAST ONE COMPOSER TAG IF SPECIFYING COMPOSER CAMPAIGN TAG',
+								'Enter at least one composer tag if specifying composer campaign tag',
 						};
 					}
 					if (!composerCampaignTag) {
 						return {
-							message: 'ENTER COMPOSER CAMPAIGN TAG IF SPECIFYING COMPOSER TAG',
+							message: 'Enter composer campaign tag if specifying composer tag',
 						};
 					}
 				}

--- a/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
@@ -135,7 +135,7 @@ export const newsletterDataSchema = z.object({
 	seriesTagDescription: z
 		.string()
 		.optional()
-		.describe('The series tag description'),
+		.describe('The Series tag description'),
 	composerTag: z.string().optional().describe('Composer tag(s)'),
 	composerCampaignTag: z.string().optional().describe('Composer campaign tag'),
 

--- a/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
@@ -132,6 +132,10 @@ export const newsletterDataSchema = z.object({
 	cancellationTimeStamp: z.number().optional(),
 
 	seriesTag: z.string().optional().describe('Series tag'),
+	seriesTagDescription: z
+		.string()
+		.optional()
+		.describe('The series tag description'),
 	composerTag: z.string().optional().describe('Composer tag(s)'),
 	composerCampaignTag: z.string().optional().describe('Composer campaign tag'),
 


### PR DESCRIPTION
## What does this change?

Adds a new field of series tag description to the newsletter schema and uses it in data collection and sending the tag email

## How to test

Create & launch a newsletter - validate that description is required where series tag is specified during data collection. On launch, verify that description is included in email

## How can we measure success?

By the above conditions being met

## Have we considered potential risks?

Should be fine


## Images
![Screenshot 2023-09-22 at 15 20 28](https://github.com/guardian/newsletters-nx/assets/3277259/2c4c8eb2-ab43-47e5-bbaa-f0f73d275fed)
![Screenshot 2023-09-25 at 08 35 19](https://github.com/guardian/newsletters-nx/assets/3277259/b8d54f35-5d2b-4f7d-8d27-5b94ad6f8465)

![Screenshot 2023-09-25 at 09 14 48](https://github.com/guardian/newsletters-nx/assets/3277259/0677ac3b-59af-42b7-960b-85c1f3a50e60)
