### PR TITLE
node-forge vuln fix

### DIFF
--- a/apps/newsletters-api/.eslintrc.json
+++ b/apps/newsletters-api/.eslintrc.json
@@ -16,6 +16,13 @@
 		{
 			"files": ["*.js", "*.jsx"],
 			"rules": {}
+		},
+		{
+			"files": ["*.mjs"],
+			"parserOptions": {
+				"ecmaVersion": 2022,
+				"sourceType": "module"
+			}
 		}
 	]
 }

--- a/apps/newsletters-api/build.mjs
+++ b/apps/newsletters-api/build.mjs
@@ -1,0 +1,17 @@
+import { build } from 'esbuild';
+import { cpSync, mkdirSync } from 'fs';
+
+mkdirSync('dist/apps/newsletters-api', { recursive: true });
+
+await build({
+	entryPoints: ['apps/newsletters-api/src/main.ts'],
+	bundle: true,
+	platform: 'node',
+	format: 'cjs',
+	outfile: 'dist/apps/newsletters-api/index.cjs',
+	tsconfig: 'apps/newsletters-api/tsconfig.app.json',
+});
+
+cpSync('apps/newsletters-api/src/assets', 'dist/apps/newsletters-api/assets', {
+	recursive: true,
+});

--- a/apps/newsletters-api/project.json
+++ b/apps/newsletters-api/project.json
@@ -5,28 +5,16 @@
 	"projectType": "application",
 	"targets": {
 		"build": {
-			"executor": "@nrwl/esbuild:esbuild",
-			"outputs": ["{options.outputPath}"],
+			"executor": "nx:run-commands",
+			"outputs": ["{workspaceRoot}/dist/apps/newsletters-api"],
 			"options": {
-				"outputPath": "dist/apps/newsletters-api",
-				"outputFileName": "index.cjs",
-				"format": ["cjs"],
-				"main": "apps/newsletters-api/src/main.ts",
-				"tsConfig": "apps/newsletters-api/tsconfig.app.json",
-				"assets": ["apps/newsletters-api/src/assets"],
-				"generatePackageJson": true,
-				"externalDependencies": "none"
+				"command": "node apps/newsletters-api/build.mjs"
 			}
 		},
 		"serve": {
-			"executor": "@nrwl/js:node",
+			"executor": "nx:run-commands",
 			"options": {
-				"buildTarget": "newsletters-api:build"
-			},
-			"configurations": {
-				"production": {
-					"buildTarget": "newsletters-api:build:production"
-				}
+				"command": "TS_NODE_PROJECT=apps/newsletters-api/tsconfig.app.json node --watch --require tsconfig-paths/register --require ts-node/register apps/newsletters-api/src/main.ts"
 			}
 		},
 		"lint": {

--- a/apps/newsletters-api/src/main.ts
+++ b/apps/newsletters-api/src/main.ts
@@ -1,5 +1,4 @@
-import bodyParser from 'body-parser';
-import ExpressApp from 'express';
+import ExpressApp, { json } from 'express';
 import {
 	isServingReadEndpoints,
 	isServingReadWriteEndpoints,
@@ -23,14 +22,14 @@ import { registerUserRoute } from './app/routes/user';
 import { registerUIServer } from './register-ui-server';
 
 const app = ExpressApp();
-app.use(setCacheControlHeaderMiddleware)
-app.use(bodyParser.json());
+app.use(setCacheControlHeaderMiddleware);
+app.use(json());
 
 registerHealthRoute(app);
 if (isServingUI()) {
 	// When running locally UI dev-server runs on :4200, even without this function.
 	// but the UI should also be served on :3000, like it is on PROD
-	// if registerUIServer is working locally, a ui route on :3000 (eg http://localhost:3000/launched) 
+	// if registerUIServer is working locally, a ui route on :3000 (eg http://localhost:3000/launched)
 	// should serve the index.html and static assets from: dist/apps/newsletters-ui (if built with nx:build)
 	registerUIServer(app);
 }
@@ -47,7 +46,6 @@ if (isServingReadEndpoints()) {
 	registerRenderingTemplatesRoutes(app);
 	registerReadLayoutRoutes(app);
 }
-
 
 const start = async () => {
 	try {
@@ -73,7 +71,7 @@ const start = async () => {
 		// TO DO - start was "intentionally asynchronous" - is that essential??
 		await new Promise(() => {
 			//
-		})
+		});
 	} catch (err) {
 		// Errors are logged here
 		console.error(err);

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -1024,7 +1024,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
       "integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -1740,7 +1739,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.45.0.tgz",
       "integrity": "sha512-brvs/WSM4fKUmF5Ot/gEve6qYiCMjm6w4HkHPfS6ZNmxTS0m0iNN4yOChImaCkqc1hRwFGqUyanMXuGal6oyyQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.45.0",
         "@typescript-eslint/types": "5.45.0",
@@ -3278,8 +3276,7 @@
       "version": "18.11.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
       "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -3369,7 +3366,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.52.0.tgz",
       "integrity": "sha512-e2KiLQOZRo4Y0D/b+3y08i3jsekoSkOYStROYmPUnGMEoA0h+k2qOH5H6tcjIc68WDvGwH+PaOrP1XRzLJ6QlA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.52.0",
         "@typescript-eslint/types": "5.52.0",
@@ -3524,7 +3520,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
       "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3714,7 +3709,6 @@
       "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1033.0.tgz",
       "integrity": "sha512-Pit2k7cVAwxoYI7RMVsOyltuy7/HGENLupJ4KAm/d8mGzOfX+SLOo9YQsx5CKY9J6ErCZ1ViLerklTfjytvQww==",
       "dev": true,
-      "peer": true,
       "bin": {
         "cdk": "bin/cdk"
       },
@@ -3743,7 +3737,6 @@
         "mime-types"
       ],
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.242",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
@@ -4250,7 +4243,6 @@
           "url": "https://tidelift.com/funding/github/npm/browserslist"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001400",
         "electron-to-chromium": "^1.4.251",
@@ -4534,8 +4526,7 @@
       "version": "10.4.2",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.4.2.tgz",
       "integrity": "sha512-wsNxBlAott2qg8Zv87q3eYZYgheb9lchtBfjHzzLHtXbttwSrHPs1NNQbBrmbb1YZvYg2+Vh0Dor76w4mFxJkA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -4863,7 +4854,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.32.0.tgz",
       "integrity": "sha512-nETVXpnthqKPFyuY2FNjz/bEd6nbosRgKbkgS/y1C7LJop96gYHWpiguLecMHQ2XCPxn77DS0P+68WzG6vkZSQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.4.1",
         "@humanwhocodes/config-array": "^0.11.8",
@@ -5062,7 +5052,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
       "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.4",
         "array.prototype.flat": "^1.2.5",
@@ -6421,7 +6410,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.4.1.tgz",
       "integrity": "sha512-cknimw7gAXPDOmj0QqztlxVtBVCw2lYY9CeIE5N6kD+kET1H4H79HSNISJmijb1HF+qk+G+ploJgiDi5k/fRlg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.4.1",
         "@jest/types": "^29.4.1",
@@ -7660,7 +7648,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
       "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -8508,7 +8495,6 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -8659,7 +8645,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9795,7 +9780,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
       "integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -10335,7 +10319,6 @@
           "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.45.0.tgz",
           "integrity": "sha512-brvs/WSM4fKUmF5Ot/gEve6qYiCMjm6w4HkHPfS6ZNmxTS0m0iNN4yOChImaCkqc1hRwFGqUyanMXuGal6oyyQ==",
           "dev": true,
-          "peer": true,
           "requires": {
             "@typescript-eslint/scope-manager": "5.45.0",
             "@typescript-eslint/types": "5.45.0",
@@ -11540,8 +11523,7 @@
       "version": "18.11.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
       "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -11614,7 +11596,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.52.0.tgz",
       "integrity": "sha512-e2KiLQOZRo4Y0D/b+3y08i3jsekoSkOYStROYmPUnGMEoA0h+k2qOH5H6tcjIc68WDvGwH+PaOrP1XRzLJ6QlA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.52.0",
         "@typescript-eslint/types": "5.52.0",
@@ -11695,8 +11676,7 @@
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
       "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -11829,7 +11809,6 @@
       "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1033.0.tgz",
       "integrity": "sha512-Pit2k7cVAwxoYI7RMVsOyltuy7/HGENLupJ4KAm/d8mGzOfX+SLOo9YQsx5CKY9J6ErCZ1ViLerklTfjytvQww==",
       "dev": true,
-      "peer": true,
       "requires": {
         "fsevents": "2.3.2"
       }
@@ -11839,7 +11818,6 @@
       "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.231.0.tgz",
       "integrity": "sha512-RMt88F1vhsM28j81EjvIXRoPeYQdtk72EGh9xAP6LjuyF8df1hDBIy5cawUvagdp5eCBPVHrPJ2U0eaUUKtjFg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@aws-cdk/asset-awscli-v1": "2.2.242",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
@@ -12186,7 +12164,6 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
       "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001400",
         "electron-to-chromium": "^1.4.251",
@@ -12392,8 +12369,7 @@
       "version": "10.4.2",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.4.2.tgz",
       "integrity": "sha512-wsNxBlAott2qg8Zv87q3eYZYgheb9lchtBfjHzzLHtXbttwSrHPs1NNQbBrmbb1YZvYg2+Vh0Dor76w4mFxJkA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "convert-source-map": {
       "version": "2.0.0",
@@ -12638,7 +12614,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.32.0.tgz",
       "integrity": "sha512-nETVXpnthqKPFyuY2FNjz/bEd6nbosRgKbkgS/y1C7LJop96gYHWpiguLecMHQ2XCPxn77DS0P+68WzG6vkZSQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@eslint/eslintrc": "^1.4.1",
         "@humanwhocodes/config-array": "^0.11.8",
@@ -12807,7 +12782,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
       "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "array-includes": "^3.1.4",
         "array.prototype.flat": "^1.2.5",
@@ -13782,7 +13756,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.4.1.tgz",
       "integrity": "sha512-cknimw7gAXPDOmj0QqztlxVtBVCw2lYY9CeIE5N6kD+kET1H4H79HSNISJmijb1HF+qk+G+ploJgiDi5k/fRlg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@jest/core": "^29.4.1",
         "@jest/types": "^29.4.1",
@@ -14730,8 +14703,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
       "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "pretty-format": {
       "version": "29.4.1",
@@ -15335,7 +15307,6 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -15440,8 +15411,7 @@
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1210,7 +1210,6 @@
 			"integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
 				"@babel/generator": "^7.28.5",
@@ -3317,7 +3316,6 @@
 			"version": "11.11.4",
 			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.4.tgz",
 			"integrity": "sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==",
-			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
 				"@emotion/babel-plugin": "^11.11.0",
@@ -3372,7 +3370,6 @@
 			"version": "11.11.5",
 			"resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.5.tgz",
 			"integrity": "sha512-/ZjjnaNKvuMPxcIiUkf/9SHoG4Q196DRl1w82hQ3WCsjo1IUR8uaGWrC6a87CrYAW0Kb/pK7hk8BnLgLRi9KoQ==",
-			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
 				"@emotion/babel-plugin": "^11.11.0",
@@ -3932,6 +3929,7 @@
 			"resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
 			"integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@formatjs/fast-memoize": "2.2.7",
 				"@formatjs/intl-localematcher": "0.6.2",
@@ -3944,6 +3942,7 @@
 			"resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
 			"integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -3953,6 +3952,7 @@
 			"resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
 			"integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@formatjs/ecma402-abstract": "2.3.6",
 				"@formatjs/icu-skeleton-parser": "1.8.16",
@@ -3964,6 +3964,7 @@
 			"resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
 			"integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@formatjs/ecma402-abstract": "2.3.6",
 				"tslib": "^2.8.0"
@@ -3974,6 +3975,7 @@
 			"resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
 			"integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -4052,7 +4054,6 @@
 			"integrity": "sha512-brvs/WSM4fKUmF5Ot/gEve6qYiCMjm6w4HkHPfS6ZNmxTS0m0iNN4yOChImaCkqc1hRwFGqUyanMXuGal6oyyQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "5.45.0",
 				"@typescript-eslint/types": "5.45.0",
@@ -4603,6 +4604,7 @@
 			"resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.10.1.tgz",
 			"integrity": "sha512-oJrXtQiAXLvT9clCf1K4kxp3eKsQhIaZqxEyowkBcsvZDdZkbWrVmnGknxs5flTD0VGsxrxKgBCZty1EzoiMzA==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@swc/helpers": "^0.5.0"
 			}
@@ -4612,6 +4614,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -4621,6 +4624,7 @@
 			"resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.8.tgz",
 			"integrity": "sha512-Rwk3j/TlYZhn3HQ6PyXUV0XP9Uv42jqZGNegt0BXlxjE6G3+LwHjbQZAGHhCnCPdaA6Tvd3ma/7QzLlLkJxAWA==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@swc/helpers": "^0.5.0",
 				"intl-messageformat": "^10.1.0"
@@ -4631,6 +4635,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -4640,6 +4645,7 @@
 			"resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.5.tgz",
 			"integrity": "sha512-6hY4Kl4HPBvtfS62asS/R22JzNNy8vi/Ssev7x6EobfCp+9QIB2hKvI2EtbdJ0VSQacxVNtqhE/NmF/NZ0gm6g==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@swc/helpers": "^0.5.0"
 			}
@@ -4649,6 +4655,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -4658,6 +4665,7 @@
 			"resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.7.tgz",
 			"integrity": "sha512-D4OHBjrinH+PFZPvfCXvG28n2LSykWcJ7GIioQL+ok0LON15SdfoUssoHzzOUmVZLbRoREsQXVzA6r8JKsbP6A==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@swc/helpers": "^0.5.0"
 			}
@@ -4667,6 +4675,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -4973,6 +4982,7 @@
 			"integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@types/node": "*",
 				"jest-regex-util": "30.0.1"
@@ -4987,6 +4997,7 @@
 			"integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
@@ -5176,6 +5187,7 @@
 			"integrity": "sha512-XsauDV82o5qXbhalKxD7p4TZYYdwcaEXC77PPD2HixEFF+6YGppjrAAQurTl2ECWcEomHBMMNS9AH3kcCFx8jA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.27.4",
 				"@jest/types": "30.2.0",
@@ -5203,6 +5215,7 @@
 			"integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@sinclair/typebox": "^0.34.0"
 			},
