### PR TITLE
Remove unsupported Reader Revenue Content bloacks & patch vulnerabilities

### DIFF
--- a/apps/newsletters-ui/src/app/components/GeneratedCodeDataPoint.tsx
+++ b/apps/newsletters-ui/src/app/components/GeneratedCodeDataPoint.tsx
@@ -36,14 +36,7 @@ interface Props {
 	language: string;
 }
 
-export type MerchandisingOverride =
-	| 'default'
-	| 'AUS'
-	| 'Culture'
-	| 'Features'
-	| 'Global'
-	| 'Sport'
-	| 'US';
+export type MerchandisingOverride = 'default' | 'AUS' | 'Global' | 'US';
 
 export const GeneratedCodeDataPoint = ({
 	newsletter,
@@ -56,15 +49,21 @@ export const GeneratedCodeDataPoint = ({
 		'default' as MerchandisingOverride,
 	);
 
-	const codeOverride = override === 'default' ? undefined : override;
+	const overrideMapping: Record<string, string> = {
+		Global: 'Newsletters',
+	};
+
+	const getOverride = (override: string): string =>
+		overrideMapping[override] ?? override;
+
+	const codeOverride =
+		getOverride(override) === 'default' ? undefined : getOverride(override);
+
 	const generatedValue = valueGenerator.generate(newsletter, codeOverride);
 
 	const valueKeyMapping = {
 		AUS: 'Australia',
-		Culture: 'Culture',
-		Features: 'Features',
 		Global: 'Global',
-		Sport: 'Sport',
 		US: 'US',
 		default: 'Default',
 	};
@@ -98,15 +97,7 @@ export const GeneratedCodeDataPoint = ({
 										setOverride(override.target.value as MerchandisingOverride)
 									}
 								>
-									{[
-										'default',
-										'AUS',
-										'Culture',
-										'Features',
-										'Global',
-										'Sport',
-										'US',
-									].map((item) => (
+									{['default', 'AUS', 'US', 'Global'].map((item) => (
 										<FormControlLabel
 											key={item}
 											value={item}

--- a/libs/newsletters-data-client/src/lib/generate-braze-template.ts
+++ b/libs/newsletters-data-client/src/lib/generate-braze-template.ts
@@ -8,28 +8,21 @@ const getDrrSlotSet = (slotKey: DrrSlotKey) => ({
 	middle: `Logic_Middle_${slotKey}`,
 });
 
-const drrSlotKeyMappings = {
-	'AU': 'AUS',
-	'sport': 'Newsletters',
-	'culture': 'Newsletters',
-	'features': 'Newsletters',
+const drrSlotKeyMapping = {
+	'AU': 'AUS'
 }
 const getMerchandisingContent = (newsletterData: NewsletterData, override?: string) => {
-	const { regionFocus, theme } = newsletterData;
+	const { regionFocus} = newsletterData;
 
 	if (override) {
 		return getDrrSlotSet(override as DrrSlotKey)
 	}
 
 	if (regionFocus && ['US', 'AU'].includes(regionFocus)) {
-		return getDrrSlotSet((drrSlotKeyMappings[regionFocus as keyof typeof drrSlotKeyMappings] || regionFocus) as DrrSlotKey);
+		return getDrrSlotSet((drrSlotKeyMapping[regionFocus as keyof typeof drrSlotKeyMapping] || regionFocus) as DrrSlotKey);
 	}
 
-	if (['culture', 'sport', 'features'].includes(theme)) {
-		return getDrrSlotSet((drrSlotKeyMappings[theme as keyof typeof drrSlotKeyMappings] || theme) as DrrSlotKey);
-	}
-
-	return undefined;
+	return getDrrSlotSet(('Newsletters') as DrrSlotKey);
 }
 
 export const generateBrazeTemplateString = (newsletterData: NewsletterData, override?: string): string => {
@@ -37,8 +30,6 @@ export const generateBrazeTemplateString = (newsletterData: NewsletterData, over
 	const contentBlocks = category === 'article-based' ? 'Editorial_FirstEditionContent' : 'Editorial_Content'
 	const emailEndpoint = seriesTag && ['article-based', 'article-based-legacy'].includes(category) ? `${seriesTag}/latest.json` : 'EMAIL ENDPOINT IS NOT SET';
 	const merchandisingContent = getMerchandisingContent(newsletterData, override);
-
-	if (!merchandisingContent) return "Could not determine merchandising content. Please select a DRR slot set";
 
 	const { header, footer, middle } = merchandisingContent;
 	return `{% comment %} Required Campaign-level variables {% endcomment %}

--- a/libs/newsletters-data-client/src/lib/generate-braze-template.ts
+++ b/libs/newsletters-data-client/src/lib/generate-braze-template.ts
@@ -1,6 +1,6 @@
 import type { NewsletterData } from './schemas/newsletter-data-type';
 
-export type DrrSlotKey = 'AUS' | 'Culture' | 'Sport' | 'US' | 'Features' | 'Global';
+export type DrrSlotKey = 'AUS' | 'US' | 'Newsletters';
 
 const getDrrSlotSet = (slotKey: DrrSlotKey) => ({
 	header: `Logic_Header_${slotKey}`,
@@ -10,8 +10,9 @@ const getDrrSlotSet = (slotKey: DrrSlotKey) => ({
 
 const drrSlotKeyMappings = {
 	'AU': 'AUS',
-	'sport': 'Sport',
-	'culture': 'Culture',
+	'sport': 'Newsletters',
+	'culture': 'Newsletters',
+	'features': 'Newsletters',
 }
 const getMerchandisingContent = (newsletterData: NewsletterData, override?: string) => {
 	const { regionFocus, theme } = newsletterData;
@@ -24,7 +25,7 @@ const getMerchandisingContent = (newsletterData: NewsletterData, override?: stri
 		return getDrrSlotSet((drrSlotKeyMappings[regionFocus as keyof typeof drrSlotKeyMappings] || regionFocus) as DrrSlotKey);
 	}
 
-	if (['culture', 'sport'].includes(theme)) {
+	if (['culture', 'sport', 'features'].includes(theme)) {
 		return getDrrSlotSet((drrSlotKeyMappings[theme as keyof typeof drrSlotKeyMappings] || theme) as DrrSlotKey);
 	}
 

--- a/libs/newsletters-data-client/src/lib/generate-braze-template.ts
+++ b/libs/newsletters-data-client/src/lib/generate-braze-template.ts
@@ -3,10 +3,9 @@ import type { NewsletterData } from './schemas/newsletter-data-type';
 export type DrrSlotKey = 'AUS' | 'Culture' | 'Sport' | 'US' | 'Features' | 'Global';
 
 const getDrrSlotSet = (slotKey: DrrSlotKey) => ({
-		header: `Logic_Header_${slotKey}`,
-		footer: `Logic_Footer_${slotKey}`,
-		middle: `Logic_Middle_${slotKey}`,
-		lifecycle: `Logic_Lifecycle_${slotKey}`
+	header: `Logic_Header_${slotKey}`,
+	footer: `Logic_Footer_${slotKey}`,
+	middle: `Logic_Middle_${slotKey}`,
 });
 
 const drrSlotKeyMappings = {
@@ -15,7 +14,7 @@ const drrSlotKeyMappings = {
 	'culture': 'Culture',
 }
 const getMerchandisingContent = (newsletterData: NewsletterData, override?: string) => {
-	const { regionFocus, theme} = newsletterData;
+	const { regionFocus, theme } = newsletterData;
 
 	if (override) {
 		return getDrrSlotSet(override as DrrSlotKey)
@@ -33,14 +32,14 @@ const getMerchandisingContent = (newsletterData: NewsletterData, override?: stri
 }
 
 export const generateBrazeTemplateString = (newsletterData: NewsletterData, override?: string): string => {
-	const {identityName, campaignName, campaignCode, seriesTag, category} = newsletterData;
+	const { identityName, campaignName, campaignCode, seriesTag, category } = newsletterData;
 	const contentBlocks = category === 'article-based' ? 'Editorial_FirstEditionContent' : 'Editorial_Content'
 	const emailEndpoint = seriesTag && ['article-based', 'article-based-legacy'].includes(category) ? `${seriesTag}/latest.json` : 'EMAIL ENDPOINT IS NOT SET';
 	const merchandisingContent = getMerchandisingContent(newsletterData, override);
 
 	if (!merchandisingContent) return "Could not determine merchandising content. Please select a DRR slot set";
 
-	const {header, footer, middle, lifecycle} = merchandisingContent;
+	const { header, footer, middle } = merchandisingContent;
 	return `{% comment %} Required Campaign-level variables {% endcomment %}
 {% assign identity_newsletter_id = "${identityName}" %}
 {% assign email_endpoint = "${emailEndpoint}" %}
@@ -48,7 +47,6 @@ export const generateBrazeTemplateString = (newsletterData: NewsletterData, over
 {% assign CMP = "${campaignCode ?? 'CAMPAIGN CODE IS NOT SET'}" %}
 {% capture email_content %}{{content_blocks.\${${contentBlocks}}}}{% endcapture %}
 {% capture merchandising_content_header %}{{content_blocks.\${${header}}}}{% endcapture %}
-{% capture merchandising_content_lifecycle %}{{content_blocks.\${${lifecycle}}}}{% endcapture %}
 {% capture merchandising_content_middle %}{{content_blocks.\${${middle}}}}{% endcapture %}
 {% capture merchandising_content_footer %}{{content_blocks.\${${footer}}}}{% endcapture %}
 {% capture merchandising_content_newsletter %}{% endcapture %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11539,12 +11539,12 @@
 			}
 		},
 		"node_modules/braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
 			"dependencies": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -15277,9 +15277,9 @@
 			}
 		},
 		"node_modules/fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
@@ -29367,9 +29367,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.16.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-			"integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+			"integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"


### PR DESCRIPTION
## What does this change?

The LifeStyle content block is no longer used in Braze but is present in the generated tamplate - this causes an error as we are referencing a non existant block.

This PR removes that reference

There is also a bump to a couple of vulnerabilities

## How to test

Check generated templates no longer have a lifestyle ref

## How can we measure success?

Templates still work

## Have we considered potential risks?

Low risk - this is a manual activity - it's currently broken - this should fix. 

