### PR TITLE
Remove subnet parameter from riff raff yaml

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -35,9 +35,9 @@ deployments:
       # into a new default.
       templateParameters:
         newslettersapiPrivateSubnets:
-          /devx/bigger/private/subnets
+          /account/vpc/primary/subnets/private
         newsletterstoolPrivateSubnets:
-          /devx/bigger/private/subnets
+          /account/vpc/primary/subnets/private
 
   # Newsletters internal tool autoscaling deployment
   newsletters-tool:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -29,15 +29,6 @@ deployments:
       templateStagePaths:
         CODE: NewslettersTool-CODE.template.json
         PROD: NewslettersTool-PROD.template.json
-      #
-      # This is to be an interim solution on the way to bigger subnets that will be reverted once we are in
-      # a position to make the values of the new values in the parameter /devx/bigger/private/subnets
-      # into a new default.
-      templateParameters:
-        newslettersapiPrivateSubnets:
-          /account/vpc/primary/subnets/private
-        newsletterstoolPrivateSubnets:
-          /account/vpc/primary/subnets/private
 
   # Newsletters internal tool autoscaling deployment
   newsletters-tool:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This patch reverts the change introduced in https://github.com/guardian/newsletters-nx/pull/335.

We've now migrated everything to the new subnets so we can go back to omitting this parameter. That will make the system go back to relying on defaults, which are now to the new subnets, so this change will result in a no op.