### PR TITLE
new Zod types and missing input fields bug fix

### DIFF
--- a/apps/newsletters-ui/src/app/components/SchemaForm/SchemaField.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/SchemaField.tsx
@@ -4,10 +4,12 @@ import {
 	ZodArray,
 	ZodBoolean,
 	ZodDate,
+	ZodEmail,
 	ZodEnum,
 	ZodNumber,
 	ZodObject,
 	ZodString,
+	ZodURL,
 } from 'zod';
 import { recursiveUnwrap } from '@newsletters-nx/newsletters-data-client';
 import {
@@ -131,7 +133,11 @@ export function SchemaField<T extends z.ZodRawShape>({
 		);
 	}
 
-	if (innerZod instanceof ZodString) {
+	if (
+		innerZod instanceof ZodString ||
+		innerZod instanceof ZodEmail ||
+		innerZod instanceof ZodURL
+	) {
 		if (typeof value !== 'string' && typeof value !== 'undefined') {
 			return <WrongValueTypeMessage field={field} />;
 		}


### PR DESCRIPTION
## What was going on?
There was a bug that was introduced by the following pr: https://github.com/guardian/newsletters-nx/pull/596.

Zod v3 introduced z.url and z.email as a more specific type than z.string that was used for banner and email input fields. The new types were used, but the code that checks the zod type in SchemaField.tsx was not updated and was still only checking for ZodString.

## What does this change?
In apps/newsletters-ui/src/app/components/SchemaForm/SchemaField.tsx there was a conditional check for any `ZodString` types before deciding to render a component. This check would have previously picked up the banner input fields as well as the email input field. However they were moved from being a zodString type to a zodURL and zodEmail type, so the conditional if statement needed updating to reflect this.

## How has this change been tested?
That's a good question, this has been tested the same way that the original pr that introduced the bug was, by running the lint, build and test commands and deploying the branch to code to manually check the newsletters tool to see if it looks like it is still working.

Adding some more thorough integration/e2e tests may have caught this issue before it could have been deployed. In this specific case some storybook stories connected with chromatic would probably have caught the visual regression. 

Perhaps this is something we can look into introducing.

## Images
Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/eda6b304-0cf7-4c27-86b3-481c6f171b6a)  |  ![](https://github.com/user-attachments/assets/d1808df3-8557-4484-bcb9-71ec7f03685b)


