### PR TITLE
grant editLayouts permissions to editors and CP

### DIFF
--- a/libs/newsletters-data-client/src/lib/user-profile.ts
+++ b/libs/newsletters-data-client/src/lib/user-profile.ts
@@ -76,7 +76,11 @@ export const levelToPermissions = (
 		].includes(accessLevel),
 		viewMetaData: [UserAccessLevel.Developer].includes(accessLevel),
 		useJsonEditor: [UserAccessLevel.Developer].includes(accessLevel),
-		editLayouts: [UserAccessLevel.Developer].includes(accessLevel),
+		editLayouts: [
+			UserAccessLevel.Developer,
+			UserAccessLevel.Editor,
+			UserAccessLevel.CentralProduction,
+		].includes(accessLevel),
 		editBraze: [UserAccessLevel.BrazeEditor].includes(accessLevel),
 		editOphan: [UserAccessLevel.OphanEditor].includes(accessLevel),
 		editTags: [UserAccessLevel.CentralProduction].includes(accessLevel),


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Updates the list of user levels able to use the new "edit layouts" feature

## How to test

Probably not necessary, but could be tested on CODE by changing your permission level in (0=Developer, 1=Editor) in the JSON file in the frontend s3 account 

## How can we measure success?

once merged, the feature will be visible to the users listed in the permissions s3 file as being CP, editors or Developers (currently visible to those listed as Developers only).

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