@@ -5216,6 +5229,7 @@
 			"integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@jest/pattern": "30.0.1",
 				"@jest/schemas": "30.0.5",
@@ -5234,7 +5248,8 @@
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
 			"integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@jest/transform/node_modules/babel-plugin-istanbul": {
 			"version": "7.0.1",
@@ -5242,6 +5257,7 @@
 			"integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"workspaces": [
 				"test/babel-8"
 			],
@@ -5262,6 +5278,7 @@
 			"integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.23.9",
 				"@babel/parser": "^7.23.9",
@@ -5279,6 +5296,7 @@
 			"integrity": "sha512-sQA/jCb9kNt+neM0anSj6eZhLZUIhQgwDt7cPGjumgLM4rXsfb9kpnlacmvZz3Q5tb80nS+oG/if+NBKrHC+Xw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@jest/types": "30.2.0",
 				"@types/node": "*",
@@ -5304,6 +5322,7 @@
 			"integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
@@ -5314,6 +5333,7 @@
 			"integrity": "sha512-0Q4Uk8WF7BUwqXHuAjc23vmopWJw5WH7w2tqBoUOZpOjW/ZnR44GXXd1r82RvnmI2GZge3ivrYXk/BE2+VtW2g==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@types/node": "*",
 				"@ungap/structured-clone": "^1.3.0",
@@ -5331,6 +5351,7 @@
 			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -5344,6 +5365,7 @@
 			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=14"
 			},
@@ -5357,6 +5379,7 @@
 			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -5373,6 +5396,7 @@
 			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"imurmurhash": "^0.1.4",
 				"signal-exit": "^4.0.1"
@@ -5567,7 +5591,6 @@
 			"resolved": "https://registry.npmjs.org/@mui/material/-/material-5.18.0.tgz",
 			"integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.23.9",
 				"@mui/core-downloads-tracker": "^5.18.0",
@@ -5673,7 +5696,6 @@
 			"resolved": "https://registry.npmjs.org/@mui/system/-/system-5.18.0.tgz",
 			"integrity": "sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.23.9",
 				"@mui/private-theming": "^5.17.1",
@@ -7316,6 +7338,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/autocomplete/-/autocomplete-3.0.0-rc.3.tgz",
 			"integrity": "sha512-vemf7h3hvIDk3MxiiPryysfYgJDg8R72X46dRIeg0+cXKYxjPYou64/DTucSV2z5J6RC5JalINu0jIDaLhEILw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/combobox": "^3.14.0",
 				"@react-aria/focus": "^3.21.2",
@@ -7342,6 +7365,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -7351,6 +7375,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/breadcrumbs/-/breadcrumbs-3.5.30.tgz",
 			"integrity": "sha512-DZymglA70SwvDJA7GB147sUexvdDy6vWcriGrlEHhMMzBLhGB30I5J96R4pPzURLxXISrWFH56KC5rRgIqsqqg==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/i18n": "^3.12.14",
 				"@react-aria/link": "^3.8.7",
@@ -7369,6 +7394,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -7378,6 +7404,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/button/-/button-3.14.3.tgz",
 			"integrity": "sha512-iJTuEECs9im7TwrCRZ0dvuwp8Gao0+I1IuYs1LQvJQgKLpgRH2/6jAiqb2bdAcoAjdbaMs7Xe0xUwURpVNkEyA==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/interactions": "^3.26.0",
 				"@react-aria/toolbar": "3.0.0-beta.22",
