### PR TITLE
Add ref to signup embed code for CP

### DIFF
--- a/libs/email-builder/src/lib/components/RenderTagAndSignUpPageCreationMessage.tsx
+++ b/libs/email-builder/src/lib/components/RenderTagAndSignUpPageCreationMessage.tsx
@@ -20,6 +20,7 @@ export const RequestTagAndSignUpPageMessage = ({
 		composerCampaignTag,
 		composerTag: tagsThatPromptRecommendationOfCampaignTag,
 	} = newsletter;
+	const viewDetailsLink = pageLink.split('/').filter(element => element !== 'edit').join('/');
 	const embargoDate =
 		newsletter.signUpPageDate.valueOf() > Date.now()
 			? newsletter.signUpPageDate.toLocaleDateString(undefined, {
@@ -70,6 +71,9 @@ export const RequestTagAndSignUpPageMessage = ({
 				newsletter={newsletter}
 				properties={['name', 'signUpHeadline', 'signUpDescription']}
 			/>
+			<p>
+				The embed code for the sign-up page is available in the <a href={viewDetailsLink}>newsletters tool</a>.
+			</p>
 			{embargoDate && (
 				<p>
 					Please add an embargo so that the sign up page should not go live


### PR DESCRIPTION
## What does this change?

The recent launch of the Crunch newsletter revealed a need to signpost the location of the sign-up embed code in the tool to assist CP in creating a sign-up page. 

This change adds a link to the body of the email sent to CP on launch

## How to test

## How can we measure success?

- Run locally with frontend credentials and `ENABLE_EMAIL_SERVICE` set to true in your `.env.local` configuration file (created by the setup script, not in source control)
- Launch a newsletter and verify that the CP email contains a link to the details page


## Have we considered potential risks?

Should be fine

## Images

<img width="789" alt="Screenshot 2023-11-06 at 09 33 42" src="https://github.com/guardian/newsletters-nx/assets/3277259/03d69f90-52aa-4824-854c-5ceabc702cc3">
