### PR TITLE
image size comments

### DIFF
--- a/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
+++ b/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
@@ -1,6 +1,6 @@
-import { Alert, Snackbar } from '@mui/material';
+import { Alert, Link, Snackbar } from '@mui/material';
 import { useState } from 'react';
-import { useNavigate } from "react-router";
+import { useNavigate } from 'react-router';
 import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
 import { getUserEditSchema } from '@newsletters-nx/newsletters-data-client';
 import { requestNewsletterEdit } from '../api-requests/request-newsletter-edit';
@@ -46,7 +46,6 @@ export const EditNewsletterForm = ({ originalItem }: Props) => {
 			setItem(response.data);
 			setWaitingForResponse(false);
 			navigate(`/launched/${response.data.identityName}`);
-
 		} else {
 			setWaitingForResponse(false);
 			setErrorMessage(response.message);
@@ -77,6 +76,36 @@ export const EditNewsletterForm = ({ originalItem }: Props) => {
 					signUpDescription: {
 						inputType: 'textArea',
 					},
+				}}
+				explanations={{
+					illustrationCard: (
+						<Alert severity="info" sx={{ marginBottom: 1, maxWidth: 600 }}>
+							<p>
+								When used on the theguardian.com or other platforms, images are
+								optimised and resized by our image service to be displayed at
+								the most approriate file size for the usage.
+							</p>
+							<p>
+								However, if the orginal image is too large for the image service
+								to process, it will fail and the original version will be used
+								on the page. This can harm the pages performance, especially for
+								users on mobile devices.
+							</p>
+							<p>
+								Please make sure that the image you are uploading does not
+								exceed the limits described in{' '}
+								<Link
+									href={
+										'https://www.fastly.com/documentation/reference/io/#limitations-and-constraints'
+									}
+									target="_blank"
+								>
+									this documentation from our image service
+								</Link>
+								.
+							</p>
+						</Alert>
+					),
 				}}
 			/>
 

--- a/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
+++ b/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
@@ -1,4 +1,4 @@
-import { Alert, Link, Snackbar } from '@mui/material';
+import { Alert, Link, Snackbar, Typography } from '@mui/material';
 import { useState } from 'react';
 import { useNavigate } from 'react-router';
 import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
