### PR TITLE
embargo date refactor and copy change

### DIFF
--- a/libs/email-builder/src/fixtures/sample-newsletters.ts
+++ b/libs/email-builder/src/fixtures/sample-newsletters.ts
@@ -1,0 +1,41 @@
+import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
+
+export const ART_WEEKLY_FIXTURE: Readonly<NewsletterData> = {
+	brazeCampaignCreationStatus: 'COMPLETED',
+	ophanCampaignCreationStatus: 'COMPLETED',
+	signupPageCreationStatus: 'COMPLETED',
+	tagCreationStatus: 'COMPLETED',
+	identityName: 'art-weekly',
+	name: 'Art Weekly',
+	category: 'article-based-legacy',
+	restricted: false,
+	status: 'live',
+	emailConfirmation: false,
+	brazeSubscribeAttributeName: 'ArtWeekly_Subscribe_Email',
+	brazeSubscribeEventNamePrefix: 'art_weekly',
+	brazeNewsletterName: 'Editorial_ArtWeekly',
+	theme: 'culture',
+	group: 'Culture',
+	signUpDescription:
+		'Your weekly art world round-up, sketching out all the biggest stories, scandals and exhibitions',
+	signUpEmbedDescription:
+		'Your weekly art world round-up, sketching out all the biggest stories, scandals and exhibitions',
+	frequency: 'Weekly',
+	listIdV1: 99,
+	listId: 4134,
+	campaignName: 'ArtWeekly',
+	campaignCode: 'artweekly_email',
+	brazeSubscribeAttributeNameAlternate: ['email_subscribe_art_weekly'],
+	signupPage: '/artanddesign/2015/oct/19/sign-up-to-the-art-weekly-email',
+	exampleUrl: '/artanddesign/series/art-weekly/latest/email',
+	figmaIncludesThrashers: false,
+	creationTimeStamp: 946684800,
+	seriesTag: 'artanddesign/series/art-weekly',
+	launchDate: new Date('1970-01-11T22:58:04.800Z'),
+	signUpPageDate: new Date('1970-01-11T22:58:04.800Z'),
+	thrasherDate: new Date('1970-01-11T22:58:04.800Z'),
+	privateUntilLaunch: false,
+	mailSuccessDescription: "We'll send you Art Weekly every week",
+	illustrationCard:
+		'https://media.guim.co.uk/e6ee88c4b60cd6fd315fb472beb8989920dd59a9/7_231_882_529/500.jpg',
+} as const;

--- a/libs/email-builder/src/lib/components/RenderTagAndSignUpPageCreationMessage.tsx
+++ b/libs/email-builder/src/lib/components/RenderTagAndSignUpPageCreationMessage.tsx
@@ -80,15 +80,13 @@ export const RequestTagAndSignUpPageMessage = ({
 					until {embargoDate}.
 				</p>
 			)}
-			{!embargoDate && (
-				<p>
-					When the page has been created, please check with{' '}
-					<a href="mailto:newsletters@guardian.co.uk">
-						newsletters@guardian.co.uk
-					</a>{' '}
-					before setting the page live.
-				</p>
-			)}
+			<p>
+				When the page has been created, please check with{' '}
+				<a href="mailto:newsletters@guardian.co.uk">
+					newsletters@guardian.co.uk
+				</a>{' '}
+				before setting the page live.
+			</p>
 			<p>
 				When the tasks are completed, please go to{' '}
 				<a href={pageLink}>this page on the newsletters tool</a> to confirm

--- a/libs/email-builder/src/lib/components/RenderTagAndSignUpPageCreationMessage.tsx
+++ b/libs/email-builder/src/lib/components/RenderTagAndSignUpPageCreationMessage.tsx
@@ -82,11 +82,11 @@ export const RequestTagAndSignUpPageMessage = ({
 			)}
 			{!embargoDate && (
 				<p>
-					When the page has been created, please contact{' '}
+					When the page has been created, please check with{' '}
 					<a href="mailto:newsletters@guardian.co.uk">
 						newsletters@guardian.co.uk
 					</a>{' '}
-					to confirm when the page should be made live.
+					before setting the page live.
 				</p>
 			)}
 			<p>

--- a/libs/email-builder/src/lib/components/RenderTagAndSignUpPageCreationMessage.tsx
+++ b/libs/email-builder/src/lib/components/RenderTagAndSignUpPageCreationMessage.tsx
@@ -80,7 +80,15 @@ export const RequestTagAndSignUpPageMessage = ({
 					until {embargoDate}.
 				</p>
 			)}
-			{!embargoDate && <p>The page can go live immediately.</p>}
+			{!embargoDate && (
+				<p>
+					When the page has been created, please contact{' '}
+					<a href="mailto:newsletters@guardian.co.uk">
+						newsletters@guardian.co.uk
+					</a>{' '}
+					to confirm when the page should be made live.
+				</p>
+			)}
 			<p>
 				When the tasks are completed, please go to{' '}
 				<a href={pageLink}>this page on the newsletters tool</a> to confirm

--- a/libs/email-builder/src/lib/components/RenderTagAndSignUpPageCreationMessage.tsx
+++ b/libs/email-builder/src/lib/components/RenderTagAndSignUpPageCreationMessage.tsx
@@ -1,6 +1,7 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
 import type { MessageContent } from '../types';
+import { getEmbargoDate } from '../util';
 import { MessageFormat } from './MessageFormat';
 import { NewsletterPropertyTable } from './NewsletterPropertyTable';
 
