### PR TITLE
Remove football daily (the-fiver) from the list of email-rendering-managed newsletters

### DIFF
--- a/apps/newsletters-ui/src/app/components/RenderingOptionsForm.tsx
+++ b/apps/newsletters-ui/src/app/components/RenderingOptionsForm.tsx
@@ -57,7 +57,6 @@ export const RenderingOptionsForm = ({ originalItem }: Props) => {
 		'pushing-buttons',
 		'morning-briefing',
 		'green-light',
-		'the-fiver',
 		'afternoon-update',
 	];
 	const { identityName } = originalItem;


### PR DESCRIPTION
## What does this change?

Removed Football Daily newsletter (the-fiver) from the list of email rendering managed newsletters. The effect of this is to stop the banner appearing at the top of the email rendering config page saying this i smanaged in email rendering.

## How to test

deploy to code and check that the banner is not there

## How can we measure success?


## Have we considered potential risks?

Do not merge prior to https://github.com/guardian/email-rendering/pull/399 - risk is low even if we did though. This causes a banner to appear. Nothing else.

## Images

| Before | after |
|--------|--------|
| <img width="1486" alt="Screenshot 2024-06-11 at 08 34 29" src="https://github.com/guardian/newsletters-nx/assets/3277259/afc10b4f-fca0-4c12-b706-b3fc569c9f41"> |![Screenshot 2024-06-11 at 10 22 42](https://github.com/guardian/newsletters-nx/assets/3277259/c00e8da0-0401-4bc8-9c1b-f525d7bfc914) |
