### PR TITLE
Update footer key with underscore

### DIFF
--- a/libs/newsletters-data-client/src/lib/generate-braze-template.ts
+++ b/libs/newsletters-data-client/src/lib/generate-braze-template.ts
@@ -4,7 +4,7 @@ export type DrrSlotKey = 'AUS' | 'Culture' | 'Sport' | 'US' | 'Features' | 'Glob
 
 const getDrrSlotSet = (slotKey: DrrSlotKey) => ({
 		header: `Logic_Header_${slotKey}`,
-		footer: `Logic_Footer${slotKey}`,
+		footer: `Logic_Footer_${slotKey}`,
 		middle: `Logic_Middle_${slotKey}`,
 		lifecycle: `Logic_Lifecycle_${slotKey}`
 });


### PR DESCRIPTION
## What does this change?

Updates reference to logic footer content to include underscore - this was an oversigt from the [original braze template pr](https://github.com/guardian/newsletters-nx/pull/289)

## How to test

Verify that the generated Braze template references `Logic_Footer_Global` rather than `Logic_FooterGlobal`

## Have we considered potential risks?

Low risk

