### PR TITLE
Remove unused config parameters

### DIFF
--- a/libs/email-builder/src/lib/message-config.ts
+++ b/libs/email-builder/src/lib/message-config.ts
@@ -4,12 +4,12 @@ import type { EmailRecipientConfiguration, MessageConfig } from './types';
 
 /** 15 minutes*/
 const TIME_BETWEEN_RECIPIENT_PARAM_CHECKS = 1000 * 60 * 15;
+const CODE_TOOLS_DOMAIN = 'newsletters-tool.code.dev-gutools.co.uk';
+const PROD_TOOLS_DOMAIN = 'newsletters-tool.gutools.co.uk';
 
 export type NewsletterMessageId =
 	| 'NEW_DRAFT_CREATED'
 	| 'NEWSLETTER_LAUNCH'
-	| 'SIGN_UP_PAGE_CREATION_REQUEST'
-	| 'TAG_CREATION_REQUEST'
 	| 'BRAZE_SET_UP_REQUEST'
 	| 'BRAZE_UPDATE_REQUEST'
 	| 'CENTRAL_PRODUCTION_TAGS_AND_SIGNUP_PAGE_REQUEST';
@@ -22,8 +22,6 @@ export const getMessageConfig = async (
 
 	const {
 		draftCreatedRecipients,
-		tagRecipients,
-		signUpPageRecipients,
 		brazeRecipients,
 		launchRecipients,
 		centralProductionRecipients,
@@ -36,8 +34,6 @@ export const getMessageConfig = async (
 	const recipientMapping: Record<NewsletterMessageId, string[]> = {
 		NEW_DRAFT_CREATED: draftCreatedRecipients,
 		NEWSLETTER_LAUNCH: launchRecipients,
-		SIGN_UP_PAGE_CREATION_REQUEST: signUpPageRecipients,
-		TAG_CREATION_REQUEST: tagRecipients,
 		BRAZE_SET_UP_REQUEST: brazeRecipients,
 		BRAZE_UPDATE_REQUEST: brazeRecipients,
 		CENTRAL_PRODUCTION_TAGS_AND_SIGNUP_PAGE_REQUEST:
@@ -47,17 +43,17 @@ export const getMessageConfig = async (
 		case 'PROD':
 			return {
 				recipients: recipientMapping[messageType],
-				toolHost: 'https://newsletters-tool.gutools.co.uk',
+				toolHost: `https://${PROD_TOOLS_DOMAIN}`,
 				replyToAddresses: ['newsletters@guardian.co.uk'],
-				source: 'newsletters <notifications@newsletters-tool-gutools.co.uk>',
+				source: `newsletters <notifications@${PROD_TOOLS_DOMAIN}>`,
 			};
 		case 'CODE':
 			return {
 				recipients: recipientMapping[messageType],
-				toolHost: 'https://newsletters-tool.code.dev-gutools.co.uk',
+				toolHost: `https://${CODE_TOOLS_DOMAIN}`,
 				replyToAddresses: ['newsletters@guardian.co.uk'],
 				source:
-					'newsletters CODE <notifications@newsletters-tool.code.dev-gutools.co.uk>',
+					`newsletters CODE <notifications@${CODE_TOOLS_DOMAIN}>`,
 			};
 		case 'DEV':
 		default:
@@ -66,7 +62,7 @@ export const getMessageConfig = async (
 				toolHost: 'http://localhost:4200',
 				replyToAddresses: ['newsletters@guardian.co.uk'],
 				source:
-					'newsletters DEV <notifications@newsletters-tool.code.dev-gutools.co.uk>',
+					`newsletters DEV <notifications@${CODE_TOOLS_DOMAIN}>`,
 			};
 	}
 };

--- a/libs/email-builder/src/lib/messages/newsletter-launched-message.spec.ts
+++ b/libs/email-builder/src/lib/messages/newsletter-launched-message.spec.ts
@@ -14,7 +14,7 @@ const testNewsletter: NewsletterData = {
 describe('buildNewsLetterLaunchMessage', () => {
 	test('should generate content and config, using recipients defined in config', async () => {
 		mockedGetConfigValue.mockResolvedValueOnce(
-			'{"tagRecipients":["alpha"],"brazeRecipients":["beta"],"signUpPageRecipients":["gamma"],"launchRecipients":["delta"]}',
+			'{"centralProductionRecipients":["alpha"],"brazeRecipients":["beta"],"launchRecipients":["delta"]}',
 		);
 		const output = await buildNewsLetterLaunchMessage(
 			{

--- a/libs/email-builder/src/lib/types.ts
+++ b/libs/email-builder/src/lib/types.ts
@@ -44,9 +44,7 @@ export type MessageParams =
 
 export type EmailRecipientConfiguration = {
 	draftCreatedRecipients: string[];
-	tagRecipients: string[];
 	brazeRecipients: string[];
-	signUpPageRecipients: string[];
 	launchRecipients: string[];
 	centralProductionRecipients: string[];
 };


### PR DESCRIPTION
## What does this change?

Removes the config options for tag and sign up page recipients as we now have these conmbined as central production recipients.

Tested locally - works fine.


## How to test

Run locally or on CODE with email services enabled. Verify that emails are sent that that all behaves as expected. 

## How can we measure success?

By its still working

## Have we considered potential risks?

Should be fine - there are no references to those values in the project. Once merged we can remove the config values from the paramter store
