### PR TITLE
Remove double underscores / hyphens from generated ids

### DIFF
--- a/libs/newsletters-data-client/src/index.ts
+++ b/libs/newsletters-data-client/src/index.ts
@@ -1,5 +1,5 @@
 export * from './lib/api-response-type';
-export * from './lib/deriveNewsletterFields';
+export * from './lib/derive-newsletter-fields';
 export * from './lib/draft-service';
 export * from './lib/draft-storage';
 export * from './lib/draft-to-newsletter';

--- a/libs/newsletters-data-client/src/lib/derive-newsletter-fields.spec.ts
+++ b/libs/newsletters-data-client/src/lib/derive-newsletter-fields.spec.ts
@@ -2,7 +2,7 @@ import { deriveNewsletterFieldsFromName } from './derive-newsletter-fields';
 
 describe('deriveNewsletterFieldsFromName', () => {
 	it('should derive the newsletter fields', () => {
-		expect(deriveNewsletterFieldsFromName("foo bar")).toEqual({
+		const expectedOutput = {
 			identityName: "foo-bar",
 			brazeSubscribeEventNamePrefix: "foo_bar",
 			brazeNewsletterName: "Editorial_foobar",
@@ -10,26 +10,9 @@ describe('deriveNewsletterFieldsFromName', () => {
 			brazeSubscribeAttributeNameAlternate: ["email_subscribe_foo_bar"],
 			campaignName: "foobar",
 			campaignCode: "foobar_email",
-		});
-
-		expect(deriveNewsletterFieldsFromName("foo - bar")).toEqual({
-			identityName: "foo-bar",
-			brazeSubscribeEventNamePrefix: "foo_bar",
-			brazeNewsletterName: "Editorial_foobar",
-			brazeSubscribeAttributeName: "foobar_Subscribe_Email",
-			brazeSubscribeAttributeNameAlternate: ["email_subscribe_foo_bar"],
-			campaignName: "foobar",
-			campaignCode: "foobar_email",
-		});
-	});
-
-	expect(deriveNewsletterFieldsFromName("foo - ::: ----- bar ---------")).toEqual({
-		identityName: "foo-bar",
-		brazeSubscribeEventNamePrefix: "foo_bar",
-		brazeNewsletterName: "Editorial_foobar",
-		brazeSubscribeAttributeName: "foobar_Subscribe_Email",
-		brazeSubscribeAttributeNameAlternate: ["email_subscribe_foo_bar"],
-		campaignName: "foobar",
-		campaignCode: "foobar_email",
+		};
+		expect(deriveNewsletterFieldsFromName("foo bar")).toEqual(expectedOutput);
+		expect(deriveNewsletterFieldsFromName("foo - bar")).toEqual(expectedOutput);
+		expect(deriveNewsletterFieldsFromName("foo - ::: ----- bar ---------")).toEqual(expectedOutput);
 	});
 });

--- a/libs/newsletters-data-client/src/lib/derive-newsletter-fields.spec.ts
+++ b/libs/newsletters-data-client/src/lib/derive-newsletter-fields.spec.ts
@@ -1,0 +1,35 @@
+import { deriveNewsletterFieldsFromName } from './derive-newsletter-fields';
+
+describe('deriveNewsletterFieldsFromName', () => {
+	it('should derive the newsletter fields', () => {
+		expect(deriveNewsletterFieldsFromName("foo bar")).toEqual({
+			identityName: "foo-bar",
+			brazeSubscribeEventNamePrefix: "foo_bar",
+			brazeNewsletterName: "Editorial_foobar",
+			brazeSubscribeAttributeName: "foobar_Subscribe_Email",
+			brazeSubscribeAttributeNameAlternate: ["email_subscribe_foo_bar"],
+			campaignName: "foobar",
+			campaignCode: "foobar_email",
+		});
+
+		expect(deriveNewsletterFieldsFromName("foo - bar")).toEqual({
+			identityName: "foo-bar",
+			brazeSubscribeEventNamePrefix: "foo_bar",
+			brazeNewsletterName: "Editorial_foobar",
+			brazeSubscribeAttributeName: "foobar_Subscribe_Email",
+			brazeSubscribeAttributeNameAlternate: ["email_subscribe_foo_bar"],
+			campaignName: "foobar",
+			campaignCode: "foobar_email",
+		});
+	});
+
+	expect(deriveNewsletterFieldsFromName("foo - ::: ----- bar ---------")).toEqual({
+		identityName: "foo-bar",
+		brazeSubscribeEventNamePrefix: "foo_bar",
+		brazeNewsletterName: "Editorial_foobar",
+		brazeSubscribeAttributeName: "foobar_Subscribe_Email",
+		brazeSubscribeAttributeNameAlternate: ["email_subscribe_foo_bar"],
+		campaignName: "foobar",
+		campaignCode: "foobar_email",
+	});
+});

--- a/libs/newsletters-data-client/src/lib/derive-newsletter-fields.ts
+++ b/libs/newsletters-data-client/src/lib/derive-newsletter-fields.ts
@@ -11,23 +11,28 @@ export type NewsletterFieldsDerivedFromName =
 
 const allWhiteSpaceRegEx = new RegExp(/\W/, 'g');
 const replaceWhiteSpace = (input: string, replaceValue = '') =>
-	input.replace(allWhiteSpaceRegEx, replaceValue);
+	input.replace(allWhiteSpaceRegEx, replaceValue)
+		.replace(/_+/g, '_')
+		.replace(/-+/g, '-');
 
+const removeNonAlphaNumericCharacters = (input: string) =>
+	input.replace(/[^a-zA-Z0-9\s]/g, '');
 export const deriveNewsletterFieldsFromName = (
 	name: string,
 ): Pick<NewsletterData, NewsletterFieldsDerivedFromName> => {
-	const lowerCased = name.toLowerCase();
+	const sanitizedName = removeNonAlphaNumericCharacters(name)
+	const lowerCased = sanitizedName.toLowerCase();
 	const trimmedLowerCase = lowerCased.trim();
 
 	return {
 		identityName: replaceWhiteSpace(trimmedLowerCase, '-'),
 		brazeSubscribeEventNamePrefix: replaceWhiteSpace(trimmedLowerCase, '_'),
-		brazeNewsletterName: 'Editorial_' + replaceWhiteSpace(name.trim()),
-		brazeSubscribeAttributeName: replaceWhiteSpace(name) + '_Subscribe_Email',
+		brazeNewsletterName: 'Editorial_' + replaceWhiteSpace(sanitizedName.trim()),
+		brazeSubscribeAttributeName: replaceWhiteSpace(sanitizedName) + '_Subscribe_Email',
 		brazeSubscribeAttributeNameAlternate: [
 			'email_subscribe_' + replaceWhiteSpace(trimmedLowerCase, '_'),
 		],
-		campaignName: replaceWhiteSpace(name),
+		campaignName: replaceWhiteSpace(sanitizedName),
 		campaignCode: replaceWhiteSpace(trimmedLowerCase) + '_email',
 	};
 };
@@ -38,7 +43,7 @@ export const deriveNewsletterFieldsFromName = (
  * if `${original}${delimiter}i` is already an existingToken.
  *
  * This is not ideal - it ensures the suggested derived name is
- * unqiue, but the user should have the option to replace it with a
+ * unique, but the user should have the option to replace it with a
  * more readable name.
  */
 export const addSuffixToMakeTokenUnique = (

--- a/libs/newsletters-data-client/src/lib/derive-newsletter-fields.ts
+++ b/libs/newsletters-data-client/src/lib/derive-newsletter-fields.ts
@@ -12,8 +12,7 @@ export type NewsletterFieldsDerivedFromName =
 const allWhiteSpaceRegEx = new RegExp(/\W/, 'g');
 const replaceWhiteSpace = (input: string, replaceValue = '') =>
 	input.replace(allWhiteSpaceRegEx, replaceValue)
-		.replace(/_+/g, '_')
-		.replace(/-+/g, '-');
+		.replace(/[\s_-]+/g, replaceValue)
 
 const removeNonAlphaNumericCharacters = (input: string) =>
 	input.replace(/[^a-zA-Z0-9\s]/g, '');

--- a/libs/newsletters-data-client/src/lib/draft-to-newsletter.ts
+++ b/libs/newsletters-data-client/src/lib/draft-to-newsletter.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import type { NewsletterFieldsDerivedFromName } from './deriveNewsletterFields';
-import { deriveNewsletterFieldsFromName } from './deriveNewsletterFields';
+import type { NewsletterFieldsDerivedFromName } from './derive-newsletter-fields';
+import { deriveNewsletterFieldsFromName } from './derive-newsletter-fields';
 import {
 	dataCollectionRenderingOptionsSchema,
 	dataCollectionSchema,

--- a/libs/newsletters-data-client/src/lib/zod-helpers/schema-helpers.ts
+++ b/libs/newsletters-data-client/src/lib/zod-helpers/schema-helpers.ts
@@ -16,7 +16,7 @@ export const kebabOrUnderscoreCasedString = () =>
 		.string()
 		.regex(
 			/^[a-z0-9]+(?:[-_][a-z0-9]+)*$/,
-			'Must containt numbers or lower-case letters only, separated by dashes or underscores',
+			'Must contain numbers or lower-case letters only, separated by dashes or underscores',
 		);
 
 export const urlPathString = (customValidationMessage?: string) =>


### PR DESCRIPTION
## What does this change?

Titles may contain non-alpha-numeric characters however, the ids what we derive from these may not. When hyphens, colons etc are used in a title, the auto-generated ids fail validation, and it is not possible to launch the newsletter.

This PR updates the `deriveNewsletterFieldsFromName` function to strip out non-alpha-numeric characters and also, removes double underscores or hyphens (which also break validation rules for identifiers)

The result is that the title is not constrained by the id validation rules. 

## How to test

On main, try creating a newsletter with a title containing non-numeric characters. EG:

`foo ::: bar ------ Baz`
`The Stakes - US Election Edition`

The above will fail at the point you attempt to launch. Now try again on this branch

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

The newsletter can be launched

## Have we considered potential risks?

Up will now, it was only possible to use a-Z, 0-9 in titles - this enables use to use anything else. That anything else will be returned from the API. The API response is used in:

- Embeds
- Manage My Account
- All Newsletters Page

Is this OK?
