### PR TITLE
More campaign tag related info in UI

### DIFF
--- a/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
+++ b/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
@@ -2,7 +2,10 @@ import { Alert, Link, Snackbar, Typography } from '@mui/material';
 import { useState } from 'react';
 import { useNavigate } from 'react-router';
 import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
-import { getUserEditSchema } from '@newsletters-nx/newsletters-data-client';
+import {
+	composerCampaignTagId,
+	getUserEditSchema,
+} from '@newsletters-nx/newsletters-data-client';
 import { requestNewsletterEdit } from '../api-requests/request-newsletter-edit';
 import { usePermissions } from '../hooks/user-hooks';
 import { SimpleForm } from './SimpleForm';
@@ -80,12 +83,12 @@ export const EditNewsletterForm = ({ originalItem }: Props) => {
 				explanations={{
 					illustrationCard: (
 						<Alert severity="info" sx={{ marginBottom: 1, maxWidth: 600 }}>
-							<Typography>
+							<Typography marginBottom={1}>
 								When used on the theguardian.com or other platforms, images are
 								optimised and resized by our image service to be displayed at
 								the most approriate file size for the usage.
 							</Typography>
-							<Typography>
+							<Typography marginBottom={1}>
 								However, if the orginal image is too large for the image service
 								to process, it will fail and the original version will be used
 								on the page. This can harm the pages performance, especially for
@@ -103,6 +106,35 @@ export const EditNewsletterForm = ({ originalItem }: Props) => {
 									this documentation from our image service
 								</Link>
 								.
+							</Typography>
+						</Alert>
+					),
+					composerTag: (
+						<Alert severity="info" sx={{ marginBottom: 1, maxWidth: 600 }}>
+							<Typography marginBottom={1}>
+								"Composer tags" are the tags that, when added in Composer,
+								should propose that the user also includes the Composer campaign
+								tag
+							</Typography>
+							<Typography>
+								For example, the <b>Games (video games only)</b> tag recommends
+								the user adds the <b>Pushing Buttons (newsletter signup)</b>{' '}
+								campaign tag, which displays the sign up form for Pushing
+								Buttons.
+							</Typography>
+						</Alert>
+					),
+					composerCampaignTag: (
+						<Alert severity="info" sx={{ marginBottom: 1, maxWidth: 600 }}>
+							<Typography marginBottom={1}>
+								The "Composer campaign tag" is the tag that will cause the sign
+								up form for this newsletter to be inserted into articles and
+								sign-up pages.
+							</Typography>
+							<Typography>
+								Note that the path/id for the "Composer campaign tag" must be in
+								a set format in order to work. In this case, it would be{' '}
+								<b>{composerCampaignTagId.generate(originalItem)}</b>.
 							</Typography>
 						</Alert>
 					),

--- a/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
+++ b/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
@@ -1,17 +1,18 @@
-import { Alert, Badge, Box, Grid, Stack, Typography} from '@mui/material';
+import { Alert, Badge, Box, Grid, Stack, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
 import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
 import {
 	brazeSubscribeEventName,
 	brazeTemplateCode,
 	brazeUnsubscribeEventName,
+	composerCampaignTagId,
 	embedIframeCode,
 	getPropertyDescription,
 } from '@newsletters-nx/newsletters-data-client';
 import { usePermissions } from '../hooks/user-hooks';
 import { shouldShowEditOptions } from '../services/authorisation';
 import { DetailAccordian } from './DetailAccordian';
-import { GeneratedCodeDataPoint } from "./GeneratedCodeDataPoint";
+import { GeneratedCodeDataPoint } from './GeneratedCodeDataPoint';
 import { GeneratedDataPoint } from './GeneratedDataPoint';
 import { higherLevelDataPoint } from './higher-level-data-point';
 import { Illustration } from './Illustration';
@@ -43,13 +44,16 @@ export const NewsletterDataDetails = ({ newsletter }: Props) => {
 				columnSpacing={2}
 				justifyContent={'space-between'}
 			>
-				{status === 'live' && restricted &&
-					<Grid item paddingBottom={"16px"} flexGrow={1}>
-						<Alert severity="error">The Newsletter is set to live but with a restricted status. This will prevent the newsletter from appearing in MMA and in-article promotions for it will not be rendered </Alert>
+				{status === 'live' && restricted && (
+					<Grid item paddingBottom={'16px'} flexGrow={1}>
+						<Alert severity="error">
+							The Newsletter is set to live but with a restricted status. This
+							will prevent the newsletter from appearing in MMA and in-article
+							promotions for it will not be rendered{' '}
+						</Alert>
 					</Grid>
-				}
+				)}
 				<Grid item>
-
 					<Badge badgeContent={status} color="secondary">
 						<Typography variant="h2">{name}</Typography>
 					</Badge>
@@ -107,8 +111,15 @@ export const NewsletterDataDetails = ({ newsletter }: Props) => {
 
 			<DetailAccordian title="Tags">
 				<DataPoint property="seriesTag" />
-				<DataPoint property="composerTag" />
+				<GeneratedDataPoint
+					newsletter={newsletter}
+					valueGenerator={composerCampaignTagId}
+				/>
 				<DataPoint property="composerCampaignTag" />
+				<DataPoint
+					property="composerTag"
+					tooltip="The list of tags that, when added in Composer, should trigger the suggestion to include the Composer campaign tag"
+				/>
 			</DetailAccordian>
 
 			<DetailAccordian title="Links" defaultExpanded>

--- a/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
+++ b/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
@@ -118,7 +118,7 @@ export const NewsletterDataDetails = ({ newsletter }: Props) => {
 				<DataPoint property="composerCampaignTag" />
 				<DataPoint
 					property="composerTag"
-					tooltip="The list of tags that, when added in Composer, should trigger the suggestion to include the Composer campaign tag"
+					tooltip="The list of tags that, when added in Composer, should propose that the user also includes the Composer campaign tag"
 				/>
 			</DetailAccordian>
 

--- a/libs/newsletters-data-client/src/lib/newsletter-value-generators.ts
+++ b/libs/newsletters-data-client/src/lib/newsletter-value-generators.ts
@@ -1,9 +1,8 @@
 import type { NewsletterData } from '..';
-import {generateBrazeTemplateString} from "./generate-braze-template";
-
+import { generateBrazeTemplateString } from './generate-braze-template';
 
 export type NewsletterValueGenerator = {
-	generate: { (newsletter: NewsletterData, 	override?: string): string };
+	generate: { (newsletter: NewsletterData, override?: string): string };
 	displayName: string;
 	description: string;
 };
@@ -17,10 +16,10 @@ export const embedIframeCode: NewsletterValueGenerator = {
 };
 
 export const brazeTemplateCode: NewsletterValueGenerator = {
-	generate: (newsletter: NewsletterData, 	override?: string) => generateBrazeTemplateString(newsletter, override),
+	generate: (newsletter: NewsletterData, override?: string) =>
+		generateBrazeTemplateString(newsletter, override),
 	displayName: 'Braze campaign template code',
-	description:
-		'The template code to use in the Braze campaign.',
+	description: 'The template code to use in the Braze campaign.',
 };
 
 // see https://github.com/guardian/identity/blob/main/identity-api/src/main/scala/com/gu/identity/api/mail/CmtModels.scala
@@ -77,7 +76,7 @@ export const emailContent: NewsletterValueGenerator = {
 // see https://github.com/guardian/frontend/blob/d67c1c03875bfb972de000305a922dade6c8285d/common/app/services/NewsletterService.scala#L31
 export const composerCampaignTagId: NewsletterValueGenerator = {
 	generate: ({ identityName }) => `campaign/email/${identityName}`,
-	displayName: 'Campaign Tag Id',
+	displayName: 'Composer Campaign Tag Id(path)',
 	description:
-		'The id to use when creating the Composer Campaign Tag (must be in this format to add the signup form to an article)',
+		'The id (AKA "path") to use when creating the Composer Campaign Tag. The Composer Campaign Tag path MUST be this to cause signup forms to appear in articles and sign-up pages.',
 };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

On the newsletter details page, adds:
- a "generated data point" for the composer campaign tag id
- a tool tip explaining what the 'composer tag(s)' are

On the edit newsletter page, adds some long-form comments:
 -  explaining what the 'composer tag(s)' are
 -  that the composer campaign tag  needs to have an id in the right format to work

There was an update to the display name to the "generated data point" for the composerCampaignTagId - this would also be used in the emails to CP.

## How to test

Just a visual change.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<img width="764" alt="Screenshot 2024-05-24 at 12 29 10" src="https://github.com/guardian/newsletters-nx/assets/30567854/c8129959-7d7f-4c53-b95b-80c5dd37612a">

<img width="764" alt="Screenshot 2024-05-24 at 12 27 59" src="https://github.com/guardian/newsletters-nx/assets/30567854/5494a66d-0302-4cc2-b01e-c35c18ed86c4">

