### PR TITLE
Updating qs and react router packages to avoid reported vulnerabilities

### DIFF
--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -7,9 +7,6 @@
     "": {
       "name": "cdk",
       "version": "0.0.0",
-      "dependencies": {
-        "constructs": "^10.4.2"
-      },
       "devDependencies": {
         "@guardian/cdk": "^62.1.2",
         "@guardian/eslint-config-typescript": "3.0.0",
@@ -20,6 +17,7 @@
         "@typescript-eslint/parser": "^5.52.0",
         "aws-cdk": "^2.1033.0",
         "aws-cdk-lib": "^2.231.0",
+        "constructs": "^10.4.2",
         "eslint": "^8.32.0",
         "jest": "^29.3.1",
         "prettier": "^2.8.3",
@@ -4527,7 +4525,8 @@
     "node_modules/constructs": {
       "version": "10.4.2",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.4.2.tgz",
-      "integrity": "sha512-wsNxBlAott2qg8Zv87q3eYZYgheb9lchtBfjHzzLHtXbttwSrHPs1NNQbBrmbb1YZvYg2+Vh0Dor76w4mFxJkA=="
+      "integrity": "sha512-wsNxBlAott2qg8Zv87q3eYZYgheb9lchtBfjHzzLHtXbttwSrHPs1NNQbBrmbb1YZvYg2+Vh0Dor76w4mFxJkA==",
+      "dev": true
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -12369,7 +12368,8 @@
     "constructs": {
       "version": "10.4.2",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.4.2.tgz",
-      "integrity": "sha512-wsNxBlAott2qg8Zv87q3eYZYgheb9lchtBfjHzzLHtXbttwSrHPs1NNQbBrmbb1YZvYg2+Vh0Dor76w4mFxJkA=="
+      "integrity": "sha512-wsNxBlAott2qg8Zv87q3eYZYgheb9lchtBfjHzzLHtXbttwSrHPs1NNQbBrmbb1YZvYg2+Vh0Dor76w4mFxJkA==",
+      "dev": true
     },
     "convert-source-map": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
 				"react": "18.2.0",
 				"react-dom": "18.2.0",
 				"react-markdown": "^8.0.5",
-				"react-router-dom": "6.4.3",
+				"react-router-dom": "^6.30.3",
 				"react-table": "^7.8.0",
 				"tslib": "^2.3.0",
 				"zod": "^3.22.3"
@@ -7497,12 +7497,11 @@
 			}
 		},
 		"node_modules/@remix-run/router": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.0.3.tgz",
-			"integrity": "sha512-ceuyTSs7PZ/tQqi19YZNBc5X7kj1f8p+4DIyrcIYFY9h+hd1OKm4RqtiWldR9eGEvIiJfsqwM4BsuCtRIuEw6Q==",
-			"license": "MIT",
+			"version": "1.23.2",
+			"resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+			"integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
 			"engines": {
-				"node": ">=14"
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@rollup/pluginutils": {
@@ -23167,10 +23166,9 @@
 			"license": "MIT"
 		},
 		"node_modules/qs": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-			"integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-			"license": "BSD-3-Clause",
+			"version": "6.14.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+			"integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
 			"dependencies": {
 				"side-channel": "^1.1.0"
 			},
@@ -23338,31 +23336,29 @@
 			}
 		},
 		"node_modules/react-router": {
-			"version": "6.4.3",
-			"resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.3.tgz",
-			"integrity": "sha512-BT6DoGn6aV1FVP5yfODMOiieakp3z46P1Fk0RNzJMACzE7C339sFuHebfvWtnB4pzBvXXkHP2vscJzWRuUjTtA==",
-			"license": "MIT",
+			"version": "6.30.3",
+			"resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+			"integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
 			"dependencies": {
-				"@remix-run/router": "1.0.3"
+				"@remix-run/router": "1.23.2"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=14.0.0"
 			},
 			"peerDependencies": {
 				"react": ">=16.8"
 			}
 		},
 		"node_modules/react-router-dom": {
-			"version": "6.4.3",
-			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.4.3.tgz",
-			"integrity": "sha512-MiaYQU8CwVCaOfJdYvt84KQNjT78VF0TJrA17SIQgNHRvLnXDJO6qsFqq8F/zzB1BWZjCFIrQpu4QxcshitziQ==",
-			"license": "MIT",
+			"version": "6.30.3",
+			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+			"integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
 			"dependencies": {
-				"@remix-run/router": "1.0.3",
-				"react-router": "6.4.3"
+				"@remix-run/router": "1.23.2",
+				"react-router": "6.30.3"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=14.0.0"
 			},
 			"peerDependencies": {
 				"react": ">=16.8",
@@ -27445,22 +27441,6 @@
 			"integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/webpack-dev-server/node_modules/qs": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-			"integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"side-channel": "^1.0.6"
-			},
-			"engines": {
-				"node": ">=0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/webpack-dev-server/node_modules/raw-body": {
 			"version": "2.5.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"react": "18.2.0",
 		"react-dom": "18.2.0",
 		"react-markdown": "^8.0.5",
-		"react-router-dom": "6.4.3",
+		"react-router-dom": "^6.30.3",
 		"react-table": "^7.8.0",
 		"tslib": "^2.3.0",
 		"zod": "^3.22.3"
@@ -109,5 +109,8 @@
 		"vite-plugin-eslint": "^1.8.1",
 		"vite-tsconfig-paths": "^4.0.2",
 		"vitest": "^0.25.8"
+	},
+	"overrides": {
+		"qs": "6.14.1"
 	}
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

See more info in security advisories:

https://github.com/advisories/GHSA-6rw7-vpxm-498p
https://github.com/advisories/GHSA-2w69-qvjg-hvjx

Bumps `react-router-dom` to `6.30.3` and overrides `qs` to `6.14.1`. Normally wouldn't like to force a override, but the version of `body-parser` we're pulling in has it pinned to a specific version.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Will deploy to CODE and look at testing instructions in #343

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Removing dependency on package versions with reported high severity vulnerabilities.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

Risk of unintentional regressions, so will test functionality, and make newsletters team aware of changes also.
