### PR TITLE
add layouts page links

### DIFF
--- a/apps/newsletters-ui/src/app/components/HomeMenu.tsx
+++ b/apps/newsletters-ui/src/app/components/HomeMenu.tsx
@@ -126,7 +126,7 @@ export function HomeMenu() {
 
 				<ButtonGridItem
 					path="/layouts"
-					content={'All Newsletters page layouts'}
+					content={'View Newsletter Layouts'}
 					variant="outlined"
 				/>
 			</Grid>

--- a/apps/newsletters-ui/src/app/components/HomeMenu.tsx
+++ b/apps/newsletters-ui/src/app/components/HomeMenu.tsx
@@ -123,6 +123,12 @@ export function HomeMenu() {
 						/>
 					</Grid>
 				)}
+
+				<ButtonGridItem
+					path="/layouts"
+					content={'All Newsletters page layouts'}
+					variant="outlined"
+				/>
 			</Grid>
 		</Container>
 	);

--- a/apps/newsletters-ui/src/app/components/MainNav.tsx
+++ b/apps/newsletters-ui/src/app/components/MainNav.tsx
@@ -32,6 +32,7 @@ const navLinks: NavLink[] = [
 	{ path: '/launched', label: 'Launched' },
 	{ path: '/drafts', label: 'Drafts' },
 	{ path: '/templates', label: 'Email Templates' },
+	{ path: '/layouts', label: 'Layouts' },
 ];
 
 const menuItemIsSelected = (path: string): boolean => {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds links to the /layouts page recently added. The pages are already in place - not that [DCR is using the data published by the API](https://github.com/guardian/dotcom-rendering/pull/12795), we should make the pages visible on the uI

## How to test

Link buttons on the header nav and home page will direct to the /layouts page


## Images

<img width="899" alt="Screenshot 2025-02-10 at 11 50 47" src="https://github.com/user-attachments/assets/17037c40-6869-44df-b7d5-8bfe67effa07" />

