### PR TITLE
Small README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To run the UI and API locally with the default options:
 
 ### Unit Tests
 ```bash
-npm run tests
+npm run test
 ```
 
 ### E2E Tests


### PR DESCRIPTION
## What does this change?
Fixes a tiny typo in the README for the example command to run the unit tests