@@ -7397,6 +7424,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/toolbar/-/toolbar-3.0.0-beta.22.tgz",
 			"integrity": "sha512-Q1gOj6N4vzvpGrIoNAxpUudEQP82UgQACENH/bcH8FnEMbSP7DHvVfDhj7GTU6ldMXO2cjqLhiidoUK53gkCiA==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/focus": "^3.21.3",
 				"@react-aria/i18n": "^3.12.14",
@@ -7414,6 +7442,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -7423,6 +7452,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/calendar/-/calendar-3.9.3.tgz",
 			"integrity": "sha512-F12UQ4zd8GIxpJxs9GAHzDD9Lby2hESHm0LF5tjsYBIOBJc5K7ICeeE5UqLMBPzgnEP5nfh1CKS8KhCB0mS7PA==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@internationalized/date": "^3.10.1",
 				"@react-aria/i18n": "^3.12.14",
@@ -7445,6 +7475,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -7454,6 +7485,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/checkbox/-/checkbox-3.16.3.tgz",
 			"integrity": "sha512-2p1haCUtERo5XavBAWNaX//dryNVnOOWfSKyzLs4UiCZR/NL0ttN+Nu/i445q0ipjLqZ6bBJtx0g0NNrubbU7Q==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/form": "^3.1.3",
 				"@react-aria/interactions": "^3.26.0",
@@ -7477,6 +7509,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -7486,6 +7519,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/collections/-/collections-3.0.1.tgz",
 			"integrity": "sha512-C8KBQGXzVefR4I+hQmkb10t09Jt1Ivl12qgQKshmT0hV2yBESXEYWMZUxV4ggOgWDreAgCtr+Ho3X+7MzBQT8Q==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/interactions": "^3.26.0",
 				"@react-aria/ssr": "^3.9.10",
@@ -7504,6 +7538,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -7513,6 +7548,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/color/-/color-3.1.3.tgz",
 			"integrity": "sha512-EHzsFbqzFrO1/3irEa8E8wawlQg7hRd4/Jscvl9zhplAcrWFd6L5TWl8463Z6h0J6zN1eH9T2QDEn6rivDLkkg==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/i18n": "^3.12.14",
 				"@react-aria/interactions": "^3.26.0",
@@ -7538,6 +7574,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -7547,6 +7584,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/combobox/-/combobox-3.14.1.tgz",
 			"integrity": "sha512-wuP/4UQrGsYXLw1Gk8G/FcnUlHuoViA9G6w3LhtUgu5Q3E5DvASJalxej3NtyYU+4w4epD1gJidzosAL0rf8Ug==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/focus": "^3.21.3",
 				"@react-aria/i18n": "^3.12.14",
@@ -7575,6 +7613,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -7584,6 +7623,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/datepicker/-/datepicker-3.15.3.tgz",
 			"integrity": "sha512-0KkLYeLs+IubHXb879n8dzzKU/NWcxC9DXtv7M/ofL7vAvMSTmaceYJcMW+2gGYhJVpyYz8B6bk0W7kTxgB3jg==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@internationalized/date": "^3.10.1",
 				"@internationalized/number": "^3.6.5",
@@ -7614,6 +7654,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -7623,6 +7664,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/dialog/-/dialog-3.5.32.tgz",
 			"integrity": "sha512-2puMjsJS2FtB8LiFuQDAdBSU4dt3lqdJn4FWt/8GL6l91RZBqp2Dnm5Obuee6rV2duNJZcSAUWsQZ/S1iW8Y2g==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/interactions": "^3.26.0",
 				"@react-aria/overlays": "^3.31.0",
@@ -7641,6 +7683,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -7650,6 +7693,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/disclosure/-/disclosure-3.1.1.tgz",
 			"integrity": "sha512-4k8Y3CZEl+Qhou0fH7Sj7BbzvwAfi1JDL+hG7U20ZL5+MJ/VbDYuYX2gYK2KqdlbeuuzGcov3ZFQbyIVHMY+/A==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/ssr": "^3.9.10",
 				"@react-aria/utils": "^3.32.0",
@@ -7667,6 +7711,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -7676,6 +7721,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/dnd/-/dnd-3.11.4.tgz",
 			"integrity": "sha512-dBrnM33Kmk76F+Pknh2WfSLIX4dsYwFzWJUIABJCPmPc80hTG0so7mfqH45ba759/6ERMfXXoodZPLtypOjYPg==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@internationalized/string": "^3.2.7",
 				"@react-aria/i18n": "^3.12.14",
@@ -7699,6 +7745,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -7708,6 +7755,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.21.3.tgz",
 			"integrity": "sha512-FsquWvjSCwC2/sBk4b+OqJyONETUIXQ2vM0YdPAuC+QFQh2DT6TIBo6dOZVSezlhudDla69xFBd6JvCFq1AbUw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/interactions": "^3.26.0",
 				"@react-aria/utils": "^3.32.0",
@@ -7725,6 +7773,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -7734,6 +7783,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/form/-/form-3.1.3.tgz",
 			"integrity": "sha512-HAKnPjMiqTxoGLVbfZyGYcZQ1uu6aSeCi9ODmtZuKM5DWZZnTUjDmM1i2L6IXvF+d1kjyApyJC7VTbKZ8AI77g==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/interactions": "^3.26.0",
 				"@react-aria/utils": "^3.32.0",
@@ -7751,6 +7801,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -7760,6 +7811,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/grid/-/grid-3.14.6.tgz",
 			"integrity": "sha512-xagBKHNPu4Ovt/I5He7T/oIEq82MDMSrRi5Sw3oxSCwwtZpv+7eyKRSrFz9vrNUzNgWCcx5VHLE660bLdeVNDQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/focus": "^3.21.3",
 				"@react-aria/i18n": "^3.12.14",
@@ -7785,6 +7837,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -7794,6 +7847,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/gridlist/-/gridlist-3.14.2.tgz",
 			"integrity": "sha512-c51ip0bc/lKppfrPNFHbWu1n/r0NHd9Xl114904cDxuRcElJ3H/V/3e3U9HyDy+4xioiXZIdZ75CNxtEoTmrxw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/focus": "^3.21.3",
 				"@react-aria/grid": "^3.14.6",
@@ -7816,6 +7870,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -7825,6 +7880,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.12.14.tgz",
 			"integrity": "sha512-zYvs1FlLamFD49uneX3i5mPHrAsB3OjVpSWApTcPw8ydxOaphQDp/Q1aqrbcxlrQCcxZdXWHuvLlbkNR4+8jzw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@internationalized/date": "^3.10.1",
 				"@internationalized/message": "^3.1.8",
@@ -7845,6 +7901,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -7854,6 +7911,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.26.0.tgz",
 			"integrity": "sha512-AAEcHiltjfbmP1i9iaVw34Mb7kbkiHpYdqieWufldh4aplWgsF11YQZOfaCJW4QoR2ML4Zzoa9nfFwLXA52R7Q==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/ssr": "^3.9.10",
 				"@react-aria/utils": "^3.32.0",
@@ -7871,6 +7929,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -7880,6 +7939,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/label/-/label-3.7.23.tgz",
 			"integrity": "sha512-dRkuCJfsyBHPTq3WOJVHNRvNyQL4cRRLELmjYfUX9/jQKIsUW2l71YnUHZTRCSn2ZjhdAcdwq96fNcQo0hncBQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/utils": "^3.32.0",
 				"@react-types/shared": "^3.32.1",
@@ -7895,6 +7955,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -7904,6 +7965,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/landmark/-/landmark-3.0.8.tgz",
 			"integrity": "sha512-xuY8kYxCrF9C0h0Pj2lZHoxCidNfQ/SrkYWXuiN+LuBTJGCmPVif93gt7TklQ0rKJ+pKJsUgh8AC0pgwI3QP7A==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/utils": "^3.32.0",
 				"@react-types/shared": "^3.32.1",
@@ -7920,6 +7982,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -7929,6 +7992,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/link/-/link-3.8.7.tgz",
 			"integrity": "sha512-TOC6Hf/x3N0P8SLR1KD/dGiJ9PmwAq8H57RiwbFbdINnG/HIvIQr5MxGTjwBvOOWcJu9brgWL5HkQaZK7Q/4Yw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/interactions": "^3.26.0",
 				"@react-aria/utils": "^3.32.0",
@@ -7946,6 +8010,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -7955,6 +8020,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/listbox/-/listbox-3.15.1.tgz",
 			"integrity": "sha512-81iDLFhmPXvLOtkI0SKzgrngfzwfR2o9oFDAYRfpYCOxgT7jjh8SaB4wCteJXRiMwymRGmgyTvD4yxWTluEeXA==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/interactions": "^3.26.0",
 				"@react-aria/label": "^3.7.23",
