### PR TITLE
Remove Moving the goalposts from list of email rendering managed Newsletters

### DIFF
--- a/apps/newsletters-ui/src/app/components/RenderingOptionsForm.tsx
+++ b/apps/newsletters-ui/src/app/components/RenderingOptionsForm.tsx
@@ -53,7 +53,6 @@ export const RenderingOptionsForm = ({ originalItem }: Props) => {
 		'five-great-reads',
 		'morning-mail',
 		'soccer-with-jonathan-wilson',
-		'moving-the-goalposts',
 		'pushing-buttons',
 		'morning-briefing',
 		'green-light',


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Afer [this merge](https://github.com/guardian/email-rendering/pull/403) in email rendering, rendering options for moving the goalposts are now managed in the tool. This PR removed the banner which says they are not. 


## How to test

Thia is duplicate of [this PR](https://github.com/guardian/newsletters-nx/pull/321) but for moving the goalposts. A visual check will be sufficient


## How can we measure success?

Incredibly carefully

## Have we considered potential risks?

Very low risk

