### PR TITLE
Remove user permission from stacks as now fetched dynamically from process

### DIFF
--- a/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
+++ b/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
@@ -2199,11 +2199,6 @@ Environment=NEWSLETTER_BUCKET_NAME=",
                   },
                   "
 Environment=USE_IN_MEMORY_STORAGE=false
-Environment=USER_PERMISSIONS='",
-                  {
-                    "Ref": "UserPermissions",
-                  },
-                  "'
 Environment=ENABLE_DYNAMIC_IMAGE_SIGNING=true
 Environment=ENABLE_EMAIL_SERVICE=false
 [Install]
@@ -2380,11 +2375,6 @@ Environment=NEWSLETTER_BUCKET_NAME=",
                   },
                   "
 Environment=USE_IN_MEMORY_STORAGE=false
-Environment=USER_PERMISSIONS='",
-                  {
-                    "Ref": "UserPermissions",
-                  },
-                  "'
 Environment=ENABLE_DYNAMIC_IMAGE_SIGNING=false
 Environment=ENABLE_EMAIL_SERVICE=",
                   {

--- a/cdk/lib/newsletters-tool.ts
+++ b/cdk/lib/newsletters-tool.ts
@@ -27,11 +27,6 @@ export interface NewslettersToolProps extends GuStackProps {
 	domainNameApi: string;
 }
 
-const processJSONString = (jsonParam: string): string => {
-	const escapedAndWrapped = JSON.stringify(jsonParam);
-	return escapedAndWrapped.substring(1, escapedAndWrapped.length - 1);
-};
-
 export class NewslettersTool extends GuStack {
 	constructor(scope: App, id: string, props: NewslettersToolProps) {
 		super(scope, id, props);
@@ -83,7 +78,6 @@ Environment=NEWSLETTERS_API_READ=${readOnly ? 'true' : 'false'}
 Environment=NEWSLETTERS_UI_SERVE=${readOnly ? 'false' : 'true'}
 Environment=NEWSLETTER_BUCKET_NAME=${bucketName}
 Environment=USE_IN_MEMORY_STORAGE=false
-Environment=USER_PERMISSIONS='${processJSONString(userPermissions)}'
 Environment=ENABLE_DYNAMIC_IMAGE_SIGNING=${readOnly ? 'true' : 'false'}
 Environment=ENABLE_EMAIL_SERVICE=${enableEmailService}
 [Install]


### PR DESCRIPTION
## What does this change?

Cleans up unused `USER_PERMISSIONS` refs from stacks post https://github.com/guardian/newsletters-nx/pull/267

## How to test

Make sure permissions are still working (tested on code - all looks fine)

## How can we measure success?

Permissions still work

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

Yes