@@ -7976,6 +8042,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -7985,6 +8052,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/live-announcer/-/live-announcer-3.4.4.tgz",
 			"integrity": "sha512-PTTBIjNRnrdJOIRTDGNifY2d//kA7GUAwRFJNOEwSNG4FW+Bq9awqLiflw0JkpyB0VNIwou6lqKPHZVLsGWOXA==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@swc/helpers": "^0.5.0"
 			}
@@ -7994,6 +8062,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8003,6 +8072,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/menu/-/menu-3.19.4.tgz",
 			"integrity": "sha512-0A0DUEkEvZynmaD3zktHavM+EmgZSR/ht+g1ExS2jXe73CegA+dbSRfPl9eIKcHxaRrWOV96qMj2pTf0yWTBDg==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/focus": "^3.21.3",
 				"@react-aria/i18n": "^3.12.14",
@@ -8029,6 +8099,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8038,6 +8109,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/meter/-/meter-3.4.28.tgz",
 			"integrity": "sha512-elACITUBOf4Dp+BQ2aIgHIe58fjWYjspxhVcE5BMiqePktOfRkpb9ESj8nWcNXO8eqCYwrFJpElHvXkjYLWemw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/progress": "^3.4.28",
 				"@react-types/meter": "^3.4.13",
@@ -8054,6 +8126,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8063,6 +8136,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/numberfield/-/numberfield-3.12.3.tgz",
 			"integrity": "sha512-70LRXWPEuj2X8mbQXUx6l6We+RGs49Kb+2eUiSSLArHK4RvTWJWEfSjHL5IHHJ+j2AkbORdryD7SR3gcXSX+5w==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/i18n": "^3.12.14",
 				"@react-aria/interactions": "^3.26.0",
@@ -8086,6 +8160,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8095,6 +8170,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.31.0.tgz",
 			"integrity": "sha512-Vq41X1s8XheGIhGbbuqRJslJEX08qmMVX//dwuBaFX9T18mMR04tumKOMxp8Lz+vqwdGLvjNUYDMcgolL+AMjw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/focus": "^3.21.3",
 				"@react-aria/i18n": "^3.12.14",
@@ -8118,6 +8194,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8127,6 +8204,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/progress/-/progress-3.4.28.tgz",
 			"integrity": "sha512-3NUUAu+rwf1M7pau9WFkrxe/PlBPiqCl/1maGU7iufVveHnz+SVVqXdNkjYx+WkPE0ViwG86Zx6OU4AYJ1pjNw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/i18n": "^3.12.14",
 				"@react-aria/label": "^3.7.23",
@@ -8145,6 +8223,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8154,6 +8233,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/radio/-/radio-3.12.3.tgz",
 			"integrity": "sha512-noucVX++9J3VYWg7dB+r09NVX8UZSR1TWUMCbT/MffzhltOsmiLJVvgJ0uEeeVRuu3+ZM63jOshrzG89anX4TQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/focus": "^3.21.3",
 				"@react-aria/form": "^3.1.3",
@@ -8176,6 +8256,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8185,6 +8266,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/searchfield/-/searchfield-3.8.10.tgz",
 			"integrity": "sha512-1wMoSjXoekcETC4ZP5AUcWoaK96FssVuF9MgqQNqE5VnauQDjZBpPCfz6GSZwRHTGwoqb7CI4iEi7433kd50xg==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/i18n": "^3.12.14",
 				"@react-aria/textfield": "^3.18.3",
@@ -8205,6 +8287,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8214,6 +8297,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/select/-/select-3.17.1.tgz",
 			"integrity": "sha512-jPMuaSp+4SbdE9G5UrrTer2CPbbUnUSLd8I2wgRgGcyk3wFw9DtnUNfms+UBA/2SrVnAEJ6KCQAI0oiMK2m+tQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/form": "^3.1.3",
 				"@react-aria/i18n": "^3.12.14",
@@ -8240,6 +8324,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8249,6 +8334,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/selection/-/selection-3.27.0.tgz",
 			"integrity": "sha512-4zgreuCu4QM4t2U7aF3mbMvIKCEkTEo6h6nGJvbyZALZ/eFtLTvUiV8/5CGDJRLGvgMvi3XxUeF9PZbpk5nMJg==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/focus": "^3.21.3",
 				"@react-aria/i18n": "^3.12.14",
@@ -8268,6 +8354,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8277,6 +8364,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/separator/-/separator-3.4.14.tgz",
 			"integrity": "sha512-a32OB5HMAmXEdExyDvsadsnlmNcVxxpx3tt+Jxxl6H9CHsLO+Ak077KGFJteGVg4bTfhWGAgczOsnvIioR88xw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/utils": "^3.32.0",
 				"@react-types/shared": "^3.32.1",
@@ -8292,6 +8380,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8301,6 +8390,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/slider/-/slider-3.8.3.tgz",
 			"integrity": "sha512-tOZVH+wLt3ik0C3wyuXqHL9fvnQ5S+/tHMYB7z8aZV5cEe36Gt4efBILphlA7ChkL/RvpHGK2AGpEGxvuEQIuQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/i18n": "^3.12.14",
 				"@react-aria/interactions": "^3.26.0",
@@ -8321,6 +8411,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8330,6 +8421,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/spinbutton/-/spinbutton-3.7.0.tgz",
 			"integrity": "sha512-FOyH94BZp+jNhUJuZqXSubQZDNQEJyW/J19/gwCxQvQvxAP79dhDFshh1UtrL4EjbjIflmaOes+sH/XEHUnJVA==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/i18n": "^3.12.14",
 				"@react-aria/live-announcer": "^3.4.4",
@@ -8348,6 +8440,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8357,6 +8450,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.10.tgz",
 			"integrity": "sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@swc/helpers": "^0.5.0"
 			},
@@ -8372,6 +8466,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8381,6 +8476,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/switch/-/switch-3.7.9.tgz",
 			"integrity": "sha512-RZtuFRXews0PBx8Fc2R/kqaIARD5YIM5uYtmwnWfY7y5bEsBGONxp0d+m2vDyY7yk+VNpVFBdwewY9GbZmH1CA==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/toggle": "^3.12.3",
 				"@react-stately/toggle": "^3.9.3",
@@ -8398,6 +8494,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8407,6 +8504,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/table/-/table-3.17.9.tgz",
 			"integrity": "sha512-Jby561E1YfzoRgtp+RQuhDz4vnxlcqol9RTgQQ7FWXC2IcN9Pny1COU34LkA1cL9VeB9LJ0+qfMhGw4aAwaUmw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/focus": "^3.21.3",
 				"@react-aria/grid": "^3.14.6",
@@ -8434,6 +8532,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8443,6 +8542,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/tabs/-/tabs-3.10.9.tgz",
 			"integrity": "sha512-2+FNd7Ohr3hrEgYrKdZW0FWbgybzTVZft6tw95oQ2+9PnjdDVdtzHliI+8HY8jzb4hTf4bU7O8n+s/HBlCBSIw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/focus": "^3.21.3",
 				"@react-aria/i18n": "^3.12.14",
@@ -8463,6 +8563,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8472,6 +8573,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/tag/-/tag-3.7.3.tgz",
 			"integrity": "sha512-fonqGFxhpnlIDOz3u38y4+MG5wyAef9+oDybsCKaJ57K+D4BTvSmpGBemN/mcaxdabnYfyhasCm0H91Q9XRcCA==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/gridlist": "^3.14.2",
 				"@react-aria/i18n": "^3.12.14",
@@ -8494,6 +8596,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8503,6 +8606,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/textfield/-/textfield-3.18.3.tgz",
 			"integrity": "sha512-ehiSHOKuKCwPdxFe7wGE0QJlSeeJR4iJuH+OdsYVlZzYbl9J/uAdGbpsj/zPhNtBo1g/Td76U8TtTlYRZ8lUZw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/form": "^3.1.3",
 				"@react-aria/interactions": "^3.26.0",
@@ -8524,6 +8628,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8533,6 +8638,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/toast/-/toast-3.0.9.tgz",
 			"integrity": "sha512-2sRitczXl5VEwyq97o8TVvq3bIqLA7EfA7dhDPkYlHGa4T1vzKkhNqgkskKd9+Tw7gqeFRFjnokh+es9jkM11g==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/i18n": "^3.12.14",
 				"@react-aria/interactions": "^3.26.0",
@@ -8553,6 +8659,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8562,6 +8669,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/toggle/-/toggle-3.12.3.tgz",
 			"integrity": "sha512-mciUbeVP99fRObnH5qLFrkKXX+5VKeV6BhFJlmz1eo3ltR/0xZKnUcycA2CGzmqtB70w09CAhr8NMEnpNH8dwQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/interactions": "^3.26.0",
 				"@react-aria/utils": "^3.32.0",
