### PR TITLE
generate composer campaign tag id for notifications

### DIFF
--- a/libs/email-builder/src/lib/components/RenderTagAndSignUpPageCreationMessage.tsx
+++ b/libs/email-builder/src/lib/components/RenderTagAndSignUpPageCreationMessage.tsx
@@ -1,5 +1,6 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
+import { composerCampaignTagId } from '@newsletters-nx/newsletters-data-client';
 import type { MessageContent } from '../types';
 import { MessageFormat } from './MessageFormat';
 import { NewsletterPropertyTable } from './NewsletterPropertyTable';
@@ -20,7 +21,10 @@ export const RequestTagAndSignUpPageMessage = ({
 		composerCampaignTag,
 		composerTag: tagsThatPromptRecommendationOfCampaignTag,
 	} = newsletter;
-	const viewDetailsLink = pageLink.split('/').filter(element => element !== 'edit').join('/');
+	const viewDetailsLink = pageLink
+		.split('/')
+		.filter((element) => element !== 'edit')
+		.join('/');
 	const embargoDate =
 		newsletter.signUpPageDate.valueOf() > Date.now()
 			? newsletter.signUpPageDate.toLocaleDateString(undefined, {
@@ -41,7 +45,7 @@ export const RequestTagAndSignUpPageMessage = ({
 			<h2> Create Tags </h2>
 			<ul>
 				<li>
-					<b>Series Tag:</b> {seriesTag} (Section: {theme})
+					<b>Series Tag Id:</b> {seriesTag} (Section: {theme})
 				</li>
 				{seriesTagDescription && (
 					<li>
@@ -49,9 +53,15 @@ export const RequestTagAndSignUpPageMessage = ({
 					</li>
 				)}
 				{composerCampaignTag && (
-					<li>
-						<b>Campaign Tag:</b> {composerCampaignTag}
-					</li>
+					<>
+						<li>
+							<b>{composerCampaignTagId.displayName}:</b>{' '}
+							{composerCampaignTagId.generate(newsletter)}
+						</li>
+						<li>
+							<b>Campaign Tag Description:</b> {composerCampaignTag}
+						</li>
+					</>
 				)}
 			</ul>
 
@@ -72,7 +82,8 @@ export const RequestTagAndSignUpPageMessage = ({
 				properties={['name', 'signUpHeadline', 'signUpDescription']}
 			/>
 			<p>
-				The embed code for the sign-up page is available in the <a href={viewDetailsLink}>newsletters tool</a>.
+				The embed code for the sign-up page is available in the{' '}
+				<a href={viewDetailsLink}>newsletters tool</a>.
 			</p>
 			{embargoDate && (
 				<p>

--- a/libs/newsletters-data-client/src/lib/newsletter-value-generators.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-value-generators.ts
@@ -68,7 +68,7 @@ export const emailContent: NewsletterValueGenerator = {
 // see https://github.com/guardian/frontend/blob/d67c1c03875bfb972de000305a922dade6c8285d/common/app/services/NewsletterService.scala#L31
 export const composerCampaignTagId: NewsletterValueGenerator = {
 	generate: ({ identityName }) => `campaign/email/${identityName}`,
-	displayName: 'composer tag id',
+	displayName: 'Campaign Tag Id',
 	description:
-		'The id to use when creating the Composer Campaign Tag (must be in this format for the signup form to be added to an article)',
+		'The id to use when creating the Composer Campaign Tag (must be in this format to add the signup form to an article)',
 };

--- a/libs/newsletters-data-client/src/lib/newsletter-value-generators.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-value-generators.ts
@@ -56,11 +56,19 @@ export const emailEndpoint: NewsletterValueGenerator = {
 			? `${seriesTag}/latest.json`
 			: `[not available - no series tag defined]`,
 	displayName: 'email_endpoint',
-	description: 'The the value to use for email_endpoint in the Braze campaign',
+	description: 'The value to use for email_endpoint in the Braze campaign',
 };
 
 export const emailContent: NewsletterValueGenerator = {
 	generate: () => 'Editorial_FirstEditionContent',
 	displayName: 'email_content',
-	description: 'The the value to use for email_content in the Braze campaign',
+	description: 'The value to use for email_content in the Braze campaign',
+};
+
+// see https://github.com/guardian/frontend/blob/d67c1c03875bfb972de000305a922dade6c8285d/common/app/services/NewsletterService.scala#L31
+export const composerCampaignTagId: NewsletterValueGenerator = {
+	generate: ({ identityName }) => `campaign/email/${identityName}`,
+	displayName: 'composer tag id',
+	description:
+		'The id to use when creating the Composer Campaign Tag (must be in this format for the signup form to be added to an article)',
 };

--- a/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
@@ -143,7 +143,10 @@ export const newsletterDataSchema = z.object({
 		.optional()
 		.describe('The Series tag description'),
 	composerTag: z.string().optional().describe('Composer tag(s)'),
-	composerCampaignTag: z.string().optional().describe('Composer campaign tag'),
+	composerCampaignTag: z
+		.string()
+		.optional()
+		.describe('Composer campaign tag description'),
 
 	launchDate: z.coerce.date().describe('Launch date'),
 	signUpPageDate: z.coerce.date().describe('Sign up page date'),


### PR DESCRIPTION
## What does this change?

Creates a generator for deriving the correct tag ID for a newsletter's "Composer Campaign Tag", in the fomat required by Frontend.

Uses the derived value (with the description for the tag, which is still user specified) in the email to CP.

Adjust the field description for the "Composer Campaign Tag" so the forms prompt the user to provide a Tag Description, not a Tag Id.

## How to test

Set env variable for email service to true, put your email in the dev recipients in param store,
run locally,  launch some newsletters

## How can we measure success?

CP will know the required format for the campaign Tags

## Have we considered potential risks?

Should be safe

## Images
<img width="1329" alt="Screenshot 2023-11-22 at 12 06 00" src="https://github.com/guardian/newsletters-nx/assets/30567854/0ff5e9d5-979b-40b1-962c-2fd0a48ee3e8">

