### PR TITLE
Add notifications endpoint to support relaunch

### DIFF
--- a/apps/newsletters-api/src/app/authorisation.ts
+++ b/apps/newsletters-api/src/app/authorisation.ts
@@ -24,7 +24,6 @@ export const hasPermission = async (
 ): Promise<boolean> => {
 	if (!profile) return false;
 	const permissions = await permissionService.get(profile);
-	console.log('permissions', permissions);
 	return permissions[permission];
 };
 

--- a/apps/newsletters-api/src/app/authorisation.ts
+++ b/apps/newsletters-api/src/app/authorisation.ts
@@ -1,5 +1,6 @@
 import type {
 	NewsletterData,
+	UserPermissions,
 	UserProfile,
 } from '@newsletters-nx/newsletters-data-client';
 import { getUserEditSchema } from '@newsletters-nx/newsletters-data-client';
@@ -15,6 +16,16 @@ export const hasEditAccess = async (
 	return [editTags, editNewsletters, editSignUpPage, editBraze, editOphan].some(
 		(permission) => permission,
 	);
+};
+
+export const hasPermission = async (
+	profile: UserProfile | undefined,
+	permission: keyof UserPermissions,
+): Promise<boolean> => {
+	if (!profile) return false;
+	const permissions = await permissionService.get(profile);
+	console.log('permissions', permissions);
+	return permissions[permission];
 };
 
 export const isAuthorisedToMakeRequestedNewsletterUpdate = async (

--- a/apps/newsletters-api/src/app/routes/notifications.ts
+++ b/apps/newsletters-api/src/app/routes/notifications.ts
@@ -105,8 +105,8 @@ export function registerNotificationRoutes(app: FastifyInstance) {
 						.status(mapStorageFailureReasonToStatusCode(storageResponse.reason))
 						.send(makeErrorResponse(storageResponse.message));
 				}
-
-				if (!storageResponse.data.seriesTag) {
+				const notificationRequiresSeriesTag = action === 'brazeUpdate';
+				if (notificationRequiresSeriesTag && !storageResponse.data.seriesTag) {
 					return res
 						.status(400)
 						.send(makeErrorResponse(`No series tag is present`));

--- a/apps/newsletters-api/src/app/routes/notifications.ts
+++ b/apps/newsletters-api/src/app/routes/notifications.ts
@@ -1,23 +1,43 @@
-import type { FastifyInstance } from 'fastify';
+import type { FastifyInstance, FastifyReply } from 'fastify';
+import type { FastifyRequest } from 'fastify/types/request';
+import type { NewsletterMessageId } from '@newsletters-nx/email-builder';
 import { sendEmailNotifications } from '@newsletters-nx/email-builder';
 import { makeEmailEnvInfo } from '../../services/notifications/email-env';
 import { makeSesClient } from '../../services/notifications/email-service';
 import { newsletterStore } from '../../services/storage';
+import { hasPermission } from '../authorisation';
 import { getUserProfile } from '../get-user-profile';
-import { makeAccessDeniedApiResponse } from '../responses';
+import {
+	makeErrorResponse,
+	mapStorageFailureReasonToStatusCode,
+} from '../responses';
 
 export function registerNotificationRoutes(app: FastifyInstance) {
+	const canTriggerNotification = async (
+		request: FastifyRequest,
+		reply: FastifyReply,
+	) => {
+		const user = getUserProfile(request);
+		const hasLaunchAccess = await hasPermission(
+			user.profile,
+			'editNewsletters',
+		);
+
+		if (!hasLaunchAccess) {
+			void reply
+				.status(403)
+				.send(
+					makeErrorResponse(
+						'user does not have permission to send notifications',
+					),
+				);
+		}
+	};
+
 	app.get<{ Params: { newsletterId: string } }>(
 		'/email/:newsletterId',
+		{ preValidation: canTriggerNotification },
 		async (req, res) => {
-			const user = getUserProfile(req);
-			const accessDeniedError = await makeAccessDeniedApiResponse(
-				user.profile,
-				'editNewsletters',
-			);
-			if (accessDeniedError) {
-				return res.status(403).send(accessDeniedError);
-			}
 			try {
 				const { newsletterId } = req.params;
 
@@ -49,6 +69,66 @@ export function registerNotificationRoutes(app: FastifyInstance) {
 					});
 				}
 
+				return res.status(200).send({
+					message: 'Email sent from service',
+					messageId: emailResult.output.MessageId,
+				});
+			} catch (e) {
+				console.log(e);
+				return res.status(500).send({ message: 'Error sending email' });
+			}
+		},
+	);
+
+	app.get<{
+		Params: { newsletterId: string; action: string };
+	}>(
+		'/api/email/:newsletterId/:action',
+		{ preValidation: canTriggerNotification },
+		async (req, res) => {
+			const { newsletterId, action } = req.params;
+
+			const actionMapping: Record<string, NewsletterMessageId> = {
+				launch: 'NEWSLETTER_LAUNCH',
+				brazeUpdate: 'BRAZE_UPDATE_REQUEST',
+			};
+
+			try {
+				if (!Object.keys(actionMapping).includes(action)) {
+					return res.status(400).send(makeErrorResponse(`Not a valid action`));
+				}
+
+				const storageResponse = await newsletterStore.readByName(newsletterId);
+
+				if (!storageResponse.ok) {
+					return res
+						.status(mapStorageFailureReasonToStatusCode(storageResponse.reason))
+						.send(makeErrorResponse(storageResponse.message));
+				}
+
+				if (!storageResponse.data.seriesTag) {
+					return res
+						.status(400)
+						.send(makeErrorResponse(`No series tag is present`));
+				}
+				const emailResult = await sendEmailNotifications(
+					{
+						messageTemplateId: actionMapping[action] as NewsletterMessageId,
+						newsletter: storageResponse.data,
+					},
+					makeSesClient(),
+					makeEmailEnvInfo(),
+				);
+				if (!emailResult.success) {
+					return res.status(500).send({
+						message: 'Email service failed',
+					});
+				}
+				if (!emailResult.output) {
+					return res.status(200).send({
+						message: 'Email service is not enabled',
+					});
+				}
 				return res.status(200).send({
 					message: 'Email sent from service',
 					messageId: emailResult.output.MessageId,

--- a/apps/newsletters-api/static/newsletters.local.json
+++ b/apps/newsletters-api/static/newsletters.local.json
@@ -47,6 +47,7 @@
 		"signUpDescription": "Fuga corporis suscipit earum.",
 		"frequency": "Monthly",
 		"status": "cancelled",
+		"seriesTag": "some/series/tag",
 		"restricted": false,
 		"emailConfirmation": false,
 		"brazeNewsletterName": "Editorial_RoiFemaleUk",

--- a/libs/email-builder/src/lib/components/NewsletterPropertyTable.tsx
+++ b/libs/email-builder/src/lib/components/NewsletterPropertyTable.tsx
@@ -11,7 +11,7 @@ interface Props {
 export const isStringArray = (value: unknown): value is string[] =>
 	Array.isArray(value) && value.every((item) => typeof item === 'string');
 
-export const properyToString = (value: unknown): string => {
+export const propertyToString = (value: unknown): string => {
 	switch (typeof value) {
 		case 'string':
 		case 'number':
@@ -26,8 +26,7 @@ export const properyToString = (value: unknown): string => {
 				return value.join();
 			}
 			try {
-				const stringification = JSON.stringify(value);
-				return stringification;
+				return JSON.stringify(value);
 			} catch (err) {
 				return '[non-serialisable object]';
 			}
@@ -44,7 +43,7 @@ export const NewsletterPropertyTable = ({ newsletter, properties }: Props) => (
 					return (
 						<tr key={index}>
 							<th>{property}</th>
-							<td>{properyToString(newsletter[property])}</td>
+							<td>{propertyToString(newsletter[property])}</td>
 						</tr>
 					);
 				}

--- a/libs/email-builder/src/lib/components/RequestBrazeUpdateMessage.tsx
+++ b/libs/email-builder/src/lib/components/RequestBrazeUpdateMessage.tsx
@@ -1,0 +1,62 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
+import {
+	emailContent,
+	emailEndpoint,
+} from '@newsletters-nx/newsletters-data-client';
+import type { MessageContent } from '../types';
+import { MessageFormat } from './MessageFormat';
+import { NewsletterPropertyTable } from './NewsletterPropertyTable';
+
+interface Props {
+	pageLink: string;
+	newsletter: NewsletterData;
+}
+
+export const RequestBrazeUpdateMessage = ({ pageLink, newsletter }: Props) => {
+	if (!newsletter.seriesTag) {
+		throw new Error(
+			`Newsletter "${newsletter.identityName}" does not have a seriesTag`,
+		);
+	}
+	return (
+		<MessageFormat
+			title={
+				<>
+					Please update the Braze campaign for newsletter "
+					{newsletter.identityName}"
+				</>
+			}
+		>
+			<p>
+				Please update the <strong>{newsletter.brazeNewsletterName}</strong>{' '}
+				Braze campaign with the following values:
+			</p>
+			<NewsletterPropertyTable
+				newsletter={newsletter}
+				properties={[emailContent, emailEndpoint]}
+			/>
+			<p>
+				Once the Campaign has been updated, please visit{' '}
+				<a href={pageLink}>this page on the newsletters tool</a> to confirm!
+			</p>
+		</MessageFormat>
+	);
+};
+
+export const renderBrazeUpdateRequestMessage = (
+	props: Props,
+): MessageContent => {
+	const { pageLink, newsletter } = props;
+	const subject = `Update Braze campaign for newsletter "${newsletter.identityName}"`;
+
+	const text = `"${newsletter.name}" has been updated: ${pageLink}. Please update the Braze campaign.`;
+
+	try {
+		const html = renderToStaticMarkup(<RequestBrazeUpdateMessage {...props} />);
+		return { html, text, subject };
+	} catch (e) {
+		console.error(e);
+		return { html: text, text, subject };
+	}
+};

--- a/libs/email-builder/src/lib/message-config.ts
+++ b/libs/email-builder/src/lib/message-config.ts
@@ -11,6 +11,7 @@ export type NewsletterMessageId =
 	| 'SIGN_UP_PAGE_CREATION_REQUEST'
 	| 'TAG_CREATION_REQUEST'
 	| 'BRAZE_SET_UP_REQUEST'
+	| 'BRAZE_UPDATE_REQUEST'
 	| 'CENTRAL_PRODUCTION_TAGS_AND_SIGNUP_PAGE_REQUEST';
 
 export const getMessageConfig = async (
@@ -38,6 +39,7 @@ export const getMessageConfig = async (
 		SIGN_UP_PAGE_CREATION_REQUEST: signUpPageRecipients,
 		TAG_CREATION_REQUEST: tagRecipients,
 		BRAZE_SET_UP_REQUEST: brazeRecipients,
+		BRAZE_UPDATE_REQUEST: brazeRecipients,
 		CENTRAL_PRODUCTION_TAGS_AND_SIGNUP_PAGE_REQUEST:
 			centralProductionRecipients,
 	};

--- a/libs/email-builder/src/lib/messages/request-braze-update-message.ts
+++ b/libs/email-builder/src/lib/messages/request-braze-update-message.ts
@@ -1,0 +1,29 @@
+import type { EmailEnvInfo } from '@newsletters-nx/newsletters-data-client';
+import { renderBrazeUpdateRequestMessage } from '../components/RequestBrazeUpdateMessage';
+import { getMessageConfig } from '../message-config';
+import type {
+	MessageAboutNewsletterParams,
+	MessageConfig,
+	MessageContent,
+} from '../types';
+
+export async function buildBrazeUpdateRequestMessage(
+	params: MessageAboutNewsletterParams,
+	emailEnvInfo: EmailEnvInfo,
+): Promise<{ content: MessageContent; messageConfig: MessageConfig }> {
+	const { newsletter } = params;
+	const messageConfig = await getMessageConfig(
+		emailEnvInfo,
+		'BRAZE_UPDATE_REQUEST',
+	);
+
+	const pageLink = `${messageConfig.toolHost}/launched/edit/${newsletter.identityName}`;
+
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-call -- render the component
+	const content = renderBrazeUpdateRequestMessage({
+		pageLink,
+		newsletter,
+	}) as MessageContent;
+
+	return { content, messageConfig };
+}

--- a/libs/email-builder/src/lib/service.ts
+++ b/libs/email-builder/src/lib/service.ts
@@ -6,6 +6,7 @@ import {
 	buildNewDraftEmail,
 	buildNewsLetterLaunchMessage,
 } from './messages';
+import { buildBrazeUpdateRequestMessage } from './messages/request-braze-update-message';
 import { buildSignupPageAndTagCreationRequestMessage } from './messages/request-tags-and-signup-page-message';
 import type { MessageConfig, MessageContent, MessageParams } from './types';
 
@@ -23,6 +24,8 @@ const getMessage = async (
 			return buildNewsLetterLaunchMessage(params, emailEnvInfo);
 		case 'BRAZE_SET_UP_REQUEST':
 			return buildBrazeSetUpRequestMessage(params, emailEnvInfo);
+		case 'BRAZE_UPDATE_REQUEST':
+			return buildBrazeUpdateRequestMessage(params, emailEnvInfo);
 		case 'CENTRAL_PRODUCTION_TAGS_AND_SIGNUP_PAGE_REQUEST':
 			return buildSignupPageAndTagCreationRequestMessage(params, emailEnvInfo);
 	}

--- a/libs/email-builder/src/lib/types.ts
+++ b/libs/email-builder/src/lib/types.ts
@@ -31,7 +31,8 @@ export type NewDraftMessageParams = {
 export type NewsletterMessageId =
 	| 'NEWSLETTER_LAUNCH'
 	| 'CENTRAL_PRODUCTION_TAGS_AND_SIGNUP_PAGE_REQUEST'
-	| 'BRAZE_SET_UP_REQUEST';
+	| 'BRAZE_SET_UP_REQUEST'
+	| 'BRAZE_UPDATE_REQUEST';
 
 export type MessageAboutNewsletterParams = {
 	messageTemplateId: NewsletterMessageId;

--- a/libs/newsletters-data-client/src/lib/newsletter-value-generators.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-value-generators.ts
@@ -49,3 +49,18 @@ export const emailRenderingLatestInSeriesUrl: NewsletterValueGenerator = {
 	description:
 		"The URL to render the latest article in the Newsletter's series tag as JSON for consumption by Braze.",
 };
+
+export const emailEndpoint: NewsletterValueGenerator = {
+	generate: ({ seriesTag }: NewsletterData) =>
+		seriesTag
+			? `${seriesTag}/latest.json`
+			: `[not available - no series tag defined]`,
+	displayName: 'email_endpoint',
+	description: 'The the value to use for email_endpoint in the Braze campaign',
+};
+
+export const emailContent: NewsletterValueGenerator = {
+	generate: () => 'Editorial_FirstEditionContent',
+	displayName: 'email_content',
+	description: 'The the value to use for email_content in the Braze campaign',
+};


### PR DESCRIPTION
## What does this change?

Adds a new endpoint:

`GET /api/email/[:newsletterId]/[:action]`

where `action` is one of [`brazeUpdate`, `launch`]

This change also adds a new email notification for a Braze update which intended to support relaunches from the tool. 

Requests for sending a notification are limited to users with the `editNewsletters` permission. There is a  further check for the presence of a series tag where the notification request is for a `brazeUpdate`.


## How to test

Checkout, get some frontend credentials.
Here are the expected responses: (non exhaustive, but close!)

| endpoint | has EditNewsletter Permission | Newsletter exists | Newsletter Has series tag | expected response |
|--------|--------|--------|--------|--------|
|`api/email/roi-female/brazeUpdate` | true | true | true | 200 - message sent |
| `api/email/roi-female/launch` | true | true | true | 200 - message sent |
| `api/email/roi-female/launch` | true | true | false | 200 - message sent |
| `api/email/roi-female/brazeUpdate` | true | true | false | 400 - no series tag |
| `api/email/roi-female/[brazeUpdate,launch]` | false | [any] | [any] | 403 - no permission |
| `api/email/[someNonExtantNewletter]/[brazeUpdate,launch]` | true | false | [any] | 404 |
| `api/email/roi-female/[someUnknownAction]` | true | true | [any] | 400 - unknown action |


## How can we measure success?

The the enpoint does what is expected and is only available to authorised users. The emails send with the relevant data, 

## Have we considered potential risks?

Low risk - we are adding an enpoint that is not currently in use - Access requires authentication and authorisation and is limited to developers and editors. 

## Images

![Screenshot 2023-09-28 at 10 26 13](https://github.com/guardian/newsletters-nx/assets/3277259/0c31f320-b202-41b9-83d5-872f7aaf40be)