@@ -8580,6 +8688,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8589,6 +8698,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/toolbar/-/toolbar-3.0.0-beta.21.tgz",
 			"integrity": "sha512-yRCk/GD8g+BhdDgxd3I0a0c8Ni4Wyo6ERzfSoBkPkwQ4X2E2nkopmraM9D0fXw4UcIr4bnmvADzkHXtBN0XrBg==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/focus": "^3.21.2",
 				"@react-aria/i18n": "^3.12.13",
@@ -8606,6 +8716,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8615,6 +8726,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/tooltip/-/tooltip-3.9.0.tgz",
 			"integrity": "sha512-2O1DXEV8/+DeUq9dIlAfaNa7lSG+7FCZDuF+sNiPYnZM6tgFOrsId26uMF5EuwpVfOvXSSGnq0+6Ma2On7mZPg==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/interactions": "^3.26.0",
 				"@react-aria/utils": "^3.32.0",
@@ -8633,6 +8745,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8642,6 +8755,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/tree/-/tree-3.1.5.tgz",
 			"integrity": "sha512-FAq7pAhRVrWU0U/8QbQIJfBqHuoCD+F9rR9ruoM3oL0vVIZxVN57ak/dhyge3EGlraTl9vzFi6IRceXiMuk5kg==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/gridlist": "^3.14.2",
 				"@react-aria/i18n": "^3.12.14",
@@ -8662,6 +8776,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8671,6 +8786,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.32.0.tgz",
 			"integrity": "sha512-/7Rud06+HVBIlTwmwmJa2W8xVtgxgzm0+kLbuFooZRzKDON6hhozS1dOMR/YLMxyJOaYOTpImcP4vRR9gL1hEg==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/ssr": "^3.9.10",
 				"@react-stately/flags": "^3.1.2",
@@ -8689,6 +8805,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8698,6 +8815,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/virtualizer/-/virtualizer-4.1.11.tgz",
 			"integrity": "sha512-eYL//bX11Aox4Eh1BSZFX4I/4EdyVVWLjmpW+Y5qy4WajNrowjiuJJM7Fp1rQBlOAVuz0KbaDmFhiU3Z3rWjsw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/i18n": "^3.12.14",
 				"@react-aria/interactions": "^3.26.0",
@@ -8716,6 +8834,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8725,6 +8844,7 @@
 			"resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.29.tgz",
 			"integrity": "sha512-1joCP+MHBLd+YA6Gb08nMFfDBhOF0Kh1gR1SA8zoxEB5RMfQEEkufIB8k0GGwvHGSCK3gFyO8UAVsD0+rRYEyg==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-aria/interactions": "^3.26.0",
 				"@react-aria/utils": "^3.32.0",
@@ -8741,6 +8861,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8750,6 +8871,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/autocomplete/-/autocomplete-3.0.0-beta.3.tgz",
 			"integrity": "sha512-YfP/TrvkOCp6j7oqpZxJSvmSeXn+XtbKSOiBOuo+m2zCIhW2ncThmDB9uAUOkpmikDv/LkGKni40RQE8USdGdA==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-stately/utils": "^3.10.8",
 				"@swc/helpers": "^0.5.0"
@@ -8763,6 +8885,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8772,6 +8895,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/calendar/-/calendar-3.9.1.tgz",
 			"integrity": "sha512-q0Q8fivpQa1rcLg5daUVxwVj1smCp1VnpX9A5Q5PkI9lH9x+xdS0Y6eOqb8Ih3TKBDkx9/oEZonOX7RYNIzSig==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@internationalized/date": "^3.10.1",
 				"@react-stately/utils": "^3.11.0",
@@ -8788,6 +8912,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8797,6 +8922,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/checkbox/-/checkbox-3.7.3.tgz",
 			"integrity": "sha512-ve2K+uWT+NRM1JMn+tkWJDP2iBAaWvbZ0TbSXs371IUcTWaNW61HygZ+UFOB/frAZGloazEKGqAsX5XjFpgB9w==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-stately/form": "^3.2.2",
 				"@react-stately/utils": "^3.11.0",
@@ -8813,6 +8939,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8822,6 +8949,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.12.8.tgz",
 			"integrity": "sha512-AceJYLLXt1Y2XIcOPi6LEJSs4G/ubeYW3LqOCQbhfIgMaNqKfQMIfagDnPeJX9FVmPFSlgoCBxb1pTJW2vjCAQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/shared": "^3.32.1",
 				"@swc/helpers": "^0.5.0"
@@ -8835,6 +8963,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8844,6 +8973,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/color/-/color-3.9.3.tgz",
 			"integrity": "sha512-H5lQgl07upsI7+cxTwYo639ziDDG1DFgOtq5pmC4Nxi8uNl8sR/8YeLaYuxyJiVkj2VLHBYRQ3+JcxrdduFvPQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@internationalized/number": "^3.6.5",
 				"@internationalized/string": "^3.2.7",
@@ -8864,6 +8994,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8873,6 +9004,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/combobox/-/combobox-3.12.1.tgz",
 			"integrity": "sha512-RwfTTYgKJ9raIY+7grZ5DbfVRSO5pDjo/ur2VN/28LZzM0eOQrLFQ00vpBmY7/R64sHRpcXLDxpz5cqpKCdvTw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-stately/collections": "^3.12.8",
 				"@react-stately/form": "^3.2.2",
@@ -8892,6 +9024,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8901,6 +9034,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/data/-/data-3.15.0.tgz",
 			"integrity": "sha512-ocP39NQQkrbtHVCPsqltNncpEHaONyYX/8s2UK9xeLRc+55NtDI2RZDKTUf/mi6H2SHxzEwLMQH8hWtEwC55mQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/shared": "^3.32.1",
 				"@swc/helpers": "^0.5.0"
@@ -8914,6 +9048,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8923,6 +9058,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/datepicker/-/datepicker-3.15.3.tgz",
 			"integrity": "sha512-RDYoz1R/EkCyxHYewb58T7DngU3gl6CnQL7xiWiDlayPnstGaanoQ3yCZGJaIQwR8PrKdNbQwXF9NlSmj8iCOw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@internationalized/date": "^3.10.1",
 				"@internationalized/string": "^3.2.7",
@@ -8942,6 +9078,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8951,6 +9088,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/disclosure/-/disclosure-3.0.9.tgz",
 			"integrity": "sha512-M3HKsXqdzYKQf1TpnQRLZ6+/b8E3Nba3oOuY0OW5NnM5dZWSnXuj8foBQJT118FdLgMjpfBdPIkUvnaGiDCs5w==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-stately/utils": "^3.11.0",
 				"@react-types/shared": "^3.32.1",
@@ -8965,6 +9103,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8974,6 +9113,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/dnd/-/dnd-3.7.2.tgz",
 			"integrity": "sha512-tr5nNgrLMn5GV308K1f010XUZ2j8CApqHrrcjg5fa2AnpO2gECcOf+UEnAvoFNUsvknje4iPX8y0/0No2ZHsgA==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-stately/selection": "^3.20.7",
 				"@react-types/shared": "^3.32.1",
@@ -8988,6 +9128,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -8997,6 +9138,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.2.tgz",
 			"integrity": "sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@swc/helpers": "^0.5.0"
 			}
@@ -9006,6 +9148,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -9015,6 +9158,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/form/-/form-3.2.2.tgz",
 			"integrity": "sha512-soAheOd7oaTO6eNs6LXnfn0tTqvOoe3zN9FvtIhhrErKz9XPc5sUmh3QWwR45+zKbitOi1HOjfA/gifKhZcfWw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/shared": "^3.32.1",
 				"@swc/helpers": "^0.5.0"
@@ -9028,6 +9172,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -9037,6 +9182,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/grid/-/grid-3.11.7.tgz",
 			"integrity": "sha512-SqzBSxUTFZKLZicfXDK+M0A3gh07AYK1pmU/otcq2cjZ0nSC4CceKijQ2GBZnl+YGcGHI1RgkhpLP6ZioMYctQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-stately/collections": "^3.12.8",
 				"@react-stately/selection": "^3.20.7",
@@ -9053,6 +9199,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -9062,6 +9209,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/layout/-/layout-4.5.2.tgz",
 			"integrity": "sha512-quAzYkshApkv1vChz2NXBaLTC7ihJUmv3ijqJBHCkZSY6qq+1qnc4aGespDF1f3mPhmpGswTFGXFImFTAYfi5g==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-stately/collections": "^3.12.8",
 				"@react-stately/table": "^3.15.2",
@@ -9081,6 +9229,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -9090,6 +9239,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/list/-/list-3.13.2.tgz",
 			"integrity": "sha512-dGFALuQWNNOkv7W12qSsXLF4mJHLeWeK2hVvdyj4SI8Vxku+BOfaVKuW3sn3mNiixI1dM/7FY2ip4kK+kv27vw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-stately/collections": "^3.12.8",
 				"@react-stately/selection": "^3.20.7",