@@ -80,18 +80,18 @@ export const EditNewsletterForm = ({ originalItem }: Props) => {
 				explanations={{
 					illustrationCard: (
 						<Alert severity="info" sx={{ marginBottom: 1, maxWidth: 600 }}>
-							<p>
+							<Typography>
 								When used on the theguardian.com or other platforms, images are
 								optimised and resized by our image service to be displayed at
 								the most approriate file size for the usage.
-							</p>
-							<p>
+							</Typography>
+							<Typography>
 								However, if the orginal image is too large for the image service
 								to process, it will fail and the original version will be used
 								on the page. This can harm the pages performance, especially for
 								users on mobile devices.
-							</p>
-							<p>
+							</Typography>
+							<Typography>
 								Please make sure that the image you are uploading does not
 								exceed the limits described in{' '}
 								<Link
@@ -103,7 +103,7 @@ export const EditNewsletterForm = ({ originalItem }: Props) => {
 									this documentation from our image service
 								</Link>
 								.
-							</p>
+							</Typography>
 						</Alert>
 					),
 				}}

--- a/apps/newsletters-ui/src/app/components/SchemaForm/FieldWrapper.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/FieldWrapper.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 
 interface Props {
 	children: ReactNode;
+	explanation?: ReactNode;
 }
 
 export const defaultBoxProps: BoxProps = {
@@ -13,6 +14,9 @@ export const defaultBoxProps: BoxProps = {
 	maxWidth: 'sm',
 };
 
-export const FieldWrapper = ({ children }: Props) => (
-	<Box {...defaultBoxProps}>{children}</Box>
+export const FieldWrapper = ({ children, explanation }: Props) => (
+	<>
+		<Box {...defaultBoxProps}>{children}</Box>
+		{explanation}
+	</>
 );

--- a/apps/newsletters-ui/src/app/components/SchemaForm/SchemaField.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/SchemaField.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import {
 	z,
 	ZodArray,
@@ -46,6 +47,7 @@ interface SchemaFieldProps<T extends z.ZodRawShape> {
 	stringInputSettings?: StringInputSettings;
 	validationWarning?: string;
 	maxOptionsForRadioButtons: number;
+	explanation?: ReactNode;
 }
 
 const WrongValueTypeMessage = (props: { field: FieldDef }) => (
@@ -87,6 +89,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 	stringInputSettings = {},
 	validationWarning,
 	maxOptionsForRadioButtons,
+	explanation = null,
 }: SchemaFieldProps<T>) {
 	const { key, value, zod, readOnly } = field;
 
@@ -118,7 +121,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 		}
 
 		return (
-			<FieldWrapper>
+			<FieldWrapper explanation={explanation}>
 				<DateInput
 					{...standardProps}
 					value={parsed.value}
@@ -136,7 +139,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 		if (options) {
 			if (options.length <= maxOptionsForRadioButtons) {
 				return (
-					<FieldWrapper>
+					<FieldWrapper explanation={explanation}>
 						<RadioSelectInput
 							{...standardProps}
 							value={value}
@@ -146,14 +149,14 @@ export function SchemaField<T extends z.ZodRawShape>({
 				);
 			}
 			return (
-				<FieldWrapper>
+				<FieldWrapper explanation={explanation}>
 					<SelectInput {...standardProps} value={value} options={options} />
 				</FieldWrapper>
 			);
 		}
 
 		return (
-			<FieldWrapper>
+			<FieldWrapper explanation={explanation}>
 				<StringInput
 					{...standardProps}
 					value={value ?? ''}
@@ -168,7 +171,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 			return <WrongValueTypeMessage field={field} />;
 		}
 		return (
-			<FieldWrapper>
+			<FieldWrapper explanation={explanation}>
 				<BooleanInput {...standardProps} value={value ?? false} />
 			</FieldWrapper>
 		);
@@ -181,7 +184,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 
 		if (zod.isOptional()) {
 			return (
-				<FieldWrapper>
+				<FieldWrapper explanation={explanation}>
 					<OptionalNumberInput
 						{...standardProps}
 						{...numberInputSettings}
@@ -192,7 +195,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 		}
 
 		return (
-			<FieldWrapper>
+			<FieldWrapper explanation={explanation}>
 				<NumberInput
 					{...standardProps}
 					{...numberInputSettings}
@@ -213,7 +216,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 
 		if (options && options.length <= maxOptionsForRadioButtons) {
 			return (
-				<FieldWrapper>
+				<FieldWrapper explanation={explanation}>
 					<RadioSelectInput
 						{...standardProps}
 						value={value}
@@ -224,7 +227,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 		}
 
 		return (
-			<FieldWrapper>
+			<FieldWrapper explanation={explanation}>
 				<SelectInput {...standardProps} value={value} options={options ?? []} />
 			</FieldWrapper>
 		);
@@ -235,7 +238,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 			return <WrongValueTypeMessage field={field} />;
 		}
 		return (
-			<FieldWrapper>
+			<FieldWrapper explanation={explanation}>
 				<SchemaRecordInput
 					{...standardProps}
 					recordSchema={innerZod}
@@ -251,7 +254,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 				return <WrongValueTypeMessage field={field} />;
 			}
 			return (
-				<FieldWrapper>
+				<FieldWrapper explanation={explanation}>
 					<SchemaArrayInput {...standardProps} value={value ?? []} />
 				</FieldWrapper>
 			);
@@ -262,7 +265,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 				return <WrongValueTypeMessage field={field} />;
 			}
 			return (
-				<FieldWrapper>
+				<FieldWrapper explanation={explanation}>
 					<SchemaRecordArrayInput
 						{...standardProps}
 						value={value ?? []}

--- a/apps/newsletters-ui/src/app/components/SchemaForm/index.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/index.tsx
@@ -1,6 +1,5 @@
-import type { z, ZodRawShape, ZodTypeAny } from 'zod';
-import { ZodArray, ZodObject, ZodString } from 'zod';
-import { recursiveUnwrap } from '@newsletters-nx/newsletters-data-client';
+import type { ReactNode } from 'react';
+import type { z, ZodTypeAny } from 'zod';
 // eslint-disable-next-line import/no-cycle -- schemaForm renders recursively for SchemaRecordArrayInput
 import { SchemaField } from './SchemaField';
 import type {
@@ -24,6 +23,7 @@ interface Props<T extends z.ZodRawShape> {
 	readOnlyKeys?: string[];
 	validationWarnings: Partial<Record<keyof T, string>>;
 	maxOptionsForRadioButtons?: number;
+	explanations?: Partial<Record<keyof T, ReactNode>>;
 }
 
 /**
@@ -42,6 +42,7 @@ export function SchemaForm<T extends z.ZodRawShape>({
 	readOnlyKeys = [],
 	validationWarnings,
 	maxOptionsForRadioButtons = 0,
+	explanations = {},
 }: Props<T>) {
 	const fields: FieldDef[] = [];
 	for (const key in schema.shape) {
@@ -75,6 +76,7 @@ export function SchemaForm<T extends z.ZodRawShape>({
 					showUnsupported={showUnsupported}
 					validationWarning={validationWarnings[field.key]}
 					maxOptionsForRadioButtons={maxOptionsForRadioButtons}
+					explanation={explanations[field.key]}
 				/>
 			))}
 		</article>

--- a/apps/newsletters-ui/src/app/components/SimpleForm.tsx
+++ b/apps/newsletters-ui/src/app/components/SimpleForm.tsx
@@ -23,6 +23,7 @@ interface Props<T extends z.ZodRawShape> {
 	message?: ReactNode;
 	maxOptionsForRadioButtons?: number;
 	stringConfig?: Partial<Record<keyof T, StringInputSettings>>;
+	explanations?: Partial<Record<keyof T, ReactNode>>;
 }
 
 /**
@@ -43,6 +44,7 @@ export function SimpleForm<T extends z.ZodRawShape>({
 	message,
 	maxOptionsForRadioButtons,
 	stringConfig = {},
+	explanations = {},
 }: Props<T>) {
 	const [parseInitialDataResult, setParseInitialDataResult] = useState<
 		z.SafeParseReturnType<typeof schema, SchemaObjectType<T>> | undefined
@@ -143,6 +145,7 @@ export function SimpleForm<T extends z.ZodRawShape>({
 				readOnlyKeys={isDisabled ? Object.keys(schema.shape) : undefined}
 				maxOptionsForRadioButtons={maxOptionsForRadioButtons}
 				stringConfig={stringConfig}
+				explanations={explanations}
 			/>
 			<Box marginBottom={2}>
 				<Button

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/promotionContentLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/promotionContentLayout.ts
@@ -18,11 +18,13 @@ Please enter the headline, description and sign-up success message for the sign 
 
 ![Headline and Description](https://i.guim.co.uk/img/uploads/2023/10/06/signUpImageWithBoarderTwo.png?quality=85&dpr=2&width=300&s=002979e840129ac072654cb66367d971)
 
-### Specify the sign up embed description, Sign up success message, and illustration for the newsletters page
+### Specify the sign up embed description and Sign up success message
 
 Please enter the description for the sign up embeds - this text is used on the in-article embeds and on the [newsletters page](https://www.theguardian.com/email-newsletters):
 
 ![Sign Up Embed Description](https://i.guim.co.uk/img/uploads/2023/04/20/signUp-embed.png?quality=85&dpr=2&width=300&s=48b7b65b3dcbff5fcd4b78c562a4175e)
+
+### Illustration for the newsletters page
 
 To provide an image to use on the all newsletters page, upload the image (in the appropriate aspect ratio 5:3) via the [s3 Uploader service](https://s3-uploader.gutools.co.uk/).
 Once uploaded, copy the **vanity url** and paste it into the field below. Please note:

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/promotionContentLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/promotionContentLayout.ts
@@ -25,8 +25,13 @@ Please enter the description for the sign up embeds - this text is used on the i
 ![Sign Up Embed Description](https://i.guim.co.uk/img/uploads/2023/04/20/signUp-embed.png?quality=85&dpr=2&width=300&s=48b7b65b3dcbff5fcd4b78c562a4175e)
 
 To provide an image to use on the all newsletters page, upload the image (in the appropriate aspect ratio 5:3) via the [s3 Uploader service](https://s3-uploader.gutools.co.uk/).
-Once uploaded, copy the **vanity url** and paste it into the field below.
+Once uploaded, copy the **vanity url** and paste it into the field below. Please note:
 
+ - When used on the theguardian.com or other platforms, images are optimised and resized by our image service to be displayed at the most approriate file size for the usage.
+
+ - If the orginal image is too large for the image service to process, it will fail and the original version will be used on the page. This can harm the pages performance, especially for users on mobile devices.
+
+**Please make sure** that the image you are uploading does not exceed the limits described in [this documentation from our image service](https://www.fastly.com/documentation/reference/io/#limitations-and-constraints).
 
 `.trim();
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

 - adds a new `explanations` prop to the `SimpleForm` allowing explanatory content to be added after specific fields in the form
 - inserts an explanation into the `NewsletterEditForm` about the size restrictions for image processing (https://www.fastly.com/documentation/reference/io/#limitations-and-constraints)by fastly below the `IllustrationCard` field
 - incorporates the same messaging into the wizard layout that included the  `IllustrationCard` field

## How to test

Visual change only - run locally and edit a new letter, then run through the new draft wizard to see the changes.

## How can we measure success?

Users better informed about image size restrictions - hopefully no further cases of images too big for fastly to process being used

## Have we considered potential risks?

Users might get confused.

## Images
### wizard
<img width="400" alt="Screenshot 2024-04-12 at 08 25 14" src="https://github.com/guardian/newsletters-nx/assets/30567854/c28fb8b8-e2db-4567-a8f7-2dca378c1c1d">

### form
<img width="400" alt="Screenshot 2024-04-12 at 08 27 32" src="https://github.com/guardian/newsletters-nx/assets/30567854/73f662fe-d56c-491f-aa32-7d0c2672ebc3">


