### PR TITLE
Highlight Restricted live newsletters in detail view

### DIFF
--- a/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
+++ b/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
@@ -1,4 +1,4 @@
-import { Badge, Box, Grid, Stack, Typography } from '@mui/material';
+import { Alert, Badge, Box, Grid, Stack, Typography} from '@mui/material';
 import { useEffect, useState } from 'react';
 import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
 import {
@@ -23,7 +23,7 @@ interface Props {
 }
 
 export const NewsletterDataDetails = ({ newsletter }: Props) => {
-	const { status, name } = newsletter;
+	const { status, name, restricted } = newsletter;
 	const permissions = usePermissions();
 	const [showEditButton, setShowEditButton] = useState(false);
 
@@ -43,7 +43,13 @@ export const NewsletterDataDetails = ({ newsletter }: Props) => {
 				columnSpacing={2}
 				justifyContent={'space-between'}
 			>
+				{status === 'live' && restricted &&
+					<Grid item paddingBottom={"16px"} flexGrow={1}>
+						<Alert severity="error">The Newsletter is set to live but with a restricted status. This will prevent the newsletter from appearing in MMA and in-article promotions for it will not be rendered </Alert>
+					</Grid>
+				}
 				<Grid item>
+
 					<Badge badgeContent={status} color="secondary">
 						<Typography variant="h2">{name}</Typography>
 					</Badge>

--- a/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
@@ -76,7 +76,7 @@ export const newsletterDataSchema = z.object({
 	identityName: kebabOrUnderscoreCasedString().describe('identity name'),
 	name: nonEmptyString().describe('Name'),
 	category: newsletterCategoriesSchema,
-	restricted: z.boolean(),
+	restricted: z.boolean().describe('Restricted'),
 	/** The status for the newsletter:
 	 *
 	 *  - **pending**: Initial state after launch - can be promoted, not yet ready to be sent out.

--- a/libs/newsletters-data-client/src/lib/zod-helpers/user-data-schema.ts
+++ b/libs/newsletters-data-client/src/lib/zod-helpers/user-data-schema.ts
@@ -14,6 +14,7 @@ export const getUserEditSchema = (
 			regionFocus: true,
 			theme: true,
 			status: true,
+			restricted: true,
 			illustrationCard: true,
 			tagCreationStatus: true,
 			seriesTag: true,
@@ -54,6 +55,7 @@ export const getUserEditSchema = (
 			signupPage: true,
 			signUpDescription: true,
 			signUpEmbedDescription: true,
+			restricted: true,
 		});
 	}
 	return newsletterDataSchema.pick({});


### PR DESCRIPTION
## What does this change?

Where a newsletter is live and restricted, show an alert in the newsletters UI to explain that this will prevent it from appearing in MMA or in article promotions appearing. Also, allow editing of this property in the form


## How to test

Run locally, set a  newsletter to restricted and live, check that the alert appears

Check the the restricted checkbox appears in the edit form

## How can we measure success?

By meeting the above conditions

## Have we considered potential risks?

Always

## Images

![Kapture 2024-02-02 at 16 41 14](https://github.com/guardian/newsletters-nx/assets/3277259/6dd5036c-1f33-4363-a055-7e512b6b7249)