@@ -9106,6 +9256,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -9115,6 +9266,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/menu/-/menu-3.9.9.tgz",
 			"integrity": "sha512-moW5JANxMxPilfR0SygpCWCZe7Ef09oadgzTZthRymNRv0PXVS9ad4wd1EkwuMvPH/n0uZLZE2s8hNyFDgyqPA==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-stately/overlays": "^3.6.21",
 				"@react-types/menu": "^3.10.5",
@@ -9130,6 +9282,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -9139,6 +9292,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/numberfield/-/numberfield-3.10.3.tgz",
 			"integrity": "sha512-40g/oyVcWoEaLqkr61KuHZzQVLLXFi3oa2K8XLnb6o+859SM4TX3XPNqL6eNQjXSKoJO5Hlgpqhee9j+VDbGog==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@internationalized/number": "^3.6.5",
 				"@react-stately/form": "^3.2.2",
@@ -9155,6 +9309,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -9164,6 +9319,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.21.tgz",
 			"integrity": "sha512-7f25H1PS2g+SNvuWPEW30pSGqYNHxesCP4w+1RcV/XV1oQI7oP5Ji2WfI0QsJEFc9wP/ZO1pyjHNKpfLI3O88g==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-stately/utils": "^3.11.0",
 				"@react-types/overlays": "^3.9.2",
@@ -9178,6 +9334,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -9187,6 +9344,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/radio/-/radio-3.11.3.tgz",
 			"integrity": "sha512-8+Cy0azV1aBWKcBfGHi3nBa285lAS6XhmVw2LfEwxq8DeVKTbJAaCHHwvDoclxDiOAnqzE0pio0QMD8rYISt9g==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-stately/form": "^3.2.2",
 				"@react-stately/utils": "^3.11.0",
@@ -9203,6 +9361,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -9212,6 +9371,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/searchfield/-/searchfield-3.5.17.tgz",
 			"integrity": "sha512-/KExpJt6EGyuLxy/PRQJlETQxJGw8tRxVws6qF1lankN49Os2UhFEWi7ogbMCOWN67gIgevhZRdzmJnuov6BEQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-stately/utils": "^3.11.0",
 				"@react-types/searchfield": "^3.6.6",
@@ -9226,6 +9386,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -9235,6 +9396,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/select/-/select-3.9.0.tgz",
 			"integrity": "sha512-eNE33zVYpVdCPKRPGYyViN3LnEq82e1wjBIrs9T7Vo4EBnJeT57pqMZpalTPk7qsA+861t14Qrj7GnUd+YbEXw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-stately/form": "^3.2.2",
 				"@react-stately/list": "^3.13.2",
@@ -9253,6 +9415,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -9262,6 +9425,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/selection/-/selection-3.20.7.tgz",
 			"integrity": "sha512-NkiRsNCfORBIHNF1bCavh4Vvj+Yd5NffE10iXtaFuhF249NlxLynJZmkcVCqNP9taC2pBIHX00+9tcBgxhG+mA==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-stately/collections": "^3.12.8",
 				"@react-stately/utils": "^3.11.0",
@@ -9277,6 +9441,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -9286,6 +9451,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/slider/-/slider-3.7.3.tgz",
 			"integrity": "sha512-9QGnQNXFAH52BzxtU7weyOV/VV7/so6uIvE8VOHfc6QR3GMBM/kJvqBCTWZfQ0pxDIsRagBQDD/tjB09ixTOzg==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-stately/utils": "^3.11.0",
 				"@react-types/shared": "^3.32.1",
@@ -9301,6 +9467,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -9310,6 +9477,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/table/-/table-3.15.2.tgz",
 			"integrity": "sha512-vgEArBN5ocqsQdeORBj6xk8acu5iFnd/CyXEQKl0R5RyuYuw0ms8UmFHvs8Fv1HONehPYg+XR4QPliDFPX8R9A==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-stately/collections": "^3.12.8",
 				"@react-stately/flags": "^3.1.2",
@@ -9330,6 +9498,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -9339,6 +9508,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/tabs/-/tabs-3.8.7.tgz",
 			"integrity": "sha512-ETZEzg7s9F2SCvisZ2cCpLx6XBHqdvVgDGU5l3C3s9zBKBr6lgyLFt61IdGW8XXZRUvw4mMGT6tGQbXeGvR0Wg==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-stately/list": "^3.13.2",
 				"@react-types/shared": "^3.32.1",
@@ -9354,6 +9524,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -9363,6 +9534,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/toast/-/toast-3.1.2.tgz",
 			"integrity": "sha512-HiInm7bck32khFBHZThTQaAF6e6/qm57F4mYRWdTq8IVeGDzpkbUYibnLxRhk0UZ5ybc6me+nqqPkG/lVmM42Q==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@swc/helpers": "^0.5.0",
 				"use-sync-external-store": "^1.4.0"
@@ -9376,6 +9548,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -9385,6 +9558,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/toggle/-/toggle-3.9.3.tgz",
 			"integrity": "sha512-G6aA/aTnid/6dQ9dxNEd7/JqzRmVkVYYpOAP+l02hepiuSmFwLu4nE98i4YFBQqFZ5b4l01gMrS90JGL7HrNmw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-stately/utils": "^3.11.0",
 				"@react-types/checkbox": "^3.10.2",
@@ -9400,6 +9574,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -9409,6 +9584,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/tooltip/-/tooltip-3.5.9.tgz",
 			"integrity": "sha512-YwqtxFqQFfJtbeh+axHVGAfz9XHf73UaBndHxSbVM/T5c1PfI2yOB39T2FOU5fskZ2VMO3qTDhiXmFgGbGYSfQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-stately/overlays": "^3.6.21",
 				"@react-types/tooltip": "^3.5.0",
@@ -9423,6 +9599,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -9432,6 +9609,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/tree/-/tree-3.9.4.tgz",
 			"integrity": "sha512-Re1fdEiR0hHPcEda+7ecw+52lgGfFW0MAEDzFg9I6J/t8STQSP+1YC0VVVkv2xRrkLbKLPqggNKgmD8nggecnw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-stately/collections": "^3.12.8",
 				"@react-stately/selection": "^3.20.7",
@@ -9448,6 +9626,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -9457,6 +9636,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.11.0.tgz",
 			"integrity": "sha512-8LZpYowJ9eZmmYLpudbo/eclIRnbhWIJZ994ncmlKlouNzKohtM8qTC6B1w1pwUbiwGdUoyzLuQbeaIor5Dvcw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@swc/helpers": "^0.5.0"
 			},
@@ -9469,6 +9649,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -9478,6 +9659,7 @@
 			"resolved": "https://registry.npmjs.org/@react-stately/virtualizer/-/virtualizer-4.4.4.tgz",
 			"integrity": "sha512-ri8giqXSZOrznZDCCOE4U36wSkOhy+hrFK7yo/YVcpxTqqp3d3eisfKMqbDsgqBW+XTHycTU/xeAf0u9NqrfpQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/shared": "^3.32.1",
 				"@swc/helpers": "^0.5.0"
@@ -9492,6 +9674,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -9501,6 +9684,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/autocomplete/-/autocomplete-3.0.0-alpha.35.tgz",
 			"integrity": "sha512-Wv5eU4WixfJ4M+fqvJUQqliWPbw7/VldRlgoJhqAlPwlNyLlHYwv5tlA64AySDXHGcSMIbzcS38LaHm44wt0AQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/combobox": "^3.13.9",
 				"@react-types/searchfield": "^3.6.6",
@@ -9515,6 +9699,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/breadcrumbs/-/breadcrumbs-3.7.17.tgz",
 			"integrity": "sha512-IhvVTcfli5o/UDlGACXxjlor2afGlMQA8pNR3faH0bBUay1Fmm3IWktVw9Xwmk+KraV2RTAg9e+E6p8DOQZfiw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/link": "^3.6.5",
 				"@react-types/shared": "^3.32.1"
@@ -9528,6 +9713,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.14.1.tgz",
 			"integrity": "sha512-D8C4IEwKB7zEtiWYVJ3WE/5HDcWlze9mLWQ5hfsBfpePyWCgO3bT/+wjb/7pJvcAocrkXo90QrMm85LcpBtrpg==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/shared": "^3.32.1"
 			},
@@ -9540,6 +9726,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/calendar/-/calendar-3.8.1.tgz",
 			"integrity": "sha512-B0UuitMP7YkArBAQldwSZSNL2WwazNGCG+lp6yEDj831NrH9e36/jcjv1rObQ9ZMS6uDX9LXu5C8V5RFwGQabA==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@internationalized/date": "^3.10.1",
 				"@react-types/shared": "^3.32.1"
@@ -9553,6 +9740,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/checkbox/-/checkbox-3.10.2.tgz",
 			"integrity": "sha512-ktPkl6ZfIdGS1tIaGSU/2S5Agf2NvXI9qAgtdMDNva0oLyAZ4RLQb6WecPvofw1J7YKXu0VA5Mu7nlX+FM2weQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/shared": "^3.32.1"
 			},
