### PR TITLE
Include Mail signup success description in Data collection and Edit form

### DIFF
--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
@@ -77,6 +77,7 @@ export const formSchemas = {
 			signUpHeadline: true,
 			signUpDescription: true,
 			signUpEmbedDescription: true,
+			mailSuccessDescription: true,
 			illustrationCard: true,
 		})
 		.describe('Add promotion copy and newsletters page image'),

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/promotionContentLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/promotionContentLayout.ts
@@ -14,11 +14,11 @@ const markdownTemplate = `
 ## Promotion copy and image for {{name}}.
 
 ### Sign up page text
-Please enter the headline and description for the sign up page:
+Please enter the headline, description and sign-up success message for the sign up page:
 
-![Headline and Description](https://i.guim.co.uk/img/uploads/2023/03/15/signUp.png?quality=85&dpr=2&width=300&s=3b06497952cbb042084787fd324ebe6c)
+![Headline and Description](https://i.guim.co.uk/img/uploads/2023/10/06/signUpImageWithBoarderTwo.png?quality=85&dpr=2&width=300&s=002979e840129ac072654cb66367d971)
 
-### Specify the sign up embed description and illustration for newsletters page
+### Specify the sign up embed description, Sign up success message, and illustration for the newsletters page
 
 Please enter the description for the sign up embeds - this text is used on the in-article embeds and on the [newsletters page](https://www.theguardian.com/email-newsletters):
 

--- a/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
@@ -143,7 +143,7 @@ export const newsletterDataSchema = z.object({
 
 	renderingOptions: renderingOptionsSchema.optional(),
 	thrasherOptions: thrasherOptionsSchema.optional(),
-	mailSuccessDescription: z.string().optional(),
+	mailSuccessDescription: z.string().optional().describe('Sign-up success message'),
 	brazeCampaignCreationStatus: workflowStatusEnumSchema.describe(
 		'Braze campaign creation status',
 	),

--- a/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
@@ -143,7 +143,10 @@ export const newsletterDataSchema = z.object({
 
 	renderingOptions: renderingOptionsSchema.optional(),
 	thrasherOptions: thrasherOptionsSchema.optional(),
-	mailSuccessDescription: z.string().optional().describe('Sign-up success message'),
+	mailSuccessDescription: z
+		.string()
+		.optional()
+		.describe('Sign-up success message'),
 	brazeCampaignCreationStatus: workflowStatusEnumSchema.describe(
 		'Braze campaign creation status',
 	),

--- a/libs/newsletters-data-client/src/lib/zod-helpers/user-data-schema.ts
+++ b/libs/newsletters-data-client/src/lib/zod-helpers/user-data-schema.ts
@@ -23,6 +23,7 @@ export const getUserEditSchema = (
 			signupPageCreationStatus: true,
 			signupPage: true,
 			signUpDescription: true,
+			mailSuccessDescription: true,
 			brazeCampaignCreationStatus: true,
 			brazeNewsletterName: true,
 			brazeSubscribeAttributeName: true,


### PR DESCRIPTION
## What does this change?

adds `mailSuccessDescription` for the data collection wizard and exposes in the Edit form too

## How to test

Check the field is visible, editable and returned from the API

## How can we measure success?

By the above conditions being met

## Have we considered potential risks?

Should be fine

## Images

<img width="796" alt="Screenshot 2023-10-06 at 10 59 43" src="https://github.com/guardian/newsletters-nx/assets/3277259/7fea9b4a-b86d-472b-bdd6-fd80e8d09b2f">

![Screenshot 2023-10-06 at 11 10 02](https://github.com/guardian/newsletters-nx/assets/3277259/b9820682-65d9-4d86-90d0-e942103dc8c7)