@@ -20,13 +21,11 @@ export const RequestTagAndSignUpPageMessage = ({
 		composerCampaignTag,
 		composerTag: tagsThatPromptRecommendationOfCampaignTag,
 	} = newsletter;
-	const viewDetailsLink = pageLink.split('/').filter(element => element !== 'edit').join('/');
-	const embargoDate =
-		newsletter.signUpPageDate.valueOf() > Date.now()
-			? newsletter.signUpPageDate.toLocaleDateString(undefined, {
-					dateStyle: 'long',
-			  })
-			: undefined;
+	const viewDetailsLink = pageLink
+		.split('/')
+		.filter((element) => element !== 'edit')
+		.join('/');
+	const embargoDate = getEmbargoDate(newsletter);
 	const tagTitle = composerCampaignTag
 		? ` series and campaign tags`
 		: ` a series tag`;
@@ -72,7 +71,8 @@ export const RequestTagAndSignUpPageMessage = ({
 				properties={['name', 'signUpHeadline', 'signUpDescription']}
 			/>
 			<p>
-				The embed code for the sign-up page is available in the <a href={viewDetailsLink}>newsletters tool</a>.
+				The embed code for the sign-up page is available in the{' '}
+				<a href={viewDetailsLink}>newsletters tool</a>.
 			</p>
 			{embargoDate && (
 				<p>

--- a/libs/email-builder/src/lib/util.spec.ts
+++ b/libs/email-builder/src/lib/util.spec.ts
@@ -1,0 +1,24 @@
+import { ART_WEEKLY_FIXTURE } from '../fixtures/sample-newsletters';
+import { getEmbargoDate } from './util';
+
+const FAR_PAST = new Date('1024-01-01');
+const FAR_FUTURE = new Date('4024-01-01');
+
+describe('getEmbargoDate', () => {
+	it('Should return undefined if the signUpPageDate is in the past', () => {
+		const result = getEmbargoDate({
+			...ART_WEEKLY_FIXTURE,
+			signUpPageDate: FAR_PAST,
+		});
+		expect(result).toBeUndefined();
+	});
+	it('Should return a string with the date if the signUpPageDate is in the future', () => {
+		const result = getEmbargoDate({
+			...ART_WEEKLY_FIXTURE,
+			signUpPageDate: FAR_FUTURE,
+		});
+
+		expect(result).toBeDefined();
+		expect(result?.includes('4024')).toBeTruthy();
+	});
+});

--- a/libs/email-builder/src/lib/util.spec.ts
+++ b/libs/email-builder/src/lib/util.spec.ts
@@ -21,4 +21,27 @@ describe('getEmbargoDate', () => {
 		expect(result).toBeDefined();
 		expect(result?.includes('4024')).toBeTruthy();
 	});
+	it('Works for small differences', () => {
+		const yesterday = new Date('2020-01-14');
+		const now = new Date('2020-01-15');
+		const tomorrow = new Date('2020-01-16');
+
+		const resultWhenSignUpDateIsYesterday = getEmbargoDate(
+			{
+				...ART_WEEKLY_FIXTURE,
+				signUpPageDate: yesterday,
+			},
+			now.valueOf(),
+		);
+		const resultWhenSignUpDateIsTomorrow = getEmbargoDate(
+			{
+				...ART_WEEKLY_FIXTURE,
+				signUpPageDate: tomorrow,
+			},
+			now.valueOf(),
+		);
+
+		expect(resultWhenSignUpDateIsYesterday).toBeUndefined();
+		expect(resultWhenSignUpDateIsTomorrow).toBeDefined();
+	});
 });

--- a/libs/email-builder/src/lib/util.ts
+++ b/libs/email-builder/src/lib/util.ts
@@ -3,7 +3,10 @@ import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
 /**
  * If the newsletter's signUpPageDate is in the future, relative
  * to the sendTime (defaults to now), return a string describing that
- * date, otherwise return undefined
+ * date, otherwise return undefined.
+ *
+ * Not working reliably in PROD, return undefined when the date
+ * should be in the future - reasons unknown.
  */
 export const getEmbargoDate = (
 	newsletter: NewsletterData,

--- a/libs/email-builder/src/lib/util.ts
+++ b/libs/email-builder/src/lib/util.ts
@@ -1,0 +1,16 @@
+import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
+
+/**
+ * If the newsletter's signUpPageDate is in the future, relative
+ * to the sendTime (defaults to now), return a string describing that
+ * date, otherwise return undefined
+ */
+export const getEmbargoDate = (
+	newsletter: NewsletterData,
+	sendTime = Date.now(),
+) =>
+	newsletter.signUpPageDate.valueOf() > sendTime
+		? newsletter.signUpPageDate.toLocaleDateString(undefined, {
+				dateStyle: 'long',
+		  })
+		: undefined;


### PR DESCRIPTION
## What does this change?

Extracts the code for deriving and embargo data string from the newsletter data to a utility file and puts some tests on it.

Changes the text of the the 'sign-up page and tags' email to ask CP to check with Editorial rather than put live immediately - even if there is no embargo date.

There is a bug on PROD that can't be re-produced locally where the sign-up page date is in the future, but the "put live immediately" text was being included in the email.


## How to test

Run locally, with the  ENABLE_EMAIL_SERVICE env variable on, and add your email address to the  DEV email recipients in the param store.  
Create some drafts, check email contents

## How can we measure success?

No misleading instructions in the emails.

## Have we considered potential risks?

More queries to editorial from CP
