### PR TITLE
feat: Update load balancer access logs prefix

### DIFF
--- a/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
+++ b/cdk/lib/__snapshots__/newsletters-tool.test.ts.snap
@@ -1405,7 +1405,7 @@ exports[`The Newsletters stack matches the snapshot 1`] = `
           },
           {
             "Key": "access_logs.s3.prefix",
-            "Value": "ELBLogs/newsletters/newsletters-tool/TEST",
+            "Value": "application-load-balancer/TEST/newsletters/newsletters-tool",
           },
         ],
         "Scheme": "internet-facing",

--- a/cdk/lib/newsletters-tool.ts
+++ b/cdk/lib/newsletters-tool.ts
@@ -196,7 +196,8 @@ EOL`,
 			app: toolAppName,
 			accessLogging: {
 				enabled: true,
-				prefix: `ELBLogs/${this.stack}/${toolAppName}/${this.stage}`,
+				// This is the prefix pattern DevX assume so that the logs can be shown on the Availability dashboard.
+				prefix: `application-load-balancer/${this.stage}/${this.stack}/${toolAppName}`,
 			},
 			applicationLogging: {
 				enabled: true,


### PR DESCRIPTION
## What does this change?
Updates the prefix used when shipping load balancer access logs to S3. This is the prefix pattern DevX assume so that the logs can be shown on the [Availability dashboard](https://metrics.gutools.co.uk/d/zM0ouzs4z/availability-dashboard). Note, this is part of an [ongoing spike](https://docs.google.com/document/d/1fjxhWG9x_BOE0KAoC-ApWUTx8PnV0q5XgtOYb6uA9nU/edit?tab=t.0).

See also https://github.com/guardian/aws-account-setup/pull/351.
