### PR TITLE
add cache control headers

### DIFF
--- a/apps/newsletters-api/src/app/headers.ts
+++ b/apps/newsletters-api/src/app/headers.ts
@@ -1,0 +1,23 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+export const getCacheControl = (req: FastifyRequest) => {
+	if (req.routerPath.startsWith('/api/newsletters')) {
+		return {
+			age: '60',
+		};
+	}
+
+	return undefined;
+};
+
+export const setHeaderHook = async (
+	req: FastifyRequest,
+	reply: FastifyReply,
+) => {
+	const cacheControl = getCacheControl(req);
+	if (!cacheControl) {
+		return;
+	}
+
+	void reply.header(`Cache-Control`, `max-age=${cacheControl.age}`);
+};

--- a/apps/newsletters-api/src/app/headers.ts
+++ b/apps/newsletters-api/src/app/headers.ts
@@ -1,4 +1,5 @@
 import type { FastifyReply, FastifyRequest } from 'fastify';
+import { isServingUI } from '../apiDeploymentSettings';
 
 type TtlSettings = {
 	cacheMaxAge: number;
@@ -13,6 +14,11 @@ const newsletterTtl: TtlSettings = {
 export const getCacheControl = (
 	req: FastifyRequest,
 ): TtlSettings | undefined => {
+	// the API instance serving the UI must always provide fresh data
+	if (isServingUI()) {
+		return undefined;
+	}
+
 	if (req.routerPath.startsWith('/api/newsletters')) {
 		return newsletterTtl;
 	}

--- a/apps/newsletters-api/src/app/headers.ts
+++ b/apps/newsletters-api/src/app/headers.ts
@@ -3,12 +3,10 @@ import { isServingUI } from '../apiDeploymentSettings';
 
 type TtlSettings = {
 	cacheMaxAge: number;
-	surrogateMaxAge: number;
 };
 
 const newsletterTtl: TtlSettings = {
 	cacheMaxAge: 60,
-	surrogateMaxAge: 360,
 };
 
 export const getCacheControl = (
@@ -38,12 +36,5 @@ export const setHeaderHook = async (
 		return;
 	}
 
-	// Fastly gives priority to the Surrogate-Control header to determine how often to
-	// refresh the data from the origin server
-	// https://docs.fastly.com/en/guides/caching-best-practices#understand-how-cache-control-headers-work
-	void reply.header(
-		`Surrogate-Control`,
-		`max-age=${cacheControl.surrogateMaxAge}`,
-	);
 	void reply.header(`Cache-Control`, `max-age=${cacheControl.cacheMaxAge}`);
 };

--- a/apps/newsletters-api/src/app/routes/newsletters.ts
+++ b/apps/newsletters-api/src/app/routes/newsletters.ts
@@ -55,13 +55,9 @@ export function registerReadNewsletterRoutes(app: FastifyInstance) {
 				const newsletterDataWithSignedImages = await Promise.all(
 					storageResponse.data.map(signTemplateImages),
 				);
-				return res
-					.headers({ 'Cache-Control': 'max-age=60' })
-					.send(makeSuccessResponse(newsletterDataWithSignedImages));
+				return makeSuccessResponse(newsletterDataWithSignedImages);
 			}
-			return res
-				.headers({ 'Cache-Control': 'max-age=60' })
-				.send(makeSuccessResponse(storageResponse.data));
+			return makeSuccessResponse(storageResponse.data);
 		},
 	);
 

--- a/apps/newsletters-api/src/app/routes/newsletters.ts
+++ b/apps/newsletters-api/src/app/routes/newsletters.ts
@@ -24,7 +24,7 @@ import {
 export function registerReadNewsletterRoutes(app: FastifyInstance) {
 	// not using the makeSuccess function on this route as
 	// we are emulating the response of the legacy API
-	app.get('/api/legacy/newsletters', async (req, res) => {
+	app.get('/api/legacy/newsletters', {}, async (req, res) => {
 		const storageResponse = await newsletterStore.list();
 		if (!storageResponse.ok) {
 			return res
@@ -50,13 +50,18 @@ export function registerReadNewsletterRoutes(app: FastifyInstance) {
 					.send(makeErrorResponse(storageResponse.message));
 			}
 			const { signImages } = req.query;
+
 			if (isDynamicImageSigningEnabled() && signImages) {
 				const newsletterDataWithSignedImages = await Promise.all(
 					storageResponse.data.map(signTemplateImages),
 				);
-				return makeSuccessResponse(newsletterDataWithSignedImages);
+				return res
+					.headers({ 'Cache-Control': 'max-age=60' })
+					.send(makeSuccessResponse(newsletterDataWithSignedImages));
 			}
-			return makeSuccessResponse(storageResponse.data);
+			return res
+				.headers({ 'Cache-Control': 'max-age=60' })
+				.send(makeSuccessResponse(storageResponse.data));
 		},
 	);
 

--- a/apps/newsletters-api/src/app/routes/newsletters.ts
+++ b/apps/newsletters-api/src/app/routes/newsletters.ts
@@ -24,7 +24,7 @@ import {
 export function registerReadNewsletterRoutes(app: FastifyInstance) {
 	// not using the makeSuccess function on this route as
 	// we are emulating the response of the legacy API
-	app.get('/api/legacy/newsletters', {}, async (req, res) => {
+	app.get('/api/legacy/newsletters', async (req, res) => {
 		const storageResponse = await newsletterStore.list();
 		if (!storageResponse.ok) {
 			return res
@@ -50,7 +50,6 @@ export function registerReadNewsletterRoutes(app: FastifyInstance) {
 					.send(makeErrorResponse(storageResponse.message));
 			}
 			const { signImages } = req.query;
-
 			if (isDynamicImageSigningEnabled() && signImages) {
 				const newsletterDataWithSignedImages = await Promise.all(
 					storageResponse.data.map(signTemplateImages),

--- a/apps/newsletters-api/src/main.ts
+++ b/apps/newsletters-api/src/main.ts
@@ -4,6 +4,7 @@ import {
 	isServingReadWriteEndpoints,
 	isServingUI,
 } from './apiDeploymentSettings';
+import { setHeaderHook } from './app/headers';
 import { registerCurrentStepRoute } from './app/routes/currentStep';
 import { registerDraftsRoutes } from './app/routes/drafts';
 import { registerHealthRoute } from './app/routes/health';
@@ -32,6 +33,8 @@ if (isServingReadEndpoints()) {
 	registerDraftsRoutes(app);
 	registerRenderingTemplatesRoutes(app);
 }
+
+app.addHook('onSend', setHeaderHook);
 
 const start = async () => {
 	try {


### PR DESCRIPTION
## What does this change?

Adds cache-control (60 second max age) ~~and surrogate control~~ headers to responses from the newsletters api. The headers are currently unset, and since the api is behind fastly, the default TTL of 1 hour is being used.

Note that there are two differently-configured deployments of this repo:
- the "newsletters api" which serves a public, read-only, cached version of the rest API for newsletters data; and 
-  the "newsletters tool" which serves the UI and a read-write version of rest API , both using  google auth to restrict access

## How to test

Deploy this branch to CODE

There should still  be no delay on updates appearing on the "newsletters tool" -  https://newsletters-tool.code.dev-gutools.co.uk/ - as soon as a newsletter is updated, the UI must reflect this.

open https://newsletters.code.dev-guardianapis.com/api/newsletters  ("newsletters api") and check the cache-control header is set

run frontend locally (local frontend uses the CODE newsletters API) - this branch has been modified to reduce the newsletterSignUpAgin refresh time and log out the names of the parsed newsletters: https://github.com/guardian/frontend/tree/dblatcher/newsletter-refresh-debug

see frontend's lit of live newsletters at : http://localhost:9000/email-newsletters.json

make a change to a code newsletter in the tool - eg change the name on https://newsletters-tool.code.dev-gutools.co.uk/launched/edit/alpha

watch local frontend's logs for newsletter refreshes - observe  - the change should come through on a newsletter refresh within 1 minute of your change.

## How can we measure success?

When the Frontend project refreshes its internal cache (currently every 15 minutes), it should receive an update that is not more that five minutes old - ie updates made in the newsletters tool (which update the s3 files which are the data source for the API) should reliably be visible on frontend within 20 minutes.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

