### PR TITLE
Set newsletters with pending status to restricted to prevent display on MMA page

### DIFF
--- a/libs/newsletters-data-client/src/lib/transformDataToLegacyNewsletter.ts
+++ b/libs/newsletters-data-client/src/lib/transformDataToLegacyNewsletter.ts
@@ -67,7 +67,7 @@ const deriveLegacyNewsletter = (
 			identityName: newsletterData.identityName,
 			name: newsletterData.name,
 			cancelled,
-			restricted: newsletterData.restricted,
+			restricted: newsletterData.status === 'pending' || newsletterData.restricted,
 			paused,
 			emailConfirmation: newsletterData.emailConfirmation,
 			brazeNewsletterName: newsletterData.brazeNewsletterName,


### PR DESCRIPTION
## What does this change?

Sets mapped `restricted` status to in legacy mapper to prevent display of newsletters in MMA page with a pending status


## How to test

Run locally. (`npm run dev`)
launch a newsletter:
Check the [Newsletters API](http://localhost:4200/api/newsletters)
Check the [Legacy newsletters API](http://localhost:4200/api/legacy/newsletters)

## How can we measure success?

By the above conditions being true

## Have we considered potential risks?

This reduces risk of showing an unlaunched newsletter in the MMA page

## Images

![Screenshot 2023-10-30 at 09 10 20](https://github.com/guardian/newsletters-nx/assets/3277259/9070229b-7a7f-4dfc-a973-c279e9c4b5f5)
![Screenshot 2023-10-30 at 09 09 56](https://github.com/guardian/newsletters-nx/assets/3277259/7d9e180b-ebfb-4304-b12a-951a340fbaa5)
