### PR TITLE
Generate Braze template

### DIFF
--- a/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
+++ b/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
@@ -1,5 +1,6 @@
 import { Alert, Snackbar } from '@mui/material';
 import { useState } from 'react';
+import { useNavigate } from "react-router";
 import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
 import { getUserEditSchema } from '@newsletters-nx/newsletters-data-client';
 import { requestNewsletterEdit } from '../api-requests/request-newsletter-edit';
@@ -11,6 +12,7 @@ interface Props {
 }
 
 export const EditNewsletterForm = ({ originalItem }: Props) => {
+	const navigate = useNavigate();
 	const [item, setItem] = useState(originalItem);
 	const permissions = usePermissions();
 	const [waitingForResponse, setWaitingForResponse] = useState<boolean>(false);
@@ -43,7 +45,8 @@ export const EditNewsletterForm = ({ originalItem }: Props) => {
 		if (response.ok) {
 			setItem(response.data);
 			setWaitingForResponse(false);
-			setConfirmationMessage('newsletter updated!');
+			navigate(`/launched/${response.data.identityName}`);
+
 		} else {
 			setWaitingForResponse(false);
 			setErrorMessage(response.message);

--- a/apps/newsletters-ui/src/app/components/GeneratedCodeDataPoint.tsx
+++ b/apps/newsletters-ui/src/app/components/GeneratedCodeDataPoint.tsx
@@ -2,8 +2,8 @@ import CopyAllIcon from '@mui/icons-material/CopyAll';
 import {
 	Box,
 	Button,
-	Chip, FormControl,
-	Grid, InputLabel, Select,
+	Chip, FormControl, FormControlLabel, FormLabel,
+	Grid, Radio, RadioGroup,
 	Stack,
 	Tooltip,
 	Typography,
@@ -13,12 +13,11 @@ import 'highlight.js/styles/github.css';
 import django from 'highlight.js/lib/languages/django';
 import javascript from 'highlight.js/lib/languages/javascript';
 import xml from 'highlight.js/lib/languages/xml';
-import type {
-    NewsletterData,
-    NewsletterValueGenerator,
-} from '@newsletters-nx/newsletters-data-client';
-import MenuItem from "@mui/material/MenuItem";
 import {useState} from "react";
+import type {
+	NewsletterData,
+	NewsletterValueGenerator,
+} from '@newsletters-nx/newsletters-data-client';
 
 
 hljs.registerLanguage('javascript', javascript);
@@ -26,80 +25,80 @@ hljs.registerLanguage('django', django);
 hljs.registerLanguage('xml', xml);
 
 interface Props {
-    newsletter: NewsletterData;
-    valueGenerator: NewsletterValueGenerator;
-    includeCopyButton?: boolean;
-		showOverride?: boolean;
-    language: string;
+	newsletter: NewsletterData;
+	valueGenerator: NewsletterValueGenerator;
+	includeCopyButton?: boolean;
+	showOverride?: boolean;
+	language: string;
 }
 
 
 export const GeneratedCodeDataPoint = ({
-		newsletter,
-		valueGenerator,
-		includeCopyButton,
-		showOverride,
-		language,
-	 }: Props) => {
+																				 newsletter,
+																				 valueGenerator,
+																				 includeCopyButton,
+																				 showOverride,
+																				 language,
+																			 }: Props) => {
 
 	type MerchandisingOverride = 'default' | 'aus' | 'culture' | 'features' | 'global' | 'sport' | 'us';
 	const [override, setOverride] = useState<MerchandisingOverride>('default' as MerchandisingOverride);
 	const codeOverride = override === 'default' ? undefined : override;
-  const generatedValue = valueGenerator.generate(newsletter, codeOverride);
-  const copyToClipBoard = async () => await navigator.clipboard.writeText(generatedValue);
+	const generatedValue = valueGenerator.generate(newsletter, codeOverride);
+	const copyToClipBoard = async () => await navigator.clipboard.writeText(generatedValue);
 
-	const code = hljs.highlight(generatedValue, { language })
+	const code = hljs.highlight(generatedValue, {language})
 	return (
-			<Grid container justifyContent={'space-between'} spacing={1}>
-					<Grid item xs={3} flexGrow={1} flexShrink={0}>
-							<Typography variant="caption">{valueGenerator.displayName}</Typography>
-							<Tooltip title={valueGenerator.description} arrow>
-									<Chip size="small" label="?"/>
-							</Tooltip>
-					</Grid>
-					<Grid item xs={9} flexShrink={1}>
-						{showOverride && (
-							<Stack direction={'row'}>
-								<Box flex={1} display={'flex'} sx={{p: 1}}>
-									<FormControl fullWidth>
-										<InputLabel id="demo-simple-select-label">DRR</InputLabel>
-										<Select
-											labelId="demo-simple-select-label"
-											id="demo-simple-select"
-											value={override}
-											label="Age"
-											onChange={(override) => setOverride(override.target.value as MerchandisingOverride)}
-										>
-											<MenuItem value={"default"}>Default</MenuItem>
-											<MenuItem value={"AU"}>Australia</MenuItem>
-											<MenuItem value={"Culture"}>Culture</MenuItem>
-											<MenuItem value={"Features"}>Features</MenuItem>
-											<MenuItem value={"Global"}>Global</MenuItem>
-											<MenuItem value={"Sport"}>Sport</MenuItem>
-											<MenuItem value={"US"}>US</MenuItem>
-										</Select>
-									</FormControl>
-								</Box>
-							</Stack>)
-						}
-							<Stack direction={'row'}>
-									{
-											<>
-													<Box flex={1} display={'flex'} sx={{p: 1}}>
-															<div dangerouslySetInnerHTML={{__html: code.value}}  />
-													</Box>
-													{includeCopyButton && (
-															<Button
-																	onClick={copyToClipBoard}
-																	startIcon={<CopyAllIcon/>}
-															>
-																	copy
-															</Button>)
-													}
-											</>
-									}
-							</Stack>
-					</Grid>
+		<Grid container justifyContent={'space-between'} spacing={1}>
+			<Grid item xs={3} flexGrow={1} flexShrink={0}>
+				<Typography variant="caption">{valueGenerator.displayName}</Typography>
+				<Tooltip title={valueGenerator.description} arrow>
+					<Chip size="small" label="?"/>
+				</Tooltip>
 			</Grid>
+			<Grid item xs={9} flexShrink={1}>
+				{showOverride && (
+					<Stack direction={'row'}>
+						<Box flex={1} display={'flex'} sx={{p: 1}}>
+							<FormControl fullWidth>
+								<FormLabel id="demo-row-radio-buttons-group-label">DRR Slot Set</FormLabel>
+								<RadioGroup
+									row
+									aria-labelledby="demo-row-radio-buttons-group-label"
+									name="row-radio-buttons-group"
+									value={override}
+									onChange={(override) => setOverride(override.target.value as MerchandisingOverride)}
+								>
+									<FormControlLabel value="default" control={<Radio/>} label="Default"/>
+									<FormControlLabel value="AUS" control={<Radio/>} label="Australia"/>
+									<FormControlLabel value="Culture" control={<Radio/>} label="Culture"/>
+									<FormControlLabel value="Features" control={<Radio/>} label="Features"/>
+									<FormControlLabel value="Global" control={<Radio/>} label="Global"/>
+									<FormControlLabel value="Sport" control={<Radio/>} label="Sport"/>
+									<FormControlLabel value="US" control={<Radio/>} label="US"/>
+								</RadioGroup>
+							</FormControl>
+						</Box>
+					</Stack>)
+				}
+				<Stack direction={'row'}>
+					{
+						<>
+							<Box flex={1} display={'flex'} sx={{p: 1}}>
+								<div dangerouslySetInnerHTML={{__html: code.value}}/>
+							</Box>
+							{includeCopyButton && (
+								<Button
+									onClick={copyToClipBoard}
+									startIcon={<CopyAllIcon/>}
+								>
+									copy
+								</Button>)
+							}
+						</>
+					}
+				</Stack>
+			</Grid>
+		</Grid>
 	);
 };

--- a/apps/newsletters-ui/src/app/components/GeneratedCodeDataPoint.tsx
+++ b/apps/newsletters-ui/src/app/components/GeneratedCodeDataPoint.tsx
@@ -37,7 +37,7 @@ interface Props {
 	language: string;
 }
 
-export type MerchandisingOverride = 'default' | 'aus' | 'culture' | 'features' | 'global' | 'sport' | 'us';
+export type MerchandisingOverride = 'default' | 'AUS' | 'Culture' | 'Features' | 'Global' | 'Sport' | 'US';
 
 export const GeneratedCodeDataPoint = ({
 																				 newsletter,
@@ -52,6 +52,17 @@ export const GeneratedCodeDataPoint = ({
 
 	const codeOverride = override === 'default' ? undefined : override;
 	const generatedValue = valueGenerator.generate(newsletter, codeOverride);
+
+
+	const valueKeyMapping = {
+		'AUS': 'Australia',
+		'Culture': 'Culture',
+		'Features': 'Features',
+		'Global': 'Global',
+		'Sport': 'Sport',
+		'US': 'US',
+		'default': 'Default',
+	}
 	const copyToClipBoard = async () => await navigator.clipboard.writeText(generatedValue);
 
 	const code = hljs.highlight(generatedValue, {language})
@@ -77,13 +88,11 @@ export const GeneratedCodeDataPoint = ({
 									value={override}
 									onChange={(override) => setOverride(override.target.value as MerchandisingOverride)}
 								>
-									<FormControlLabel value="default" control={<Radio/>} label="Default"/>
-									<FormControlLabel value="AUS" control={<Radio/>} label="Australia"/>
-									<FormControlLabel value="Culture" control={<Radio/>} label="Culture"/>
-									<FormControlLabel value="Features" control={<Radio/>} label="Features"/>
-									<FormControlLabel value="Global" control={<Radio/>} label="Global"/>
-									<FormControlLabel value="Sport" control={<Radio/>} label="Sport"/>
-									<FormControlLabel value="US" control={<Radio/>} label="US"/>
+									{
+										['default', 'AUS', 'Culture', 'Features', 'Global', 'Sport', 'US'].map((item) => <FormControlLabel
+											value={item} control={<Radio/>} label={valueKeyMapping[item as keyof typeof valueKeyMapping]}/>)
+									}
+
 								</RadioGroup>
 							</FormControl>
 						</Box>

--- a/apps/newsletters-ui/src/app/components/GeneratedCodeDataPoint.tsx
+++ b/apps/newsletters-ui/src/app/components/GeneratedCodeDataPoint.tsx
@@ -1,12 +1,12 @@
 import CopyAllIcon from '@mui/icons-material/CopyAll';
 import {
-    Box,
-    Button,
-    Chip,
-    Grid,
-    Stack,
-    Tooltip,
-    Typography,
+	Box,
+	Button,
+	Chip, FormControl,
+	Grid, InputLabel, Select,
+	Stack,
+	Tooltip,
+	Typography,
 } from '@mui/material';
 import hljs from 'highlight.js/lib/core';
 import 'highlight.js/styles/github.css';
@@ -17,6 +17,8 @@ import type {
     NewsletterData,
     NewsletterValueGenerator,
 } from '@newsletters-nx/newsletters-data-client';
+import MenuItem from "@mui/material/MenuItem";
+import {useState} from "react";
 
 
 hljs.registerLanguage('javascript', javascript);
@@ -27,6 +29,7 @@ interface Props {
     newsletter: NewsletterData;
     valueGenerator: NewsletterValueGenerator;
     includeCopyButton?: boolean;
+		showOverride?: boolean;
     language: string;
 }
 
@@ -35,11 +38,14 @@ export const GeneratedCodeDataPoint = ({
 		newsletter,
 		valueGenerator,
 		includeCopyButton,
+		showOverride,
 		language,
 	 }: Props) => {
 
-  const generatedValue = valueGenerator.generate(newsletter);
-
+	type MerchandisingOverride = 'default' | 'aus' | 'culture' | 'features' | 'global' | 'sport' | 'us';
+	const [override, setOverride] = useState<MerchandisingOverride>('default' as MerchandisingOverride);
+	const codeOverride = override === 'default' ? undefined : override;
+  const generatedValue = valueGenerator.generate(newsletter, codeOverride);
   const copyToClipBoard = async () => await navigator.clipboard.writeText(generatedValue);
 
 	const code = hljs.highlight(generatedValue, { language })
@@ -52,6 +58,30 @@ export const GeneratedCodeDataPoint = ({
 							</Tooltip>
 					</Grid>
 					<Grid item xs={9} flexShrink={1}>
+						{showOverride && (
+							<Stack direction={'row'}>
+								<Box flex={1} display={'flex'} sx={{p: 1}}>
+									<FormControl fullWidth>
+										<InputLabel id="demo-simple-select-label">DRR</InputLabel>
+										<Select
+											labelId="demo-simple-select-label"
+											id="demo-simple-select"
+											value={override}
+											label="Age"
+											onChange={(override) => setOverride(override.target.value as MerchandisingOverride)}
+										>
+											<MenuItem value={"default"}>Default</MenuItem>
+											<MenuItem value={"AU"}>Australia</MenuItem>
+											<MenuItem value={"Culture"}>Culture</MenuItem>
+											<MenuItem value={"Features"}>Features</MenuItem>
+											<MenuItem value={"Global"}>Global</MenuItem>
+											<MenuItem value={"Sport"}>Sport</MenuItem>
+											<MenuItem value={"US"}>US</MenuItem>
+										</Select>
+									</FormControl>
+								</Box>
+							</Stack>)
+						}
 							<Stack direction={'row'}>
 									{
 											<>

--- a/apps/newsletters-ui/src/app/components/GeneratedCodeDataPoint.tsx
+++ b/apps/newsletters-ui/src/app/components/GeneratedCodeDataPoint.tsx
@@ -2,8 +2,13 @@ import CopyAllIcon from '@mui/icons-material/CopyAll';
 import {
 	Box,
 	Button,
-	Chip, FormControl, FormControlLabel, FormLabel,
-	Grid, Radio, RadioGroup,
+	Chip,
+	FormControl,
+	FormControlLabel,
+	FormLabel,
+	Grid,
+	Radio,
+	RadioGroup,
 	Stack,
 	Tooltip,
 	Typography,
@@ -32,6 +37,7 @@ interface Props {
 	language: string;
 }
 
+export type MerchandisingOverride = 'default' | 'aus' | 'culture' | 'features' | 'global' | 'sport' | 'us';
 
 export const GeneratedCodeDataPoint = ({
 																				 newsletter,
@@ -41,13 +47,15 @@ export const GeneratedCodeDataPoint = ({
 																				 language,
 																			 }: Props) => {
 
-	type MerchandisingOverride = 'default' | 'aus' | 'culture' | 'features' | 'global' | 'sport' | 'us';
+
 	const [override, setOverride] = useState<MerchandisingOverride>('default' as MerchandisingOverride);
+
 	const codeOverride = override === 'default' ? undefined : override;
 	const generatedValue = valueGenerator.generate(newsletter, codeOverride);
 	const copyToClipBoard = async () => await navigator.clipboard.writeText(generatedValue);
 
 	const code = hljs.highlight(generatedValue, {language})
+
 	return (
 		<Grid container justifyContent={'space-between'} spacing={1}>
 			<Grid item xs={3} flexGrow={1} flexShrink={0}>
@@ -61,11 +69,11 @@ export const GeneratedCodeDataPoint = ({
 					<Stack direction={'row'}>
 						<Box flex={1} display={'flex'} sx={{p: 1}}>
 							<FormControl fullWidth>
-								<FormLabel id="demo-row-radio-buttons-group-label">DRR Slot Set</FormLabel>
+								<FormLabel id="drr-override-group-label">DRR Slot Set</FormLabel>
 								<RadioGroup
 									row
-									aria-labelledby="demo-row-radio-buttons-group-label"
-									name="row-radio-buttons-group"
+									aria-labelledby="drr-override-group-label"
+									name="drr-row-radio-buttons-group"
 									value={override}
 									onChange={(override) => setOverride(override.target.value as MerchandisingOverride)}
 								>

--- a/apps/newsletters-ui/src/app/components/GeneratedCodeDataPoint.tsx
+++ b/apps/newsletters-ui/src/app/components/GeneratedCodeDataPoint.tsx
@@ -39,10 +39,7 @@ export const GeneratedCodeDataPoint = ({
                                        }: Props) => {
     const generatedValue = valueGenerator.generate(newsletter);
 
-    const copyToClipBoard = async () => {
-        console.log('copying to clipboard');
-        await navigator.clipboard.writeText(generatedValue);
-    };
+    const copyToClipBoard = async () => await navigator.clipboard.writeText(generatedValue);
 
     const code = hljs.highlight(generatedValue, { language })
     return (

--- a/apps/newsletters-ui/src/app/components/GeneratedCodeDataPoint.tsx
+++ b/apps/newsletters-ui/src/app/components/GeneratedCodeDataPoint.tsx
@@ -32,44 +32,44 @@ interface Props {
 
 
 export const GeneratedCodeDataPoint = ({
-                                           newsletter,
-                                           valueGenerator,
-                                           includeCopyButton,
-                                            language,
-                                       }: Props) => {
-    const generatedValue = valueGenerator.generate(newsletter);
+		newsletter,
+		valueGenerator,
+		includeCopyButton,
+		language,
+	 }: Props) => {
 
-    const copyToClipBoard = async () => await navigator.clipboard.writeText(generatedValue);
+  const generatedValue = valueGenerator.generate(newsletter);
 
-    const code = hljs.highlight(generatedValue, { language })
-    return (
-        <Grid container justifyContent={'space-between'} spacing={1}>
-            <Grid item xs={3} flexGrow={1} flexShrink={0}>
-                <Typography variant="caption">{valueGenerator.displayName}</Typography>
-                <Tooltip title={valueGenerator.description} arrow>
-                    <Chip size="small" label="?"/>
-                </Tooltip>
-            </Grid>
-            <Grid item xs={9} flexShrink={1}>
-                <Stack direction={'row'}>
-                    {
-                        <>
-                            <Box flex={1} display={'flex'} sx={{p: 1}}>
-                                <div dangerouslySetInnerHTML={{__html: code.value}}  />
-                            </Box>
-                            {includeCopyButton && (
-                                <Button
-                                    onClick={copyToClipBoard}
-                                    startIcon={<CopyAllIcon/>}
-                                >
-                                    copy
-                                </Button>)
-                            }
+  const copyToClipBoard = async () => await navigator.clipboard.writeText(generatedValue);
 
-                        </>
-                    }
-                </Stack>
-            </Grid>
-        </Grid>
-    );
+	const code = hljs.highlight(generatedValue, { language })
+	return (
+			<Grid container justifyContent={'space-between'} spacing={1}>
+					<Grid item xs={3} flexGrow={1} flexShrink={0}>
+							<Typography variant="caption">{valueGenerator.displayName}</Typography>
+							<Tooltip title={valueGenerator.description} arrow>
+									<Chip size="small" label="?"/>
+							</Tooltip>
+					</Grid>
+					<Grid item xs={9} flexShrink={1}>
+							<Stack direction={'row'}>
+									{
+											<>
+													<Box flex={1} display={'flex'} sx={{p: 1}}>
+															<div dangerouslySetInnerHTML={{__html: code.value}}  />
+													</Box>
+													{includeCopyButton && (
+															<Button
+																	onClick={copyToClipBoard}
+																	startIcon={<CopyAllIcon/>}
+															>
+																	copy
+															</Button>)
+													}
+											</>
+									}
+							</Stack>
+					</Grid>
+			</Grid>
+	);
 };

--- a/apps/newsletters-ui/src/app/components/GeneratedCodeDataPoint.tsx
+++ b/apps/newsletters-ui/src/app/components/GeneratedCodeDataPoint.tsx
@@ -4,7 +4,6 @@ import {
     Button,
     Chip,
     Grid,
-    Link,
     Stack,
     Tooltip,
     Typography,

--- a/apps/newsletters-ui/src/app/components/GeneratedCodeDataPoint.tsx
+++ b/apps/newsletters-ui/src/app/components/GeneratedCodeDataPoint.tsx
@@ -1,0 +1,79 @@
+import CopyAllIcon from '@mui/icons-material/CopyAll';
+import {
+    Box,
+    Button,
+    Chip,
+    Grid,
+    Link,
+    Stack,
+    Tooltip,
+    Typography,
+} from '@mui/material';
+import hljs from 'highlight.js/lib/core';
+import 'highlight.js/styles/github.css';
+import django from 'highlight.js/lib/languages/django';
+import javascript from 'highlight.js/lib/languages/javascript';
+import xml from 'highlight.js/lib/languages/xml';
+import type {
+    NewsletterData,
+    NewsletterValueGenerator,
+} from '@newsletters-nx/newsletters-data-client';
+
+
+hljs.registerLanguage('javascript', javascript);
+hljs.registerLanguage('django', django);
+hljs.registerLanguage('xml', xml);
+
+interface Props {
+    newsletter: NewsletterData;
+    valueGenerator: NewsletterValueGenerator;
+    includeCopyButton?: boolean;
+    language: string;
+}
+
+
+export const GeneratedCodeDataPoint = ({
+                                           newsletter,
+                                           valueGenerator,
+                                           includeCopyButton,
+                                            language,
+                                       }: Props) => {
+    const generatedValue = valueGenerator.generate(newsletter);
+
+    const copyToClipBoard = async () => {
+        console.log('copying to clipboard');
+        await navigator.clipboard.writeText(generatedValue);
+    };
+
+    const code = hljs.highlight(generatedValue, { language })
+    return (
+        <Grid container justifyContent={'space-between'} spacing={1}>
+            <Grid item xs={3} flexGrow={1} flexShrink={0}>
+                <Typography variant="caption">{valueGenerator.displayName}</Typography>
+                <Tooltip title={valueGenerator.description} arrow>
+                    <Chip size="small" label="?"/>
+                </Tooltip>
+            </Grid>
+            <Grid item xs={9} flexShrink={1}>
+                <Stack direction={'row'}>
+                    {
+                        <>
+                            <Box flex={1} display={'flex'} sx={{p: 1}}>
+                                <div dangerouslySetInnerHTML={{__html: code.value}}  />
+                            </Box>
+                            {includeCopyButton && (
+                                <Button
+                                    onClick={copyToClipBoard}
+                                    startIcon={<CopyAllIcon/>}
+                                >
+                                    copy
+                                </Button>)
+                            }
+
+                        </>
+                    }
+                </Stack>
+            </Grid>
+        </Grid>
+    );
+};

--- a/apps/newsletters-ui/src/app/components/GeneratedDataPoint.tsx
+++ b/apps/newsletters-ui/src/app/components/GeneratedDataPoint.tsx
@@ -59,7 +59,6 @@ export const GeneratedDataPoint = ({
 									style={{
 										width: '100%',
 										display: 'flex',
-										resize: 'none',
 										minHeight: 80,
 									}}
 									value={generatedValue}
@@ -67,7 +66,7 @@ export const GeneratedDataPoint = ({
 								/>
 							</Box>
 							<Button
-								onClick={void copyToClipBoard}
+								onClick={copyToClipBoard}
 								startIcon={<CopyAllIcon />}
 							>
 								copy

--- a/apps/newsletters-ui/src/app/components/GeneratedDataPoint.tsx
+++ b/apps/newsletters-ui/src/app/components/GeneratedDataPoint.tsx
@@ -60,6 +60,7 @@ export const GeneratedDataPoint = ({
 										width: '100%',
 										display: 'flex',
 										minHeight: 80,
+										resize: 'none',
 									}}
 									value={generatedValue}
 									readOnly

--- a/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
+++ b/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
@@ -151,6 +151,7 @@ export const NewsletterDataDetails = ({ newsletter }: Props) => {
 					newsletter={newsletter}
 					valueGenerator={brazeTemplateCode}
 					includeCopyButton
+					showOverride
 					language={'django'}
 				/>
 			</DetailAccordian>

--- a/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
+++ b/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
@@ -10,12 +10,12 @@ import {
 import { usePermissions } from '../hooks/user-hooks';
 import { shouldShowEditOptions } from '../services/authorisation';
 import { DetailAccordian } from './DetailAccordian';
+import { GeneratedCodeDataPoint } from "./GeneratedCodeDataPoint";
 import { GeneratedDataPoint } from './GeneratedDataPoint';
 import { higherLevelDataPoint } from './higher-level-data-point';
 import { Illustration } from './Illustration';
 import { NavigateButton } from './NavigateButton';
 import { RawDataDialog } from './RawDataDialog';
-import {GeneratedCodeDataPoint} from "./GeneratedCodeDataPoint";
 
 interface Props {
 	newsletter: NewsletterData;

--- a/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
+++ b/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
@@ -2,7 +2,7 @@ import { Badge, Box, Grid, Stack, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
 import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
 import {
-	brazeSubscribeEventName,
+	brazeSubscribeEventName, brazeTemplateCode,
 	brazeUnsubscribeEventName,
 	embedIframeCode,
 	getPropertyDescription,
@@ -15,6 +15,7 @@ import { higherLevelDataPoint } from './higher-level-data-point';
 import { Illustration } from './Illustration';
 import { NavigateButton } from './NavigateButton';
 import { RawDataDialog } from './RawDataDialog';
+import {GeneratedCodeDataPoint} from "./GeneratedCodeDataPoint";
 
 interface Props {
 	newsletter: NewsletterData;
@@ -139,10 +140,17 @@ export const NewsletterDataDetails = ({ newsletter }: Props) => {
 			</DetailAccordian>
 
 			<DetailAccordian title="Generated values" defaultExpanded>
-				<GeneratedDataPoint
+				<GeneratedCodeDataPoint
 					newsletter={newsletter}
 					valueGenerator={embedIframeCode}
 					includeCopyButton
+					language={'xml'}
+				/>
+				<GeneratedCodeDataPoint
+					newsletter={newsletter}
+					valueGenerator={brazeTemplateCode}
+					includeCopyButton
+					language={'django'}
 				/>
 			</DetailAccordian>
 

--- a/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
+++ b/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
@@ -2,7 +2,8 @@ import { Badge, Box, Grid, Stack, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
 import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
 import {
-	brazeSubscribeEventName, brazeTemplateCode,
+	brazeSubscribeEventName,
+	brazeTemplateCode,
 	brazeUnsubscribeEventName,
 	embedIframeCode,
 	getPropertyDescription,

--- a/libs/email-builder/src/lib/components/RequestBrazeSetUpMessage.tsx
+++ b/libs/email-builder/src/lib/components/RequestBrazeSetUpMessage.tsx
@@ -15,7 +15,8 @@ interface Props {
 	newsletter: NewsletterData;
 }
 
-export const RequestBrazeSetUpMessage = ({ pageLink, newsletter }: Props) => {
+export const RequestBrazeSetUpMessage = ({ pageLink: pageEditLink, newsletter }: Props) => {
+	const pageDetailsLink = pageEditLink.split('/').filter(element => element !== 'edit').join('/');
 	return (
 		<MessageFormat
 			title={
@@ -28,7 +29,7 @@ export const RequestBrazeSetUpMessage = ({ pageLink, newsletter }: Props) => {
 			<p>
 				The Braze values for this newsletter are below - if these need to change
 				for any reason, please{' '}
-				<a href={pageLink}>update in the newsletters tool</a> .
+				<a href={pageEditLink}>update in the newsletters tool</a> .
 			</p>
 
 			<NewsletterPropertyTable
@@ -47,6 +48,11 @@ export const RequestBrazeSetUpMessage = ({ pageLink, newsletter }: Props) => {
 			/>
 
 			<p>
+				A Braze template has been created for this newsletter. The template code
+				is available in the <a href={pageDetailsLink}>newsletters tool</a>.
+			</p>
+
+			<p>
 				Note that the "temporary sign Up URL" will not be available immediately
 				after a newsletter is launched as the site can take 1-3 hours to update
 				its list of newsletters.
@@ -54,7 +60,7 @@ export const RequestBrazeSetUpMessage = ({ pageLink, newsletter }: Props) => {
 
 			<p>
 				When you have set up the campaign, please go to{' '}
-				<a href={pageLink}>this page on the newsletters tool</a> to confirm!
+				<a href={pageEditLink}>this page on the newsletters tool</a> to confirm!
 			</p>
 		</MessageFormat>
 	);

--- a/libs/newsletters-data-client/src/lib/generate-braze-template.ts
+++ b/libs/newsletters-data-client/src/lib/generate-braze-template.ts
@@ -1,57 +1,38 @@
 import type { NewsletterData } from './schemas/newsletter-data-type';
 
-const merchandisingMap = {
-	AU: {
-		header: 'Logic_Header_AU',
-		footer: 'Logic_Footer_AU',
-		middle: 'Logic_Middle_AU',
-		lifecycle: 'Logic_Lifecycle_AU',
-	},
-	US: {
-		header: 'Logic_Header_US',
-		footer: 'Logic_Footer_US',
-		middle: 'Logic_Middle_US',
-		lifecycle: 'Logic_Lifecycle_US',
-	},
-	Culture: {
-		header: 'Logic_Header_Culture',
-		footer: 'Logic_Footer_Culture',
-		middle: 'Logic_Middle_Culture',
-		lifecycle: 'Logic_Lifecycle_Culture',
-	},
-	Sport: {
-		header: 'Logic_Header_Sport',
-		footer: 'Logic_Footer_Sport',
-		middle: 'Logic_Middle_Sport',
-		lifecycle: 'Logic_Lifecycle_Sport',
-	},
+export type DrrSlotKey = 'AUS' | 'Culture' | 'Sport' | 'US' |'Features' | 'Global';
+
+const getDrrSlotSet = (slotKey: DrrSlotKey) => {
+	return {
+		header: `Logic_Header_${slotKey}`,
+		footer: `Logic_Footer${slotKey}`,
+		middle: `Logic_Middle_${slotKey}`,
+		lifecycle: `Logic_Lifecycle_${slotKey}`
+	}
 }
 const getMerchandisingContent = (newsletterData: NewsletterData, override?: string) => {
 	const {regionFocus, theme} = newsletterData;
 
 	if (override) {
-		return merchandisingMap[override as keyof typeof merchandisingMap]
+		return getDrrSlotSet(override as DrrSlotKey)
 	}
 
-	if (regionFocus && ['US', 'AU'].includes(regionFocus)) {
-		return merchandisingMap[regionFocus as keyof typeof merchandisingMap]
+	if (regionFocus && ['US', 'AUS'].includes(regionFocus)) {
+		return getDrrSlotSet(regionFocus as DrrSlotKey);
 	}
 	if (['culture', 'sport'].includes(theme)) {
-		return merchandisingMap[theme as keyof typeof merchandisingMap]
+		return getDrrSlotSet(theme as DrrSlotKey);
 	}
-	return {
-		header: 'SET APPROPRIATE MERCHANDISING CONTENT',
-		footer: 'SET APPROPRIATE MERCHANDISING CONTENT',
-		middle: 'SET APPROPRIATE MERCHANDISING CONTENT',
-		lifecycle: 'SET APPROPRIATE MERCHANDISING CONTENT',
-	}
+	return undefined;
 }
 
 export const generateBrazeTemplateString = (newsletterData: NewsletterData, override?: string): string => {
     const {identityName, campaignName, campaignCode, seriesTag, category} = newsletterData;
     const contentBlocks = category === 'article-based' ? 'Editorial_FirstEditionContent' : 'Editorial_Content'
     const emailEndpoint = seriesTag && ['article-based', 'article-based-legacy'].includes(category) ? `${seriesTag}/latest.json` : 'EMAIL ENDPOINT IS NOT SET';
-		const { header, footer, middle, lifecycle} = getMerchandisingContent(newsletterData, override);
+		const merchandisingContent = getMerchandisingContent(newsletterData, override);
+		if (!merchandisingContent) return "Could not determine merchandising content. Please select a DRR slot set";
+		const { header, footer, middle, lifecycle} = merchandisingContent;
     return `{% comment %} Required Campaign-level variables {% endcomment %}
 {% assign identity_newsletter_id = "${identityName}" %}
 {% assign email_endpoint = "${emailEndpoint}" %}

--- a/libs/newsletters-data-client/src/lib/generate-braze-template.ts
+++ b/libs/newsletters-data-client/src/lib/generate-braze-template.ts
@@ -1,19 +1,61 @@
 import type { NewsletterData } from './schemas/newsletter-data-type';
 
-export const generateGrazeTemplateString = (newsletterData: NewsletterData): string => {
+const getMerchandisingContent = ({ regionFocus, theme }:  NewsletterData) => {
+	if (regionFocus === 'AU') {
+		return {
+			header: 'Logic_Header_AUS',
+			footer: 'Logic_Footer_AUS',
+			middle: 'Logic_Middle_AUS',
+			lifecycle: 'Logic_Lifecycle_AUS',
+		}
+	}
+	if (regionFocus === 'US') {
+		return {
+			header: 'Logic_Header_US',
+			footer: 'Logic_Footer_US',
+			middle: 'Logic_Middle_US',
+			lifecycle: 'Logic_Lifecycle_US',
+		}
+	}
+	if (theme === 'culture') {
+		return {
+			header: 'Logic_Header_Culture',
+			footer: 'Logic_Footer_Culture',
+			middle: 'Logic_Middle_Culture',
+			lifecycle: 'Logic_Lifecycle_Culture',
+		}
+	}
+	if (theme === 'sport') {
+		return {
+			header: 'Logic_Header_Sport',
+			footer: 'Logic_Footer_Sport',
+			middle: 'Logic_Middle_Sport',
+			lifecycle: 'Logic_Lifecycle_Sport',
+		}
+	}
+	return {
+		header: 'SET APPROPRIATE MERCHANDISING CONTENT',
+		footer: 'SET APPROPRIATE MERCHANDISING CONTENT',
+		middle: 'SET APPROPRIATE MERCHANDISING CONTENT',
+		lifecycle: 'SET APPROPRIATE MERCHANDISING CONTENT',
+	}
+}
+
+export const generateBrazeTemplateString = (newsletterData: NewsletterData): string => {
     const {identityName, campaignName, campaignCode, seriesTag, category} = newsletterData;
     const contentBlocks = category === 'article-based' ? 'Editorial_FirstEditionContent' : 'Editorial_Content'
     const emailEndpoint = seriesTag && ['article-based', 'article-based-legacy'].includes(category) ? `${seriesTag}/latest.json` : 'EMAIL ENDPOINT IS NOT SET';
+		const { header, footer, middle, lifecycle} = getMerchandisingContent(newsletterData);
     return `{% comment %} Required Campaign-level variables {% endcomment %}
 {% assign identity_newsletter_id = "${identityName}" %}
 {% assign email_endpoint = "${emailEndpoint}" %}
 {% assign utm_campaign = "${campaignName ?? "CAMPAIGN NAME IS NOT SET"}" %}
 {% assign CMP = "${campaignCode ?? 'CAMPAIGN CODE IS NOT SET'}" %}
 {% capture email_content %}{{content_blocks.\${${contentBlocks}}}{% endcapture %}
-{% capture merchandising_content_header %}{{content_blocks.\${Logic_Header_Culture}}}{% endcapture %}
-{% capture merchandising_content_lifecycle %}{{content_blocks.\${Logic_Lifecycle_Culture}}}{% endcapture %}
-{% capture merchandising_content_middle %}{{content_blocks.\${Logic_Middle_Culture}}}{% endcapture %}
-{% capture merchandising_content_footer %}{{content_blocks.\${Logic_Footer_Culture}}}{% endcapture %}
+{% capture merchandising_content_header %}{{content_blocks.\${${header}}}{% endcapture %}
+{% capture merchandising_content_lifecycle %}{{content_blocks.\${${lifecycle}}}{% endcapture %}
+{% capture merchandising_content_middle %}{{content_blocks.\${${middle}}}{% endcapture %}
+{% capture merchandising_content_footer %}{{content_blocks.\${${footer}}}{% endcapture %}
 {% capture merchandising_content_newsletter %}{% endcapture %}
 {% capture merchandising_content_advert %}{{content_blocks.\${ADVERT_RECIPECARD_October23_Belazu_WordOfMouth}}}{% endcapture %}
 {{ email_content | strip | replace: "<!-- Braze Placeholder - Above Banner -->", merchandising_content_header | replace: "<!-- Braze Placeholder - Above Section 1 -->", merchandising_content_lifecycle | replace: "<!-- Braze Placeholder - Above Section 3 -->", merchandising_content_middle | replace: "<!-- Braze Placeholder - Above Footer -->", merchandising_content_footer | replace: "<!-- Braze Placeholder - Above Section 5 -->", merchandising_content_newsletter | replace: "<!-- Braze Placeholder - Above Section 4 -->", merchandising_content_advert }}`;

--- a/libs/newsletters-data-client/src/lib/generate-braze-template.ts
+++ b/libs/newsletters-data-client/src/lib/generate-braze-template.ts
@@ -1,6 +1,6 @@
 import type { NewsletterData } from './schemas/newsletter-data-type';
 
-export type DrrSlotKey = 'AUS' | 'Culture' | 'Sport' | 'US' |'Features' | 'Global';
+export type DrrSlotKey = 'AUS' | 'Culture' | 'Sport' | 'US' | 'Features' | 'Global';
 
 const getDrrSlotSet = (slotKey: DrrSlotKey) => {
 	return {
@@ -10,6 +10,10 @@ const getDrrSlotSet = (slotKey: DrrSlotKey) => {
 		lifecycle: `Logic_Lifecycle_${slotKey}`
 	}
 }
+
+const regionFocusMappings = {
+	'AU': 'AUS'
+}
 const getMerchandisingContent = (newsletterData: NewsletterData, override?: string) => {
 	const {regionFocus, theme} = newsletterData;
 
@@ -17,8 +21,8 @@ const getMerchandisingContent = (newsletterData: NewsletterData, override?: stri
 		return getDrrSlotSet(override as DrrSlotKey)
 	}
 
-	if (regionFocus && ['US', 'AUS'].includes(regionFocus)) {
-		return getDrrSlotSet(regionFocus as DrrSlotKey);
+	if (regionFocus && ['US', 'AU'].includes(regionFocus)) {
+		return getDrrSlotSet((regionFocusMappings[regionFocus as keyof typeof regionFocusMappings] || regionFocus) as DrrSlotKey);
 	}
 	if (['culture', 'sport'].includes(theme)) {
 		return getDrrSlotSet(theme as DrrSlotKey);
@@ -27,13 +31,15 @@ const getMerchandisingContent = (newsletterData: NewsletterData, override?: stri
 }
 
 export const generateBrazeTemplateString = (newsletterData: NewsletterData, override?: string): string => {
-    const {identityName, campaignName, campaignCode, seriesTag, category} = newsletterData;
-    const contentBlocks = category === 'article-based' ? 'Editorial_FirstEditionContent' : 'Editorial_Content'
-    const emailEndpoint = seriesTag && ['article-based', 'article-based-legacy'].includes(category) ? `${seriesTag}/latest.json` : 'EMAIL ENDPOINT IS NOT SET';
-		const merchandisingContent = getMerchandisingContent(newsletterData, override);
-		if (!merchandisingContent) return "Could not determine merchandising content. Please select a DRR slot set";
-		const { header, footer, middle, lifecycle} = merchandisingContent;
-    return `{% comment %} Required Campaign-level variables {% endcomment %}
+	const {identityName, campaignName, campaignCode, seriesTag, category} = newsletterData;
+	const contentBlocks = category === 'article-based' ? 'Editorial_FirstEditionContent' : 'Editorial_Content'
+	const emailEndpoint = seriesTag && ['article-based', 'article-based-legacy'].includes(category) ? `${seriesTag}/latest.json` : 'EMAIL ENDPOINT IS NOT SET';
+	const merchandisingContent = getMerchandisingContent(newsletterData, override);
+
+	if (!merchandisingContent) return "Could not determine merchandising content. Please select a DRR slot set";
+
+	const {header, footer, middle, lifecycle} = merchandisingContent;
+	return `{% comment %} Required Campaign-level variables {% endcomment %}
 {% assign identity_newsletter_id = "${identityName}" %}
 {% assign email_endpoint = "${emailEndpoint}" %}
 {% assign utm_campaign = "${campaignName ?? "CAMPAIGN NAME IS NOT SET"}" %}

--- a/libs/newsletters-data-client/src/lib/generate-braze-template.ts
+++ b/libs/newsletters-data-client/src/lib/generate-braze-template.ts
@@ -2,31 +2,33 @@ import type { NewsletterData } from './schemas/newsletter-data-type';
 
 export type DrrSlotKey = 'AUS' | 'Culture' | 'Sport' | 'US' | 'Features' | 'Global';
 
-const getDrrSlotSet = (slotKey: DrrSlotKey) => {
-	return {
+const getDrrSlotSet = (slotKey: DrrSlotKey) => ({
 		header: `Logic_Header_${slotKey}`,
 		footer: `Logic_Footer${slotKey}`,
 		middle: `Logic_Middle_${slotKey}`,
 		lifecycle: `Logic_Lifecycle_${slotKey}`
-	}
-}
+});
 
-const regionFocusMappings = {
-	'AU': 'AUS'
+const drrSlotKeyMappings = {
+	'AU': 'AUS',
+	'sport': 'Sport',
+	'culture': 'Culture',
 }
 const getMerchandisingContent = (newsletterData: NewsletterData, override?: string) => {
-	const {regionFocus, theme} = newsletterData;
+	const { regionFocus, theme} = newsletterData;
 
 	if (override) {
 		return getDrrSlotSet(override as DrrSlotKey)
 	}
 
 	if (regionFocus && ['US', 'AU'].includes(regionFocus)) {
-		return getDrrSlotSet((regionFocusMappings[regionFocus as keyof typeof regionFocusMappings] || regionFocus) as DrrSlotKey);
+		return getDrrSlotSet((drrSlotKeyMappings[regionFocus as keyof typeof drrSlotKeyMappings] || regionFocus) as DrrSlotKey);
 	}
+
 	if (['culture', 'sport'].includes(theme)) {
-		return getDrrSlotSet(theme as DrrSlotKey);
+		return getDrrSlotSet((drrSlotKeyMappings[theme as keyof typeof drrSlotKeyMappings] || theme) as DrrSlotKey);
 	}
+
 	return undefined;
 }
 

--- a/libs/newsletters-data-client/src/lib/generate-braze-template.ts
+++ b/libs/newsletters-data-client/src/lib/generate-braze-template.ts
@@ -1,4 +1,4 @@
-import {NewsletterData} from "@newsletters-nx/newsletters-data-client";
+import type { NewsletterData } from './schemas/newsletter-data-type';
 
 export const generateGrazeTemplateString = (newsletterData: NewsletterData): string => {
     const {identityName, campaignName, campaignCode, seriesTag, category} = newsletterData;

--- a/libs/newsletters-data-client/src/lib/generate-braze-template.ts
+++ b/libs/newsletters-data-client/src/lib/generate-braze-template.ts
@@ -57,5 +57,5 @@ export const generateBrazeTemplateString = (newsletterData: NewsletterData): str
 {% capture merchandising_content_middle %}{{content_blocks.\${${middle}}}}{% endcapture %}
 {% capture merchandising_content_footer %}{{content_blocks.\${${footer}}}}{% endcapture %}
 {% capture merchandising_content_newsletter %}{% endcapture %}
-{{ email_content | strip | replace: "<!-- Braze Placeholder - Above Banner -->", merchandising_content_header | replace: "<!-- Braze Placeholder - Above Section 1 -->", merchandising_content_lifecycle | replace: "<!-- Braze Placeholder - Above Section 3 -->", merchandising_content_middle | replace: "<!-- Braze Placeholder - Above Footer -->", merchandising_content_footer | replace: "<!-- Braze Placeholder - Above Section 5 -->", merchandising_content_newsletter | replace: "<!-- Braze Placeholder - Above Section 4 -->", merchandising_content_advert }}`;
+{{ email_content | strip | replace: "<!-- Braze Placeholder - Above Banner -->", merchandising_content_header | replace: "<!-- Braze Placeholder - Above Section 1 -->", merchandising_content_lifecycle | replace: "<!-- Braze Placeholder - Above Section 3 -->", merchandising_content_middle | replace: "<!-- Braze Placeholder - Above Footer -->", merchandising_content_footer | replace: "<!-- Braze Placeholder - Above Section 5 -->", merchandising_content_newsletter }}`;
 }

--- a/libs/newsletters-data-client/src/lib/generate-braze-template.ts
+++ b/libs/newsletters-data-client/src/lib/generate-braze-template.ts
@@ -1,37 +1,43 @@
 import type { NewsletterData } from './schemas/newsletter-data-type';
 
-const getMerchandisingContent = ({ regionFocus, theme }:  NewsletterData) => {
-	if (regionFocus === 'AU') {
-		return {
-			header: 'Logic_Header_AUS',
-			footer: 'Logic_Footer_AUS',
-			middle: 'Logic_Middle_AUS',
-			lifecycle: 'Logic_Lifecycle_AUS',
-		}
+const merchandisingMap = {
+	AU: {
+		header: 'Logic_Header_AU',
+		footer: 'Logic_Footer_AU',
+		middle: 'Logic_Middle_AU',
+		lifecycle: 'Logic_Lifecycle_AU',
+	},
+	US: {
+		header: 'Logic_Header_US',
+		footer: 'Logic_Footer_US',
+		middle: 'Logic_Middle_US',
+		lifecycle: 'Logic_Lifecycle_US',
+	},
+	Culture: {
+		header: 'Logic_Header_Culture',
+		footer: 'Logic_Footer_Culture',
+		middle: 'Logic_Middle_Culture',
+		lifecycle: 'Logic_Lifecycle_Culture',
+	},
+	Sport: {
+		header: 'Logic_Header_Sport',
+		footer: 'Logic_Footer_Sport',
+		middle: 'Logic_Middle_Sport',
+		lifecycle: 'Logic_Lifecycle_Sport',
+	},
+}
+const getMerchandisingContent = (newsletterData: NewsletterData, override?: string) => {
+	const {regionFocus, theme} = newsletterData;
+
+	if (override) {
+		return merchandisingMap[override as keyof typeof merchandisingMap]
 	}
-	if (regionFocus === 'US') {
-		return {
-			header: 'Logic_Header_US',
-			footer: 'Logic_Footer_US',
-			middle: 'Logic_Middle_US',
-			lifecycle: 'Logic_Lifecycle_US',
-		}
+
+	if (regionFocus && ['US', 'AU'].includes(regionFocus)) {
+		return merchandisingMap[regionFocus as keyof typeof merchandisingMap]
 	}
-	if (theme === 'culture') {
-		return {
-			header: 'Logic_Header_Culture',
-			footer: 'Logic_Footer_Culture',
-			middle: 'Logic_Middle_Culture',
-			lifecycle: 'Logic_Lifecycle_Culture',
-		}
-	}
-	if (theme === 'sport') {
-		return {
-			header: 'Logic_Header_Sport',
-			footer: 'Logic_Footer_Sport',
-			middle: 'Logic_Middle_Sport',
-			lifecycle: 'Logic_Lifecycle_Sport',
-		}
+	if (['culture', 'sport'].includes(theme)) {
+		return merchandisingMap[theme as keyof typeof merchandisingMap]
 	}
 	return {
 		header: 'SET APPROPRIATE MERCHANDISING CONTENT',
@@ -41,11 +47,11 @@ const getMerchandisingContent = ({ regionFocus, theme }:  NewsletterData) => {
 	}
 }
 
-export const generateBrazeTemplateString = (newsletterData: NewsletterData): string => {
+export const generateBrazeTemplateString = (newsletterData: NewsletterData, override?: string): string => {
     const {identityName, campaignName, campaignCode, seriesTag, category} = newsletterData;
     const contentBlocks = category === 'article-based' ? 'Editorial_FirstEditionContent' : 'Editorial_Content'
     const emailEndpoint = seriesTag && ['article-based', 'article-based-legacy'].includes(category) ? `${seriesTag}/latest.json` : 'EMAIL ENDPOINT IS NOT SET';
-		const { header, footer, middle, lifecycle} = getMerchandisingContent(newsletterData);
+		const { header, footer, middle, lifecycle} = getMerchandisingContent(newsletterData, override);
     return `{% comment %} Required Campaign-level variables {% endcomment %}
 {% assign identity_newsletter_id = "${identityName}" %}
 {% assign email_endpoint = "${emailEndpoint}" %}

--- a/libs/newsletters-data-client/src/lib/generate-braze-template.ts
+++ b/libs/newsletters-data-client/src/lib/generate-braze-template.ts
@@ -1,0 +1,20 @@
+import {NewsletterData} from "@newsletters-nx/newsletters-data-client";
+
+export const generateGrazeTemplateString = (newsletterData: NewsletterData): string => {
+    const {identityName, campaignName, campaignCode, seriesTag, category} = newsletterData;
+    const contentBlocks = category === 'article-based' ? 'Editorial_FirstEditionContent' : 'Editorial_Content'
+    const emailEndpoint = seriesTag && ['article-based', 'article-based-legacy'].includes(category) ? `${seriesTag}/latest.json` : 'EMAIL ENDPOINT IS NOT SET';
+    return `{% comment %} Required Campaign-level variables {% endcomment %}
+{% assign identity_newsletter_id = "${identityName}" %}
+{% assign email_endpoint = "${emailEndpoint}" %}
+{% assign utm_campaign = "${campaignName ?? "CAMPAIGN NAME IS NOT SET"}" %}
+{% assign CMP = "${campaignCode ?? 'CAMPAIGN CODE IS NOT SET'}" %}
+{% capture email_content %}{{content_blocks.\${${contentBlocks}}}{% endcapture %}
+{% capture merchandising_content_header %}{{content_blocks.\${Logic_Header_Culture}}}{% endcapture %}
+{% capture merchandising_content_lifecycle %}{{content_blocks.\${Logic_Lifecycle_Culture}}}{% endcapture %}
+{% capture merchandising_content_middle %}{{content_blocks.\${Logic_Middle_Culture}}}{% endcapture %}
+{% capture merchandising_content_footer %}{{content_blocks.\${Logic_Footer_Culture}}}{% endcapture %}
+{% capture merchandising_content_newsletter %}{% endcapture %}
+{% capture merchandising_content_advert %}{{content_blocks.\${ADVERT_RECIPECARD_October23_Belazu_WordOfMouth}}}{% endcapture %}
+{{ email_content | strip | replace: "<!-- Braze Placeholder - Above Banner -->", merchandising_content_header | replace: "<!-- Braze Placeholder - Above Section 1 -->", merchandising_content_lifecycle | replace: "<!-- Braze Placeholder - Above Section 3 -->", merchandising_content_middle | replace: "<!-- Braze Placeholder - Above Footer -->", merchandising_content_footer | replace: "<!-- Braze Placeholder - Above Section 5 -->", merchandising_content_newsletter | replace: "<!-- Braze Placeholder - Above Section 4 -->", merchandising_content_advert }}`;
+}

--- a/libs/newsletters-data-client/src/lib/generate-braze-template.ts
+++ b/libs/newsletters-data-client/src/lib/generate-braze-template.ts
@@ -51,12 +51,11 @@ export const generateBrazeTemplateString = (newsletterData: NewsletterData): str
 {% assign email_endpoint = "${emailEndpoint}" %}
 {% assign utm_campaign = "${campaignName ?? "CAMPAIGN NAME IS NOT SET"}" %}
 {% assign CMP = "${campaignCode ?? 'CAMPAIGN CODE IS NOT SET'}" %}
-{% capture email_content %}{{content_blocks.\${${contentBlocks}}}{% endcapture %}
-{% capture merchandising_content_header %}{{content_blocks.\${${header}}}{% endcapture %}
-{% capture merchandising_content_lifecycle %}{{content_blocks.\${${lifecycle}}}{% endcapture %}
-{% capture merchandising_content_middle %}{{content_blocks.\${${middle}}}{% endcapture %}
-{% capture merchandising_content_footer %}{{content_blocks.\${${footer}}}{% endcapture %}
+{% capture email_content %}{{content_blocks.\${${contentBlocks}}}}{% endcapture %}
+{% capture merchandising_content_header %}{{content_blocks.\${${header}}}}{% endcapture %}
+{% capture merchandising_content_lifecycle %}{{content_blocks.\${${lifecycle}}}}{% endcapture %}
+{% capture merchandising_content_middle %}{{content_blocks.\${${middle}}}}{% endcapture %}
+{% capture merchandising_content_footer %}{{content_blocks.\${${footer}}}}{% endcapture %}
 {% capture merchandising_content_newsletter %}{% endcapture %}
-{% capture merchandising_content_advert %}{{content_blocks.\${ADVERT_RECIPECARD_October23_Belazu_WordOfMouth}}}{% endcapture %}
 {{ email_content | strip | replace: "<!-- Braze Placeholder - Above Banner -->", merchandising_content_header | replace: "<!-- Braze Placeholder - Above Section 1 -->", merchandising_content_lifecycle | replace: "<!-- Braze Placeholder - Above Section 3 -->", merchandising_content_middle | replace: "<!-- Braze Placeholder - Above Footer -->", merchandising_content_footer | replace: "<!-- Braze Placeholder - Above Section 5 -->", merchandising_content_newsletter | replace: "<!-- Braze Placeholder - Above Section 4 -->", merchandising_content_advert }}`;
 }

--- a/libs/newsletters-data-client/src/lib/newsletter-value-generators.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-value-generators.ts
@@ -17,8 +17,7 @@ export const embedIframeCode: NewsletterValueGenerator = {
 };
 
 export const brazeTemplateCode: NewsletterValueGenerator = {
-	generate: (newsletter: NewsletterData) => generateGrazeTemplateString(newsletter)
-		 ,
+	generate: (newsletter: NewsletterData) => generateGrazeTemplateString(newsletter),
 	displayName: 'Braze campaign template code',
 	description:
 		'The template code to use in the Braze campaign.',

--- a/libs/newsletters-data-client/src/lib/newsletter-value-generators.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-value-generators.ts
@@ -3,7 +3,7 @@ import {generateBrazeTemplateString} from "./generate-braze-template";
 
 
 export type NewsletterValueGenerator = {
-	generate: { (newsletter: NewsletterData): string };
+	generate: { (newsletter: NewsletterData, 	override?: string): string };
 	displayName: string;
 	description: string;
 };
@@ -17,7 +17,7 @@ export const embedIframeCode: NewsletterValueGenerator = {
 };
 
 export const brazeTemplateCode: NewsletterValueGenerator = {
-	generate: (newsletter: NewsletterData) => generateBrazeTemplateString(newsletter),
+	generate: (newsletter: NewsletterData, 	override?: string) => generateBrazeTemplateString(newsletter, override),
 	displayName: 'Braze campaign template code',
 	description:
 		'The template code to use in the Braze campaign.',

--- a/libs/newsletters-data-client/src/lib/newsletter-value-generators.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-value-generators.ts
@@ -1,5 +1,5 @@
 import type { NewsletterData } from '..';
-import {generateGrazeTemplateString} from "./generate-braze-template";
+import {generateBrazeTemplateString} from "./generate-braze-template";
 
 
 export type NewsletterValueGenerator = {
@@ -17,7 +17,7 @@ export const embedIframeCode: NewsletterValueGenerator = {
 };
 
 export const brazeTemplateCode: NewsletterValueGenerator = {
-	generate: (newsletter: NewsletterData) => generateGrazeTemplateString(newsletter),
+	generate: (newsletter: NewsletterData) => generateBrazeTemplateString(newsletter),
 	displayName: 'Braze campaign template code',
 	description:
 		'The template code to use in the Braze campaign.',

--- a/libs/newsletters-data-client/src/lib/newsletter-value-generators.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-value-generators.ts
@@ -1,4 +1,6 @@
 import type { NewsletterData } from '..';
+import {generateGrazeTemplateString} from "./generate-braze-template";
+
 
 export type NewsletterValueGenerator = {
 	generate: { (newsletter: NewsletterData): string };
@@ -12,6 +14,14 @@ export const embedIframeCode: NewsletterValueGenerator = {
 	displayName: 'Sign up embed code',
 	description:
 		'The HTML code to paste into a composer embed block to add a sign-up form to the article content.',
+};
+
+export const brazeTemplateCode: NewsletterValueGenerator = {
+	generate: (newsletter: NewsletterData) => generateGrazeTemplateString(newsletter)
+		 ,
+	displayName: 'Braze campaign template code',
+	description:
+		'The template code to use in the Braze campaign.',
 };
 
 // see https://github.com/guardian/identity/blob/main/identity-api/src/main/scala/com/gu/identity/api/mail/CmtModels.scala

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
 				"aws-sdk": "^2.1354.0",
 				"dayjs": "^1.11.8",
 				"fastify": "4.11.0",
+				"highlight.js": "^11.9.0",
 				"instead": "^1.0.3",
 				"react": "18.2.0",
 				"react-dom": "18.2.0",
@@ -16784,6 +16785,14 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/highlight.js": {
+			"version": "11.9.0",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.9.0.tgz",
+			"integrity": "sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==",
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/hoist-non-react-statics": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 		"aws-sdk": "^2.1354.0",
 		"dayjs": "^1.11.8",
 		"fastify": "4.11.0",
+		"highlight.js": "^11.9.0",
 		"instead": "^1.0.3",
 		"react": "18.2.0",
 		"react-dom": "18.2.0",


### PR DESCRIPTION
## What does this change?

Adds a Braze template for bootstrapping the Braze campaign. Allows choosing from a set of DRR slot sets (see [this doc](https://docs.google.com/spreadsheets/d/1nFylTwFkaitL--vWBQ_IITbLRHDbrQAXSWyJFL4zsxw/edit#gid=272537086)) to select where inference is not possible from newsletter data alone. 

## How to test

Check out, look at some generated templates and test in Braze. The outputs should be valid Liquid syntax and reference our endpoints appropriately

## How can we measure success?

Reduce set up time for new Braze Campaigns when launching a new newsletter. 

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

Low risk quality of life improvement for DRR

## Images

![Kapture 2023-12-08 at 15 24 24](https://github.com/guardian/newsletters-nx/assets/3277259/e23628aa-df5d-42f7-b953-eb2ae24fa5fb)

