### PR TITLE
layouts as objects

### DIFF
--- a/apps/newsletters-api/static/layouts.local.json
+++ b/apps/newsletters-api/static/layouts.local.json
@@ -1,23 +1,25 @@
 {
-	"UK": [
-		{
-			"title": "Get started",
-			"newsletters": [
-				"bmx-tesla",
-				"roi-female",
-				"electric-bicycle",
-				"dram-security",
-				"does-not-exist"
-			]
-		},
-		{
-			"title": "In depth",
-			"newsletters": [
-				"muddle-teal",
-				"van-coordinator",
-				"does-not-exist-two",
-				"dram-security"
-			]
-		}
-	]
+	"UK": {
+		"groups": [
+			{
+				"title": "Get started",
+				"newsletters": [
+					"bmx-tesla",
+					"roi-female",
+					"electric-bicycle",
+					"dram-security",
+					"does-not-exist"
+				]
+			},
+			{
+				"title": "In depth",
+				"newsletters": [
+					"muddle-teal",
+					"van-coordinator",
+					"does-not-exist-two",
+					"dram-security"
+				]
+			}
+		]
+	}
 }

--- a/apps/newsletters-ui/src/app/components/edition-layouts/LayoutDisplay.tsx
+++ b/apps/newsletters-ui/src/app/components/edition-layouts/LayoutDisplay.tsx
@@ -13,7 +13,7 @@ interface Props {
 export const LayoutDisplay = ({ newsletters, layout }: Props) => {
 	return (
 		<Box component={'article'}>
-			{layout.map((section, index) => (
+			{layout.groups.map((section, index) => (
 				<Box key={index} component={'section'}>
 					<Typography variant="h3">{section.title}</Typography>
 					{section.subtitle && (

--- a/apps/newsletters-ui/src/app/components/edition-layouts/LayoutsMapDisplay.tsx
+++ b/apps/newsletters-ui/src/app/components/edition-layouts/LayoutsMapDisplay.tsx
@@ -6,7 +6,7 @@ import type {
 	Layout,
 	NewsletterData,
 } from '@newsletters-nx/newsletters-data-client';
-import { editionIds } from '@newsletters-nx/newsletters-data-client';
+import { editionIds, makeBlankLayout } from '@newsletters-nx/newsletters-data-client';
 import { fetchPostApiData } from '../../api-requests/fetch-api-data';
 import { usePermissions } from '../../hooks/user-hooks';
 
@@ -39,7 +39,7 @@ const LayoutOverview = ({
 		).length;
 
 	const handleCreate = async (editionId: EditionId) => {
-		const result = await fetchPostApiData(`/api/layouts/${editionId}`, []);
+		const result = await fetchPostApiData(`/api/layouts/${editionId}`, makeBlankLayout());
 		if (result) {
 			navigate(`/layouts/${editionId.toLowerCase()}`);
 		} else {

--- a/apps/newsletters-ui/src/app/components/edition-layouts/LayoutsMapDisplay.tsx
+++ b/apps/newsletters-ui/src/app/components/edition-layouts/LayoutsMapDisplay.tsx
@@ -30,7 +30,7 @@ const LayoutOverview = ({
 		(section) => section.newsletters,
 	).length;
 	const invalidNewsletterCount = layout?.groups
-		?.flatMap((section) => section.newsletters)
+		.flatMap((section) => section.newsletters)
 		.filter(
 			(newsletterId) =>
 				!newsletters.some(

--- a/apps/newsletters-ui/src/app/components/edition-layouts/LayoutsMapDisplay.tsx
+++ b/apps/newsletters-ui/src/app/components/edition-layouts/LayoutsMapDisplay.tsx
@@ -26,11 +26,10 @@ const LayoutOverview = ({
 }) => {
 	const navigate = useNavigate();
 	const permissions = usePermissions();
-
-	const newsletterCount = layout?.flatMap(
+	const newsletterCount = layout?.groups.flatMap(
 		(section) => section.newsletters,
 	).length;
-	const invalidNewsletterCount = layout
+	const invalidNewsletterCount = layout?.groups
 		?.flatMap((section) => section.newsletters)
 		.filter(
 			(newsletterId) =>
@@ -73,7 +72,7 @@ const LayoutOverview = ({
 
 			{!!newsletterCount && (
 				<Alert>
-					{newsletterCount} newsletters and {layout?.length ?? 0} groups in
+					{newsletterCount} newsletters and {layout?.groups.length ?? 0} groups in
 					layout
 				</Alert>
 			)}

--- a/apps/newsletters-ui/src/app/components/views/LayoutView.tsx
+++ b/apps/newsletters-ui/src/app/components/views/LayoutView.tsx
@@ -65,7 +65,7 @@ export const LayoutView = () => {
 	return (
 		<ContentWrapper>
 			<Typography variant="h2">Layout for {editionId}</Typography>
-			<LayoutDisplay newsletters={newsletters} layout={localLayout ?? []} />
+			<LayoutDisplay newsletters={newsletters} layout={localLayout ?? { groups: [] }} />
 			{permissions?.editLayouts && (
 				<JsonEditor
 					schema={layoutSchema}

--- a/libs/newsletters-data-client/src/lib/layout-storage/types.ts
+++ b/libs/newsletters-data-client/src/lib/layout-storage/types.ts
@@ -5,13 +5,16 @@ export const editionIdSchema = z.enum(['UK', 'US', 'AU', 'INT', 'EUR']);
 export const editionIds = editionIdSchema.options;
 export type EditionId = z.infer<typeof editionIdSchema>;
 
-export const layoutSchema = z
+const layoutGroup = z
 	.object({
 		title: z.string(),
 		subtitle: z.string().optional(),
 		newsletters: z.string().array(),
-	})
-	.array();
+	});
+
+export const layoutSchema = z.object({
+	groups: layoutGroup.array()
+});
 
 export type Layout = z.infer<typeof layoutSchema>;
 

--- a/libs/newsletters-data-client/src/lib/layout-storage/types.ts
+++ b/libs/newsletters-data-client/src/lib/layout-storage/types.ts
@@ -19,3 +19,7 @@ export const layoutSchema = z.object({
 export type Layout = z.infer<typeof layoutSchema>;
 
 export type EditionsLayouts = Partial<Record<EditionId, Layout>>;
+
+export const makeBlankLayout = (): Layout => ({
+	groups: []
+})


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

updates https://github.com/guardian/newsletters-nx/pull/328
Changes the API format for layouts to be an object with an array of groups, rather than an array of groups.

This is to make the model  easier to expand with extra data/config for the layout other than the groups of newsletters it contains.

It will also make the json data easier to handle in scala applications (EG frontend) which can more easily model the layout as (for example) a `NewsletterLayout` rather than a `List[NewsletterGroup]`.

## How to test

Should work as before locally. 
If deployed to CODE, the existing layout data will be invalidated and may need to be manually deleted from S3

## How can we measure success?

new model from the api responses

## Have we considered potential risks?

https://github.com/guardian/newsletters-nx/pull/328 has not been put live yet, so there is no layout data in the PROD bucket to get invalidated by this change