@@ -9565,6 +9753,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/color/-/color-3.1.2.tgz",
 			"integrity": "sha512-NP0TAY3j4tlMztOp/bBfMlPwC9AQKTjSiTFmc2oQNkx5M4sl3QpPqFPosdt7jZ8M4nItvfCWZrlZGjST4SB83A==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/shared": "^3.32.1",
 				"@react-types/slider": "^3.8.2"
@@ -9578,6 +9767,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/combobox/-/combobox-3.13.10.tgz",
 			"integrity": "sha512-Wo4iix++ID6JzoH9eD7ddGUlirQiGpN/VQc3iFjnaTXiJ/cj3v+1oGsDGCZZTklTVeUMU7SRBfMhMgxHHIYLXA==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/shared": "^3.32.1"
 			},
@@ -9590,6 +9780,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/datepicker/-/datepicker-3.13.3.tgz",
 			"integrity": "sha512-OTRa3banGxcUQKRTLUzr0zTVUMUL+Az1BWARCYQ+8Z/dlkYXYUW0fnS5I0pUEqihgai15KxiY13U0gAqbNSfcA==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@internationalized/date": "^3.10.1",
 				"@react-types/calendar": "^3.8.1",
@@ -9605,6 +9796,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/dialog/-/dialog-3.5.22.tgz",
 			"integrity": "sha512-smSvzOcqKE196rWk0oqJDnz+ox5JM5+OT0PmmJXiUD4q7P5g32O6W5Bg7hMIFUI9clBtngo8kLaX2iMg+GqAzg==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/overlays": "^3.9.2",
 				"@react-types/shared": "^3.32.1"
@@ -9618,6 +9810,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/form/-/form-3.7.16.tgz",
 			"integrity": "sha512-Sb7KJoWEaQ/e4XIY+xRbjKvbP1luome98ZXevpD+zVSyGjEcfIroebizP6K1yMHCWP/043xH6GUkgEqWPoVGjg==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/shared": "^3.32.1"
 			},
@@ -9630,6 +9823,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/grid/-/grid-3.3.6.tgz",
 			"integrity": "sha512-vIZJlYTii2n1We9nAugXwM2wpcpsC6JigJFBd6vGhStRdRWRoU4yv1Gc98Usbx0FQ/J7GLVIgeG8+1VMTKBdxw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/shared": "^3.32.1"
 			},
@@ -9642,6 +9836,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/link/-/link-3.6.5.tgz",
 			"integrity": "sha512-+I2s3XWBEvLrzts0GnNeA84mUkwo+a7kLUWoaJkW0TOBDG7my95HFYxF9WnqKye7NgpOkCqz4s3oW96xPdIniQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/shared": "^3.32.1"
 			},
@@ -9654,6 +9849,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/listbox/-/listbox-3.7.4.tgz",
 			"integrity": "sha512-p4YEpTl/VQGrqVE8GIfqTS5LkT5jtjDTbVeZgrkPnX/fiPhsfbTPiZ6g0FNap4+aOGJFGEEZUv2q4vx+rCORww==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/shared": "^3.32.1"
 			},
@@ -9666,6 +9862,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/menu/-/menu-3.10.5.tgz",
 			"integrity": "sha512-HBTrKll2hm0VKJNM4ubIv1L9MNo8JuOnm2G3M+wXvb6EYIyDNxxJkhjsqsGpUXJdAOSkacHBDcNh2HsZABNX4A==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/overlays": "^3.9.2",
 				"@react-types/shared": "^3.32.1"
@@ -9679,6 +9876,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/meter/-/meter-3.4.13.tgz",
 			"integrity": "sha512-EiarfbpHcvmeyXvXcr6XLaHkNHuGc4g7fBVEiDPwssFJKKfbUzqnnknDxPjyspqUVRcXC08CokS98J1jYobqDg==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/progress": "^3.5.16"
 			},
@@ -9691,6 +9889,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/numberfield/-/numberfield-3.8.16.tgz",
 			"integrity": "sha512-945F0GsD7K2T293YXhap+2Runl3tZWbnhadXVHFWLbqIKKONZFSZTfLKxQcbFr+bQXr2uh1bVJhYcOiS1l5M+A==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/shared": "^3.32.1"
 			},
@@ -9703,6 +9902,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.9.2.tgz",
 			"integrity": "sha512-Q0cRPcBGzNGmC8dBuHyoPR7N3057KTS5g+vZfQ53k8WwmilXBtemFJPLsogJbspuewQ/QJ3o2HYsp2pne7/iNw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/shared": "^3.32.1"
 			},
@@ -9715,6 +9915,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/progress/-/progress-3.5.16.tgz",
 			"integrity": "sha512-I9tSdCFfvQ7gHJtm90VAKgwdTWXQgVNvLRStEc0z9h+bXBxdvZb+QuiRPERChwFQ9VkK4p4rDqaFo69nDqWkpw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/shared": "^3.32.1"
 			},
@@ -9727,6 +9928,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/radio/-/radio-3.9.2.tgz",
 			"integrity": "sha512-3UcJXu37JrTkRyP4GJPDBU7NmDTInrEdOe+bVzA1j4EegzdkJmLBkLg5cLDAbpiEHB+xIsvbJdx6dxeMuc+H3g==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/shared": "^3.32.1"
 			},
@@ -9739,6 +9941,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/searchfield/-/searchfield-3.6.6.tgz",
 			"integrity": "sha512-cl3itr/fk7wbIQc2Gz5Ie8aVeUmPjVX/mRGS5/EXlmzycAKNYTvqf2mlxwObLndtLISmt7IgNjRRhbUUDI8Ang==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/shared": "^3.32.1",
 				"@react-types/textfield": "^3.12.6"
@@ -9752,6 +9955,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/select/-/select-3.12.0.tgz",
 			"integrity": "sha512-tM3mEbQNotvCJs1gYRFyIeXmXrIBSBLGw7feCIaYSO45IyjCGv8NZwpQWjoKPaWo3GpbHfHMNlWlq3v5QQPIXw==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/shared": "^3.32.1"
 			},
@@ -9764,6 +9968,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.32.1.tgz",
 			"integrity": "sha512-famxyD5emrGGpFuUlgOP6fVW2h/ZaF405G5KDi3zPHzyjAWys/8W6NAVJtNbkCkhedmvL0xOhvt8feGXyXaw5w==",
 			"optional": true,
+			"peer": true,
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
 			}
@@ -9773,6 +9978,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/slider/-/slider-3.8.2.tgz",
 			"integrity": "sha512-MQYZP76OEOYe7/yA2To+Dl0LNb0cKKnvh5JtvNvDnAvEprn1RuLiay8Oi/rTtXmc2KmBa4VdTcsXsmkbbkeN2Q==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/shared": "^3.32.1"
 			},
@@ -9785,6 +9991,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/switch/-/switch-3.5.15.tgz",
 			"integrity": "sha512-r/ouGWQmIeHyYSP1e5luET+oiR7N7cLrAlWsrAfYRWHxqXOSNQloQnZJ3PLHrKFT02fsrQhx2rHaK2LfKeyN3A==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/shared": "^3.32.1"
 			},
@@ -9797,6 +10004,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/table/-/table-3.13.4.tgz",
 			"integrity": "sha512-I/DYiZQl6aNbMmjk90J9SOhkzVDZvyA3Vn3wMWCiajkMNjvubFhTfda5DDf2SgFP5l0Yh6TGGH5XumRv9LqL5Q==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/grid": "^3.3.6",
 				"@react-types/shared": "^3.32.1"
@@ -9810,6 +10018,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/tabs/-/tabs-3.3.20.tgz",
 			"integrity": "sha512-Kjq4PypapdMOVPAQgaFIKH65Kr3YnRvaxBGd6RYizTsqYImQhXoGj6B4lBpjYy4KhfRd4dYS82frHqTGKmBYiA==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/shared": "^3.32.1"
 			},
@@ -9822,6 +10031,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/textfield/-/textfield-3.12.6.tgz",
 			"integrity": "sha512-hpEVKE+M3uUkTjw2WrX1NrH/B3rqDJFUa+ViNK2eVranLY4ZwFqbqaYXSzHupOF3ecSjJJv2C103JrwFvx6TPQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/shared": "^3.32.1"
 			},
@@ -9834,6 +10044,7 @@
 			"resolved": "https://registry.npmjs.org/@react-types/tooltip/-/tooltip-3.5.0.tgz",
 			"integrity": "sha512-o/m1wlKlOD2sLb9vZLWdVkD5LFLHBMLGeeK/bhyUtp0IEdUeKy0ZRTS7pa/A50trov9RvdbzLK79xG8nKNxHew==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-types/overlays": "^3.9.2",
 				"@react-types/shared": "^3.32.1"
