### PR TITLE
remove email rendering management alert from newsletters rendering options

### DIFF
--- a/apps/newsletters-ui/src/app/components/RenderingOptionsForm.tsx
+++ b/apps/newsletters-ui/src/app/components/RenderingOptionsForm.tsx
@@ -45,22 +45,6 @@ export const RenderingOptionsForm = ({ originalItem }: Props) => {
 
 	const [initialState, setInitialState] =
 		useState<NewsletterData>(originalItem);
-	const emailRenderingManagedNewsletters = [
-		'afternoon-update',
-		'cotton-capital',
-		'the-guide-staying-in',
-		'fashion-statement',
-		'five-great-reads',
-		'morning-mail',
-		'soccer-with-jonathan-wilson',
-		'pushing-buttons',
-		'morning-briefing',
-		'green-light',
-		'afternoon-update',
-	];
-	const { identityName } = originalItem;
-	const hasEmailRenderingTemplate =
-		emailRenderingManagedNewsletters.includes(identityName);
 	const [subset, setSubset] = useState<FormDataRecord>({
 		category: initialState.category,
 		seriesTag: initialState.seriesTag,
@@ -218,13 +202,6 @@ export const RenderingOptionsForm = ({ originalItem }: Props) => {
 					</Button>
 				</DialogActions>
 			</Dialog>
-			{hasEmailRenderingTemplate && (
-				<Alert severity="error">
-					This newsletter’s rendering options are managed by email rendering. To
-					make changes to <strong>{initialState.name}</strong>, please contact
-					the development team
-				</Alert>
-			)}
 			<Typography variant="h2">{initialState.name}</Typography>
 			<Typography variant="subtitle1">email-rendering settings</Typography>
 			<Alert severity={initialState.seriesTag ? 'info' : 'warning'}>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
