### PR TITLE
Add includeBreakingNews property

### DIFF
--- a/libs/newsletters-data-client/src/lib/draft-to-newsletter.ts
+++ b/libs/newsletters-data-client/src/lib/draft-to-newsletter.ts
@@ -26,6 +26,7 @@ export const defaultRenderingOptionsValues: RenderingOptions = {
 	displayDate: false,
 	displayImageCaptions: false,
 	displayStandfirst: false,
+	includeBreakingNews: false,
 } as const;
 
 export const withDefaultNewsletterValuesAndDerivedFields = (

--- a/libs/newsletters-data-client/src/lib/schemas/rendering-options-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/schemas/rendering-options-data-type.ts
@@ -28,6 +28,7 @@ export const renderingOptionsSchema = z.object({
 	displayStandfirst: z.boolean().describe('Display standfirst?'),
 	contactEmail: z.string().email().optional().describe('Contact email'),
 	displayImageCaptions: z.boolean().describe('Display image captions?'),
+	includeBreakingNews: z.boolean().optional().describe('Include breaking news sections?'),
 	darkHeadlineBackground: z
 		.boolean()
 		.optional()


### PR DESCRIPTION
## What does this change?

Adds a  `includeBreakingNews` property to rendering options as an option which will be used to determine whether we include breaking news tagged containers im newsletter content in the email rendering project. 

To discuss - Is it possible to include multple fronts? and if so, do we need to specify on a per-front basis, rather than per newsletter

## How to test

Check out the branch and verify that there is now an `includeBreakingNews`, it is defaulted to false and that it is returned by the API (not legacy - not required)

## How can we measure success?

The above conditions are met

## Have we considered potential risks?

Low risk change. Optional property not used by anything at present. 

## Images

| Form | API |
|--------|--------|
| ![Screenshot 2024-05-06 at 15 11 07](https://github.com/guardian/newsletters-nx/assets/3277259/169bb19c-4fa8-4df2-af5c-961031141b00) | ![Screenshot 2024-05-06 at 15 20 34](https://github.com/guardian/newsletters-nx/assets/3277259/e474d40d-13ae-405b-9a36-ed219fe24283)| 

