### PR TITLE
Move to bigger private subnets

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -29,6 +29,11 @@ deployments:
       templateStagePaths:
         CODE: NewslettersTool-CODE.template.json
         PROD: NewslettersTool-PROD.template.json
+      templateParameters:
+        newslettersapiPrivateSubnets:
+          /devx/bigger/private/subnets
+        newsletterstoolPrivateSubnets:
+          /devx/bigger/private/subnets
 
   # Newsletters internal tool autoscaling deployment
   newsletters-tool:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -29,6 +29,10 @@ deployments:
       templateStagePaths:
         CODE: NewslettersTool-CODE.template.json
         PROD: NewslettersTool-PROD.template.json
+      #
+      # This is to be an interim solution on the way to bigger subnets that will be reverted once we are in
+      # a position to make the values of the new values in the parameter /devx/bigger/private/subnets
+      # into a new default.
       templateParameters:
         newslettersapiPrivateSubnets:
           /devx/bigger/private/subnets


### PR DESCRIPTION
Frontent is moving to bigger, private subnets and an SSM Parameter /devx/bigger/private/subnets to reference them. 

## What does this change?

Set newslettersapiPrivateSubnets and newslettersapiPrivateSubnets to new bigger private subnets with parameter /devx/bigger/private/subnets

## How to test

Check if deployment still works

## Next steps

This is to be a interim step that will be reverted once we are in a position to make the values of the new values in the parameter /devx/bigger/private/subnets into a new default. So when the move to the new bigger subnet is complete.
