### PR TITLE
Ignore time precision on dates to fix daylight saving bug

### DIFF
--- a/apps/newsletters-ui/src/app/components/SchemaForm/DateInput.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/DateInput.tsx
@@ -24,7 +24,7 @@ export const DateInput: FunctionComponent<
 				disabled={props.readOnly}
 				onChange={(date) => {
 					if (date && date.toString() !== 'Invalid Date') {
-						props.inputHandler(date.toDate());
+						props.inputHandler(new Date(date.format('YYYY-MM-DD')));
 					}
 				}}
 				readOnly={props.readOnly}


### PR DESCRIPTION
## What does this change?

Dates selected on a client currently in BST are being translated by the Datepicker library to midnight - 1,  so 11 PM the previous day. This is resolved by ignoring the hours.  

## How to test

Create a new newsletters are verify that the date selected in the date sections are not store as the day before. 

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
