### PR TITLE
Fix 2 new zod data types not recognised elsewhere in codebase

### DIFF
--- a/apps/newsletters-ui/src/app/components/SchemaForm/SchemaField.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/SchemaField.tsx
@@ -255,7 +255,11 @@ export function SchemaField<T extends z.ZodRawShape>({
 	}
 
 	if (innerZod instanceof ZodArray) {
-		if (innerZod.element instanceof ZodString) {
+		if (
+			innerZod.element instanceof ZodString ||
+			innerZod.element instanceof ZodURL ||
+			innerZod.element instanceof ZodEmail
+		) {
 			if (!isStringArray(value) && typeof value !== 'undefined') {
 				return <WrongValueTypeMessage field={field} />;
 			}

--- a/apps/newsletters-ui/src/app/components/SchemaForm/util.ts
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/util.ts
@@ -8,6 +8,7 @@ import {
 	ZodNumber,
 	ZodObject,
 	ZodString,
+	ZodURL,
 } from 'zod';
 import { recursiveUnwrap } from '@newsletters-nx/newsletters-data-client';
 import type { PrimitiveRecord } from '@newsletters-nx/newsletters-data-client';
@@ -97,7 +98,7 @@ function fieldValueIsRightType(value: FieldValue, field: FieldDef): boolean {
 		case 'undefined':
 			return field.zod.isOptional();
 		case 'string':
-			return innerZod instanceof ZodString;
+			return innerZod instanceof ZodString || innerZod instanceof ZodURL;
 		case 'number':
 			return innerZod instanceof ZodNumber;
 		case 'boolean':

--- a/apps/newsletters-ui/src/app/components/SchemaForm/util.ts
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/util.ts
@@ -4,6 +4,7 @@ import {
 	ZodArray,
 	ZodBoolean,
 	ZodDate,
+	ZodEmail,
 	ZodEnum,
 	ZodNumber,
 	ZodObject,
@@ -76,7 +77,12 @@ function fieldValueIsRightType(value: FieldValue, field: FieldDef): boolean {
 		return value instanceof Date;
 	}
 
-	if (innerZod instanceof ZodArray && innerZod.element instanceof ZodString) {
+	if (
+		innerZod instanceof ZodArray &&
+		(innerZod.element instanceof ZodString ||
+			innerZod.element instanceof ZodURL ||
+			innerZod.element instanceof ZodEmail)
+	) {
 		return isStringArray(value);
 	}
 
@@ -98,7 +104,11 @@ function fieldValueIsRightType(value: FieldValue, field: FieldDef): boolean {
 		case 'undefined':
 			return field.zod.isOptional();
 		case 'string':
-			return innerZod instanceof ZodString || innerZod instanceof ZodURL;
+			return (
+				innerZod instanceof ZodString ||
+				innerZod instanceof ZodURL ||
+				innerZod instanceof ZodEmail
+			);
 		case 'number':
 			return innerZod instanceof ZodNumber;
 		case 'boolean':

--- a/libs/newsletters-data-client/src/lib/zod-helpers/getEmptySchemaData.ts
+++ b/libs/newsletters-data-client/src/lib/zod-helpers/getEmptySchemaData.ts
@@ -3,10 +3,12 @@ import {
 	ZodArray,
 	ZodBoolean,
 	ZodDate,
+	ZodEmail,
 	ZodEnum,
 	ZodNumber,
 	ZodOptional,
 	ZodString,
+	ZodURL,
 } from 'zod';
 import type { FormDataRecord } from '../transformWizardData';
 import { recursiveUnwrap } from './recursiveUnwrap';
@@ -43,7 +45,11 @@ export const getEmptySchemaData = (
 			: zodMaybeOptional;
 		const mod: FormDataRecord = {};
 
-		if (zod instanceof ZodString) {
+		if (
+			zod instanceof ZodString ||
+			zod instanceof ZodURL ||
+			zod instanceof ZodEmail
+		) {
 			const initalString =
 				populateStringsWithMinLength && zod.minLength
 					? '*'.repeat(zod.minLength)


### PR DESCRIPTION
## What does this change?

The introduction of the 2 new zod types ZodURL and ZodEmail as part of the series of dependency upgrade prs, specifically (https://github.com/guardian/newsletters-nx/pull/596) caused issues elsewhere in the codebase where the values were being compared to a ZodString type. 

Where values were previously being typed as a ZodString, they are now typed as ZodURL or ZodEmail where applicable.

This pr/fix updates the rest of the codebase to ensure wherever we check for the ZodString type we also include the ZodURL and ZodEmail types as well ... some of these cases were picked up in this follow up pr (https://github.com/guardian/newsletters-nx/pull/606) but not all of them :(