### PR TITLE
add name tag to newsletters-data bucket

### DIFF
--- a/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
+++ b/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
@@ -424,6 +424,12 @@ exports[`The Newsletters stack matches the snapshot 1`] = `
             "Value": "guardian/newsletters-nx",
           },
           {
+            "Key": "Name",
+            "Value": {
+              "Ref": "SsmParameterValueTESTnewslettersnewslettersapis3BucketNameC96584B6F00A464EAD1953AFF4B05118Parameter",
+            },
+          },
+          {
             "Key": "Stack",
             "Value": "newsletters",
           },

--- a/cdk/lib/newsletters-tool.ts
+++ b/cdk/lib/newsletters-tool.ts
@@ -8,7 +8,7 @@ import {
 } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
 import { GuHttpsEgressSecurityGroup } from '@guardian/cdk/lib/constructs/ec2';
-import { type App, aws_ses, Duration, SecretValue } from 'aws-cdk-lib';
+import { type App, aws_ses, Duration, SecretValue, Tags } from 'aws-cdk-lib';
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 import {
 	ApplicationListenerRule,
@@ -111,6 +111,8 @@ EOL`,
 			app: toolAppName,
 			versioned: true,
 		});
+
+		Tags.of(dataStorageBucket).add('Name', bucketName);
 
 		const sesVerifiedIdentity = new EmailIdentity(this, 'EmailIdentity', {
 			identity: aws_ses.Identity.domain(domainNameTool),


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This PR adds the Name tag to the newsletters-data bucket. We are applying this tag to all S3 buckets in the frontend account to improve cost analysis and better identify which buckets are contributing to recent cost increases.
## How to test
Tested in CODE
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
