### PR TITLE
add mobile banner image field

### DIFF
--- a/libs/newsletters-data-client/src/lib/schemas/rendering-options-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/schemas/rendering-options-data-type.ts
@@ -28,7 +28,10 @@ export const renderingOptionsSchema = z.object({
 	displayStandfirst: z.boolean().describe('Display standfirst?'),
 	contactEmail: z.string().email().optional().describe('Contact email'),
 	displayImageCaptions: z.boolean().describe('Display image captions?'),
-	includeBreakingNews: z.boolean().optional().describe('Include breaking news sections?'),
+	includeBreakingNews: z
+		.boolean()
+		.optional()
+		.describe('Include breaking news sections?'),
 	darkHeadlineBackground: z
 		.boolean()
 		.optional()
@@ -65,6 +68,11 @@ export const renderingOptionsSchema = z.object({
 		.url()
 		.optional()
 		.describe('URL for the main banner'),
+	mainBannerMobileUrl: z
+		.string()
+		.url()
+		.optional()
+		.describe('URL for the mobile size main banner'),
 	subheadingBannerUrl: z
 		.string()
 		.url()


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a property for a mobile banner image field for responsive design supporting Persephone variant.

## How to test

You can set the property in the rendering options under the main banner URL

## How can we measure success?

Part of the Persephone redesign enabling a responsive banner.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<img width="525" height="88" alt="image" src="https://github.com/user-attachments/assets/d42ccc72-6f3f-4b1b-8545-1cfce1392523" />

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
