### PR TITLE
Reduce instance size from T4g small to micro

### DIFF
--- a/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
+++ b/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
@@ -2089,7 +2089,7 @@ exports[`The Newsletters stack matches the snapshot 1`] = `
           "ImageId": {
             "Ref": "AMINewslettersapi",
           },
-          "InstanceType": "t4g.small",
+          "InstanceType": "t4g.micro",
           "MetadataOptions": {
             "HttpTokens": "required",
           },
@@ -2265,7 +2265,7 @@ systemctl start newsletters-api",
           "ImageId": {
             "Ref": "AMINewsletterstool",
           },
-          "InstanceType": "t4g.small",
+          "InstanceType": "t4g.micro",
           "MetadataOptions": {
             "HttpTokens": "required",
           },

--- a/cdk/lib/newsletters-tool.ts
+++ b/cdk/lib/newsletters-tool.ts
@@ -177,7 +177,7 @@ EOL`,
 				snsTopicName: alarmsTopicName,
 				unhealthyInstancesAlarm: true,
 			},
-			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
+			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
 			// Minimum of 1 EC2 instance running at a time. If one fails, scales up to 2 before dropping back to 1 again
 			scaling: { minimumInstances: 1, maximumInstances: 2 },
 			// Instructions to set up the environment in the instance
@@ -210,7 +210,7 @@ EOL`,
 				snsTopicName: alarmsTopicName,
 				unhealthyInstancesAlarm: true,
 			},
-			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
+			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
 			scaling: { minimumInstances: 1, maximumInstances: 2 },
 			userData: this.getUserData(
 				apiAppName,


### PR DESCRIPTION
## What does this change?

Reduces the instance size of  `newsletters-api` and `newsletters-tool` from T4g small to T4g micro.

## Why?

The apps are hugely over-provisioned (max CPU usage is around 5%).
It would be worth reducing their instance sizes accordingly
