### PR TITLE
Tweaked the copy in the draft creation email notification

### DIFF
--- a/libs/email-builder/src/lib/components/NewDraftMessage.tsx
+++ b/libs/email-builder/src/lib/components/NewDraftMessage.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 export const NewDraftMessage = ({ pageLink, draft }: Props) => {
 	return (
-		<MessageFormat title={<>new draft created launched: {draft.name}</>}>
+		<MessageFormat title={<>new draft created: {draft.name}</>}>
 			<p>{pageLink}</p>
 		</MessageFormat>
 	);
@@ -18,7 +18,7 @@ export const NewDraftMessage = ({ pageLink, draft }: Props) => {
 
 export const renderNewDraftMessage = (props: Props): MessageContent => {
 	const { draft, pageLink } = props;
-	const subject = `New draft email created: ${draft.name ?? '[UNNAMED]'}`;
+	const subject = `New draft newsletter created: ${draft.name ?? '[UNNAMED]'}`;
 	const text = `A new draft, ${
 		draft.name ?? '[UNNAMED]'
 	}, was created. You can see it on this page: ${pageLink}.`;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->


## What does this change?


The draft created copy says launch. This is a bit confusing. It also refers to email rather than newsletter. that too has been corrected

## How to test

Visual check

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

With great care

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

Low risk

