### PR TITLE
Update Launch email with Data to support Data design

### DIFF
--- a/libs/email-builder/src/lib/components/NewLaunchMessage.tsx
+++ b/libs/email-builder/src/lib/components/NewLaunchMessage.tsx
@@ -5,6 +5,7 @@ import type {
 } from '@newsletters-nx/newsletters-data-client';
 import type { MessageContent } from '../types';
 import { MessageFormat } from './MessageFormat';
+import { NewsletterPropertyTable } from './NewsletterPropertyTable';
 import { UserDescription } from './UserDescription';
 
 interface Props {
@@ -15,7 +16,7 @@ interface Props {
 
 export const NewLaunchMessage = ({ pageLink, newsletter, user }: Props) => {
 	return (
-		<MessageFormat title={<>newsletter launched: {newsletter.name}</>}>
+		<MessageFormat title={<>Newsletter launched: {newsletter.name}</>}>
 			<p>{pageLink}</p>
 
 			{user && (
@@ -24,13 +25,18 @@ export const NewLaunchMessage = ({ pageLink, newsletter, user }: Props) => {
 					<UserDescription user={user} asLink />
 				</p>
 			)}
+
+			<NewsletterPropertyTable
+				newsletter={newsletter}
+				properties={['campaignName', 'campaignCode', 'identityName']}
+			/>
 		</MessageFormat>
 	);
 };
 
 export const renderNewLaunchMessage = (props: Props): MessageContent => {
 	const { pageLink, newsletter } = props;
-	const subject = `New newsletters launched: ${newsletter.name}`;
+	const subject = `New newsletter launched: ${newsletter.name}`;
 	const text = `A new newsletter "${newsletter.name}" has been launched: ${pageLink}.`;
 
 	try {

--- a/libs/email-builder/src/lib/components/NewsletterPropertyTable.tsx
+++ b/libs/email-builder/src/lib/components/NewsletterPropertyTable.tsx
@@ -41,7 +41,7 @@ export const NewsletterPropertyTable = ({ newsletter, properties }: Props) => (
 			{properties.map((property, index) => {
 				if (typeof property === 'string') {
 					return (
-						<tr key={index}>
+						<tr style={{textAlign: "left"}} key={index}>
 							<th>{property}</th>
 							<td>{propertyToString(newsletter[property])}</td>
 						</tr>
@@ -49,7 +49,7 @@ export const NewsletterPropertyTable = ({ newsletter, properties }: Props) => (
 				}
 
 				return (
-					<tr key={index}>
+					<tr style={{textAlign: "left"}} key={index}>
 						<th>{property.displayName}</th>
 						<td>{property.generate(newsletter)}</td>
 					</tr>


### PR DESCRIPTION
## What does this change?

- Added in the campaign name and code to the email launch email.
- Updated the styling on the table to left align

Will add Data design to the recipients for the launch

This is to support the launch process and allow Data Design a heads up that they can expect to start receiving tracking information

## How to test

Generate an email locally or in CODE by launching a newsletter from the tool - ensure the generated email contains the new values and is formatted as expected.


## How can we measure success?

Emails are updated

## Have we considered potential risks?

Always. Should be fine. Very low risk change

## Images

![Screenshot 2024-03-15 at 10 44 50](https://github.com/guardian/newsletters-nx/assets/3277259/3b5aecff-0e66-4b38-a26e-d32d9738e774)