@@ -10792,7 +11003,6 @@
 			"integrity": "sha512-/xdLSWxK5QkqG524ONSjvg3V/FkNyCv538OIBdQqPNaAta3AsXj/Bd2FbvR87yMbXO2hFSWiAe/Q6IkVPDw+mw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.19.6",
 				"@svgr/babel-preset": "^6.5.1",
@@ -11082,8 +11292,7 @@
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
 			"integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@types/chai-subset": {
 			"version": "1.3.6",
@@ -11433,7 +11642,6 @@
 			"version": "18.2.79",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.79.tgz",
 			"integrity": "sha512-RwGAGXPl9kSXwdNTafkOEuFrTBD5SA2B3iEB96xi8+xu5ddUa/cpvyVCSNn+asgLCTHkb5ZxN8gbuibYJi4s1w==",
-			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"csstype": "^3.0.2"
@@ -11658,7 +11866,6 @@
 			"integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
 			"dev": true,
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "5.62.0",
 				"@typescript-eslint/types": "5.62.0",
@@ -11845,7 +12052,8 @@
 			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
 			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@vitejs/plugin-react": {
 			"version": "3.1.0",
@@ -11888,7 +12096,6 @@
 			"integrity": "sha512-wfuhghldD5QHLYpS46GK8Ru8P3XcMrWvFjRQD21KNzc9Y/qtJsqoC8KmT6xWVkMNw4oHYixpo3a4ZySRJdserw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"sirv": "^2.0.2"
 			}
@@ -12136,7 +12343,6 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -12210,7 +12416,6 @@
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -13116,7 +13321,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -13555,7 +13759,8 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
 			"integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/cliui": {
 			"version": "7.0.4",
@@ -14393,8 +14598,7 @@
 			"version": "1.11.19",
 			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
 			"integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/debug": {
 			"version": "4.4.3",
@@ -15176,7 +15380,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
@@ -15276,7 +15479,6 @@
 			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint/eslintrc": "^1.2.3",
 				"@humanwhocodes/config-array": "^0.9.2",
@@ -15330,7 +15532,6 @@
 			"integrity": "sha512-oKMhGv3ihGbCIimCAjqkdzx2Q+jthoqnXSP+d86M9tptwugycmTFdVR4IpLgq2c4SHifbwO90z2fQ8/Aio73yw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
 			},
@@ -15500,7 +15701,6 @@
 			"integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"array-includes": "^3.1.6",
 				"array.prototype.flat": "^1.3.1",
@@ -17591,6 +17791,7 @@
 			"resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
 			"integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@formatjs/ecma402-abstract": "2.3.6",
 				"@formatjs/fast-memoize": "2.2.7",
@@ -18253,7 +18454,6 @@
 			"integrity": "sha512-XvK65feuEFGZT8OO0fB/QAQS+LGHvQpaadkH5p47/j3Ocqq3xf2pK9R+G0GzgfuhXVxEv76qCOOcMb5efLk6PA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jest/core": "^29.4.3",
 				"@jest/types": "^29.4.3",
@@ -19403,6 +19603,7 @@
 			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@jest/types": "30.2.0",
 				"@types/node": "*",
@@ -19421,6 +19622,7 @@
 			"integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@sinclair/typebox": "^0.34.0"
 			},
@@ -19434,6 +19636,7 @@
 			"integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@jest/pattern": "30.0.1",
 				"@jest/schemas": "30.0.5",
@@ -19452,7 +19655,8 @@
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
 			"integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/jest-util/node_modules/ci-info": {
 			"version": "4.4.0",
@@ -19466,6 +19670,7 @@
 				}
 			],
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -19476,6 +19681,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -19868,7 +20074,6 @@
 			"integrity": "sha512-w16Xk/Ta9Hhyei0Gpz9m7VS8F28nieJaL/VyShID7cYvP6IL5oHeL6p4TXSDJqZE/lNv0oJ2pGVjJsRkfwm5FA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"copy-anything": "^2.0.1",
 				"parse-node-version": "^1.0.1",
@@ -21163,7 +21368,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@nrwl/cli": "15.9.2",
 				"@nrwl/tao": "15.9.2",
@@ -21975,7 +22179,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -22599,7 +22802,6 @@
 			"integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"prettier": "bin-prettier.js"
 			},
@@ -22858,7 +23060,6 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
 			"integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -22871,6 +23072,7 @@
 			"resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.45.0.tgz",
 			"integrity": "sha512-QsdWIhhm3+IAiW3SU9tEm7pmeIcveEPAO6riZ1IUF78ZCvH/47nU4zVztcdtYmwYWSL4168QxLncWKtlMva3BA==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@internationalized/string": "^3.2.7",
 				"@react-aria/breadcrumbs": "^3.5.30",
@@ -22925,6 +23127,7 @@
 			"resolved": "https://registry.npmjs.org/react-aria-components/-/react-aria-components-1.13.0.tgz",
 			"integrity": "sha512-t1mm3AVy/MjUJBZ7zrb+sFC5iya8Vvw3go3mGKtTm269bXGZho7BLA4IgT+0nOS3j+ku6ChVi8NEoQVFoYzJJA==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@internationalized/date": "^3.10.0",
 				"@internationalized/string": "^3.2.7",
@@ -22966,6 +23169,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
 			"integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.8.0"
 			}
@@ -22975,7 +23179,6 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
 			"integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.0"
@@ -23093,6 +23296,7 @@
 			"resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.43.0.tgz",
 			"integrity": "sha512-dScb9fTL1tRtFODPnk/2rP0a9kp1C+7+40RArS0C7j0auAUmnrO/wDILojwQUso7/kkys4fP707fTwGJDeJ7vg==",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@react-stately/calendar": "^3.9.1",
 				"@react-stately/checkbox": "^3.7.3",
@@ -23693,7 +23897,6 @@
 			"integrity": "sha512-N+7WK20/wOr7CzA2snJcUSSNTCzeCGUTFY3OgeQP3mZ1aj9NMQ0mSTXwlrnd89j33zzQJGqIN52GIOmYrfq46A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"chokidar": "^4.0.0",
 				"immutable": "^5.0.2",
@@ -23871,7 +24074,6 @@
 			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -24772,7 +24974,6 @@
 			"integrity": "sha512-MuzIIVRSbc8XxHH7FjkvWqkIcr1BvoMZoR/oFuAJDlh7VSaNJzrB4uJ38GRQa+mWjLXODAMzeDe0xi9GYbGwnw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"css": "^3.0.0",
 				"debug": "~3.1.0",
@@ -25475,8 +25676,7 @@
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"peer": true
+			"license": "0BSD"
 		},
 		"node_modules/tsutils": {
 			"version": "3.21.0",
@@ -25641,7 +25841,6 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
 			"integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
 			"devOptional": true,
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -25929,6 +26128,7 @@
 			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
 			"integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
 			"optional": true,
+			"peer": true,
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
@@ -26093,7 +26293,6 @@
 			"integrity": "sha512-+v57oAaoYNnO3hIu5Z/tJRZjq5aHM2zDve9YZ8HngVHbhk66RStobhb1sqPMIPEleV6cNKYK4eGrAbE9Ulbl2g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.18.10",
 				"postcss": "^8.4.27",
@@ -26635,7 +26834,6 @@
 			"integrity": "sha512-X75TApG2wZTJn299E/TIYevr4E9/nBo1sUtZzn0Ci5oK8qnpZAZyhwg0qCeMSakGIWtc6oRwcQFyFfW14aOFWg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/chai": "^4.3.4",
 				"@types/chai-subset": "^1.3.3",
@@ -26759,7 +26957,6 @@
 			"integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",


### PR DESCRIPTION
## What does this change?

Bumps the nrwl packages (specifically nrwl/node) in order to fix a transitive dep vulnerability in node-forge (https://github.com/guardian/newsletters-nx/security/dependabot/112)

The nrwl package (now nx - https://www.npmjs.com/package/@nx/node) that we use in newsletters-nx is quite a few major versions behind the latest. This p bumps the version up to the latest minor version and replaces the nrwl/esbuild executor with a custom esbuild build script, which fixes this vulnerability, but it might be worth looking into the major version upgrades at some point.

### How to test
Unit and E2E tests have been run locally and in CI. The branch has also been deployed to CODE and manually checked:

<img width="914" height="724" alt="Screenshot 2026-03-17 at 09 57 48" src="https://github.com/user-attachments/assets/5933d17c-1fe5-493c-a1ef-493d919a2b10" />

<img width="914" height="724" alt="Screenshot 2026-03-17 at 09 57 58" src="https://github.com/user-attachments/assets/0f19092c-4b7d-40d0-853f-f49abe82497e" />

<img width="914" height="148" alt="Screenshot 2026-03-17 at 10 02 15" src="https://github.com/user-attachments/assets/9cd17e72-c9f6-4ac7-90fa-527d990ad0f9" />
