### PR TITLE
add support for question block subheading in rendering options

### DIFF
--- a/libs/newsletters-data-client/src/lib/schemas/rendering-options-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/schemas/rendering-options-data-type.ts
@@ -46,6 +46,10 @@ export const renderingOptionsSchema = z.object({
 		.array(z.string())
 		.optional()
 		.describe('Link list subheading'),
+	questionBlockSubheading: z
+		.array(z.string())
+		.optional()
+		.describe('Question block subheading'),
 	podcastSubheading: z
 		.array(z.string())
 		.optional()

--- a/libs/newsletters-data-client/src/lib/transformWizardData.spec.ts
+++ b/libs/newsletters-data-client/src/lib/transformWizardData.spec.ts
@@ -24,6 +24,7 @@ const SIMPLE_VALID_DRAFT: DraftNewsletterData = {
 const VALID_FORM_DATA_WITH_NESTED_OBJECT: FormDataRecord = {
 	name: 'test name',
 	'renderingOptions.linkListSubheading': ['frog', 'bird', 'snake'],
+	'renderingOptions.questionBlockSubheading': ['what', 'why'],
 	'renderingOptions.displayStandfirst': true,
 };
 
@@ -31,6 +32,7 @@ const VALID_DRAFT_WITH_NESTED_OBJECT: DraftNewsletterData = {
 	name: 'test name',
 	renderingOptions: {
 		linkListSubheading: ['frog', 'bird', 'snake'],
+		questionBlockSubheading: ['what', 'why'],
 		displayStandfirst: true,
 	},
 };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds question block support to support First Edition being moved from custom to standard template

## How has this change been tested?

Unit tests and deployed to code and tested there

## How can we measure success?

Allows the question block subheading to be chosen so that question blocks can be rendered in the standard (Kronos) template.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
