### PR TITLE
add new illustrationSquare property

### DIFF
--- a/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
+++ b/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
@@ -78,7 +78,7 @@ export const EditNewsletterForm = ({ originalItem }: Props) => {
 					},
 				}}
 				explanations={{
-					illustrationCard: (
+					illustrationSquare: (
 						<Alert severity="info" sx={{ marginBottom: 1, maxWidth: 600 }}>
 							<Typography>
 								When used on the theguardian.com or other platforms, images are

--- a/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
+++ b/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
@@ -74,7 +74,7 @@ export const NewsletterDataDetails = ({ newsletter }: Props) => {
 				<Grid item>
 					<Illustration
 						name={newsletter.name}
-						url={newsletter.illustrationCard ?? newsletter.illustrationCircle}
+						url={newsletter.illustrationCard ?? newsletter.illustrationSquare ?? newsletter.illustrationCircle}
 					/>
 				</Grid>
 			</Grid>

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
@@ -79,6 +79,7 @@ export const formSchemas = {
 			signUpEmbedDescription: true,
 			mailSuccessDescription: true,
 			illustrationCard: true,
+			illustrationSquare: true,
 		})
 		.describe('Add promotion copy and newsletters page image'),
 

--- a/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
@@ -128,7 +128,12 @@ export const newsletterDataSchema = z.object({
 		.string()
 		.url()
 		.optional()
-		.describe('URL of image for all newsletters page(5:3 format)'),
+		.describe('URL of image the newsleter graphic/logo (5:3 format)'),
+	illustrationSquare: z
+		.string()
+		.url()
+		.optional()
+		.describe('URL of image the newsleter graphic/logo (1:1 format)'),
 
 	creationTimeStamp: z.number(),
 	cancellationTimeStamp: z.number().optional(),

--- a/libs/newsletters-data-client/src/lib/zod-helpers/user-data-schema.ts
+++ b/libs/newsletters-data-client/src/lib/zod-helpers/user-data-schema.ts
@@ -16,6 +16,7 @@ export const getUserEditSchema = (
 			status: true,
 			restricted: true,
 			illustrationCard: true,
+			illustrationSquare: true,
 			tagCreationStatus: true,
 			seriesTag: true,
 			composerTag: true,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a new optional string property, `illustrationSquare` , which like `illustrationCard` represents the URL to an image that can be rendered by platforms.

Include the new property on the newsletter edit form (but not the new newsletter creation wizard)

## How to test

run the UI and API locally as per the readme.
Propery should be on the edit form (note - it will have the same not-ideal behaviour as the "illustrationCard" field - you cannot type into the field as it will only accept an empty string or valid URL, which must be pasted in - will fix on subsequent PR)

See https://github.com/guardian/newsletters-nx/tree/main/libs/newsletters-data-client#how-not-to-break-the-api for testing that this change will not cause any existing newsletters to fail parsing and be excluded from the API

## How can we measure success?

The property will be available on the API for future work - such as dynamically rendering sign-up block on fronts.

## Have we considered potential risks?

Should be safe as we are only adding an optional property with no current usages.



