### PR TITLE
Expose embed description for editors and CP

### DIFF
--- a/libs/newsletters-data-client/src/lib/zod-helpers/user-data-schema.ts
+++ b/libs/newsletters-data-client/src/lib/zod-helpers/user-data-schema.ts
@@ -23,6 +23,7 @@ export const getUserEditSchema = (
 			signupPageCreationStatus: true,
 			signupPage: true,
 			signUpDescription: true,
+			signUpEmbedDescription: true,
 			mailSuccessDescription: true,
 			brazeCampaignCreationStatus: true,
 			brazeNewsletterName: true,
@@ -52,6 +53,7 @@ export const getUserEditSchema = (
 			signupPageCreationStatus: true,
 			signupPage: true,
 			signUpDescription: true,
+			signUpEmbedDescription: true,
 		});
 	}
 	return newsletterDataSchema.pick({});


### PR DESCRIPTION
## What does this change?

Updates the edit form to expose the embed description to allow self service updates for editors and CP

## How to test

Run locally and verify that the `signUpEmbedDescription` field is exposed in the edit form and that it can be edited. 

![Screenshot 2024-01-17 at 10 24 06](https://github.com/guardian/newsletters-nx/assets/3277259/daf0381d-9a1f-43b6-8c42-6a0e94c89560)


## How can we measure success?

The field is present in the form and editable

## Have we considered potential risks?

CP and users with editorial access (Newsletters editors at present) will be able to update the embed descriptions and these changes will be seen in embeds (after up to 2 hours because of caching). There is no hard limit on the size of the embed description in the tool. It would be possible to add something absurdly long which would make for an unhappy embed. Access is very limited but we might consider introdicing a sensible validated upper limit in future

