### PR TITLE
access hook allows for null values in data

### DIFF
--- a/apps/newsletters-api/src/app/routes/newsletters.ts
+++ b/apps/newsletters-api/src/app/routes/newsletters.ts
@@ -90,10 +90,11 @@ export function registerReadWriteNewsletterRoutes(app: FastifyInstance) {
 	) => {
 		const user = getUserProfile(request);
 		const isAuthorised = await hasEditAccess(user.profile);
-		const { body: update } = request;
+		const { body } = request;
+		const update = replaceNullWithUndefinedForUnknown(body);
 
 		if (!isPartialNewsletterData(update)) {
-			void reply.status(403).send(makeErrorResponse('invalid update data'));
+			void reply.status(400).send(makeErrorResponse('invalid update data'));
 		} else {
 			const isAuthorisedForUpdate =
 				await isAuthorisedToMakeRequestedNewsletterUpdate(user.profile, update);

--- a/apps/newsletters-ui/src/app/components/GeneratedCodeDataPoint.tsx
+++ b/apps/newsletters-ui/src/app/components/GeneratedCodeDataPoint.tsx
@@ -18,12 +18,11 @@ import 'highlight.js/styles/github.css';
 import django from 'highlight.js/lib/languages/django';
 import javascript from 'highlight.js/lib/languages/javascript';
 import xml from 'highlight.js/lib/languages/xml';
-import {useState} from "react";
+import { useState } from 'react';
 import type {
 	NewsletterData,
 	NewsletterValueGenerator,
 } from '@newsletters-nx/newsletters-data-client';
-
 
 hljs.registerLanguage('javascript', javascript);
 hljs.registerLanguage('django', django);
@@ -37,81 +36,102 @@ interface Props {
 	language: string;
 }
 
-export type MerchandisingOverride = 'default' | 'AUS' | 'Culture' | 'Features' | 'Global' | 'Sport' | 'US';
+export type MerchandisingOverride =
+	| 'default'
+	| 'AUS'
+	| 'Culture'
+	| 'Features'
+	| 'Global'
+	| 'Sport'
+	| 'US';
 
 export const GeneratedCodeDataPoint = ({
-																				 newsletter,
-																				 valueGenerator,
-																				 includeCopyButton,
-																				 showOverride,
-																				 language,
-																			 }: Props) => {
-
-
-	const [override, setOverride] = useState<MerchandisingOverride>('default' as MerchandisingOverride);
+	newsletter,
+	valueGenerator,
+	includeCopyButton,
+	showOverride,
+	language,
+}: Props) => {
+	const [override, setOverride] = useState<MerchandisingOverride>(
+		'default' as MerchandisingOverride,
+	);
 
 	const codeOverride = override === 'default' ? undefined : override;
 	const generatedValue = valueGenerator.generate(newsletter, codeOverride);
 
-
 	const valueKeyMapping = {
-		'AUS': 'Australia',
-		'Culture': 'Culture',
-		'Features': 'Features',
-		'Global': 'Global',
-		'Sport': 'Sport',
-		'US': 'US',
-		'default': 'Default',
-	}
-	const copyToClipBoard = async () => await navigator.clipboard.writeText(generatedValue);
+		AUS: 'Australia',
+		Culture: 'Culture',
+		Features: 'Features',
+		Global: 'Global',
+		Sport: 'Sport',
+		US: 'US',
+		default: 'Default',
+	};
+	const copyToClipBoard = async () =>
+		await navigator.clipboard.writeText(generatedValue);
 
-	const code = hljs.highlight(generatedValue, {language})
+	const code = hljs.highlight(generatedValue, { language });
 
 	return (
 		<Grid container justifyContent={'space-between'} spacing={1}>
 			<Grid item xs={3} flexGrow={1} flexShrink={0}>
 				<Typography variant="caption">{valueGenerator.displayName}</Typography>
 				<Tooltip title={valueGenerator.description} arrow>
-					<Chip size="small" label="?"/>
+					<Chip size="small" label="?" />
 				</Tooltip>
 			</Grid>
 			<Grid item xs={9} flexShrink={1}>
 				{showOverride && (
 					<Stack direction={'row'}>
-						<Box flex={1} display={'flex'} sx={{p: 1}}>
+						<Box flex={1} display={'flex'} sx={{ p: 1 }}>
 							<FormControl fullWidth>
-								<FormLabel id="drr-override-group-label">DRR Slot Set</FormLabel>
+								<FormLabel id="drr-override-group-label">
+									DRR Slot Set
+								</FormLabel>
 								<RadioGroup
 									row
 									aria-labelledby="drr-override-group-label"
 									name="drr-row-radio-buttons-group"
 									value={override}
-									onChange={(override) => setOverride(override.target.value as MerchandisingOverride)}
-								>
-									{
-										['default', 'AUS', 'Culture', 'Features', 'Global', 'Sport', 'US'].map((item) => <FormControlLabel
-											value={item} control={<Radio/>} label={valueKeyMapping[item as keyof typeof valueKeyMapping]}/>)
+									onChange={(override) =>
+										setOverride(override.target.value as MerchandisingOverride)
 									}
-
+								>
+									{[
+										'default',
+										'AUS',
+										'Culture',
+										'Features',
+										'Global',
+										'Sport',
+										'US',
+									].map((item) => (
+										<FormControlLabel
+											key={item}
+											value={item}
+											control={<Radio />}
+											label={
+												valueKeyMapping[item as keyof typeof valueKeyMapping]
+											}
+										/>
+									))}
 								</RadioGroup>
 							</FormControl>
 						</Box>
-					</Stack>)
-				}
+					</Stack>
+				)}
 				<Stack direction={'row'}>
 					{
 						<>
-							<Box flex={1} display={'flex'} sx={{p: 1}}>
-								<div dangerouslySetInnerHTML={{__html: code.value}}/>
+							<Box flex={1} display={'flex'} sx={{ p: 1 }}>
+								<div dangerouslySetInnerHTML={{ __html: code.value }} />
 							</Box>
 							{includeCopyButton && (
-								<Button
-									onClick={copyToClipBoard}
-									startIcon={<CopyAllIcon/>}
-								>
+								<Button onClick={copyToClipBoard} startIcon={<CopyAllIcon />}>
 									copy
-								</Button>)
-							}
+								</Button>
+							)}
 						</>
 					}
 				</Stack>


### PR DESCRIPTION
## What does this change?

Fixes a bug in the user access hook - the UI converts values of `undefined` in the data to `null` (since there is no `undefined` in JSON) before sending the data to the API to allow defined values to be 'cleared'. The API methods account for this and convert the `null`s back to undefined after parsing the JSON.

This wasn't happing in the hook function to check if the user had access, so the API was returning a 403 error when the user tried to set a value to undefined.

Unrelated change - adds a key to the mapped array in the `GeneratedCodeDataPoint` component to resolve a console warning on the details page.

## How to test

on main - using the 'edit newsletter' form to change a 'regional focus' from a defined value to 'undefined' will fail. (error is a 403, but should be a 400)
on this branch - the above will work (assuming user has right permissions).

## How can we measure success?

Users don't encounter the bug

## Have we considered potential risks?

Is safe - the null to undefined function is already type-safe.
