### PR TITLE
add a new drop down input field that reverts to a text input field if…

### DIFF
--- a/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
+++ b/apps/newsletters-ui/src/app/components/EditNewsletterForm.tsx
@@ -5,6 +5,7 @@ import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
 import { getUserEditSchema } from '@newsletters-nx/newsletters-data-client';
 import { requestNewsletterEdit } from '../api-requests/request-newsletter-edit';
 import { usePermissions } from '../hooks/user-hooks';
+import { FrequencySelectInput } from './SchemaForm/FrequencySelectInput';
 import { SimpleForm } from './SimpleForm';
 
 interface Props {
@@ -64,6 +65,7 @@ export const EditNewsletterForm = ({ originalItem }: Props) => {
 				initialData={item}
 				submit={requestUpdate}
 				schema={userSchema}
+				customComponents={{ frequency: FrequencySelectInput }}
 				submitButtonText="Update Newsletter"
 				isDisabled={waitingForResponse}
 				maxOptionsForRadioButtons={5}

--- a/apps/newsletters-ui/src/app/components/SchemaForm/FrequencySelectInput.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/FrequencySelectInput.tsx
@@ -1,0 +1,121 @@
+import type { SelectChangeEvent } from '@mui/material';
+import {
+	FormControl,
+	FormHelperText,
+	InputLabel,
+	MenuItem,
+	Select,
+	TextField,
+} from '@mui/material';
+import type { FormEventHandler, FunctionComponent } from 'react';
+import { useEffect, useState } from 'react';
+import type { FieldProps } from './util';
+
+const FREQUENCY_OPTIONS = [
+	'Daily',
+	'Weekdays',
+	'Twice weekly',
+	'Weekly',
+	'Fortnightly',
+	'Monthly',
+] as const;
+
+const CUSTOM_KEY = 'custom';
+
+const frequencyOptionSet = new Set<string>(FREQUENCY_OPTIONS);
+
+const isExistingCustomValue = (value: string | undefined): value is string =>
+	value !== undefined && value !== '' && !frequencyOptionSet.has(value);
+
+export const FrequencySelectInput: FunctionComponent<
+	FieldProps & {
+		value?: string;
+		inputHandler: (value?: string) => void;
+	}
+> = ({
+	value,
+	optional,
+	inputHandler,
+	label = 'Frequency',
+	readOnly,
+	error,
+}) => {
+	const [isInCustomMode, setIsInCustomMode] = useState<boolean>(() =>
+		isExistingCustomValue(value),
+	);
+	const [localCustomValue, setLocalCustomValue] = useState<string>(() =>
+		isExistingCustomValue(value) ? value : '',
+	);
+
+	useEffect(() => {
+		if (value === undefined || frequencyOptionSet.has(value)) {
+			setIsInCustomMode(false);
+			setLocalCustomValue('');
+		}
+	}, [value]);
+
+	const selectValue = isInCustomMode ? CUSTOM_KEY : (value ?? '');
+
+	const handleSelectChange = (event: SelectChangeEvent) => {
+		const selected = event.target.value;
+		if (selected === CUSTOM_KEY) {
+			setIsInCustomMode(true);
+			setLocalCustomValue('');
+			inputHandler('');
+		} else if (selected === '') {
+			setIsInCustomMode(false);
+			setLocalCustomValue('');
+			inputHandler(undefined);
+		} else {
+			setIsInCustomMode(false);
+			setLocalCustomValue('');
+			inputHandler(selected);
+		}
+	};
+
+	const handleTextInput: FormEventHandler<HTMLInputElement> = (event) => {
+		const text = (event.target as HTMLInputElement).value;
+		setLocalCustomValue(text);
+		inputHandler(text);
+	};
+
+	return (
+		<FormControl fullWidth error={!isInCustomMode && !!error}>
+			<InputLabel shrink id={`select-input-label-${label}`}>
+				{label}
+			</InputLabel>
+			<Select
+				labelId={`select-input-label-${label}`}
+				value={selectValue}
+				label={label}
+				onChange={handleSelectChange}
+				disabled={readOnly}
+				displayEmpty
+			>
+				<MenuItem value={''} disabled>
+					<em>Please select a frequency</em>
+				</MenuItem>
+				{optional && <MenuItem value={''}>[none]</MenuItem>}
+				{FREQUENCY_OPTIONS.map((option) => (
+					<MenuItem key={option} value={option}>
+						{option}
+					</MenuItem>
+				))}
+				<MenuItem value={CUSTOM_KEY}>Custom</MenuItem>
+			</Select>
+			{!isInCustomMode && error && <FormHelperText>{error}</FormHelperText>}
+			{isInCustomMode && (
+				<TextField
+					fullWidth
+					label="Custom frequency"
+					value={localCustomValue}
+					onInput={handleTextInput}
+					error={!!error}
+					helperText={error}
+					disabled={readOnly}
+					sx={{ marginTop: 1 }}
+				/>
+			)}
+		</FormControl>
+	);
+};

--- a/apps/newsletters-ui/src/app/components/SchemaForm/SchemaField.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/SchemaField.tsx
@@ -8,6 +8,7 @@ import {
 	ZodEnum,
 	ZodNumber,
 	ZodObject,
+	ZodOptional,
 	ZodString,
 	ZodURL,
 } from 'zod';
@@ -102,7 +103,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 		if (readOnly) {
 			return;
 		}
-		if (zod.isOptional() && newValue === '') {
+		if (zod instanceof ZodOptional && newValue === '') {
 			return change(undefined, field);
 		}
 		change(newValue, field);
@@ -112,7 +113,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 		label: zod.description ?? key,
 		inputHandler,
 		readOnly,
-		optional: zod.isOptional(),
+		optional: zod instanceof ZodOptional,
 		error: validationWarning,
 	};
 
@@ -200,7 +201,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 			return <WrongValueTypeMessage field={field} />;
 		}
 
-		if (zod.isOptional()) {
+		if (zod instanceof ZodOptional) {
 			return (
 				<FieldWrapper explanation={explanation}>
 					<OptionalNumberInput

--- a/apps/newsletters-ui/src/app/components/SchemaForm/SchemaField.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/SchemaField.tsx
@@ -33,6 +33,7 @@ import type {
 	FieldDef,
 	FieldValue,
 	NumberInputSettings,
+	StringCustomFieldComponent,
 	StringInputSettings,
 } from './util';
 import { fieldValueAsDisplayString } from './util';
@@ -50,6 +51,7 @@ interface SchemaFieldProps<T extends z.ZodRawShape> {
 	validationWarning?: string;
 	maxOptionsForRadioButtons: number;
 	explanation?: ReactNode;
+	customComponent?: StringCustomFieldComponent;
 }
 
 const WrongValueTypeMessage = (props: { field: FieldDef }) => (
@@ -92,6 +94,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 	validationWarning,
 	maxOptionsForRadioButtons,
 	explanation = null,
+	customComponent,
 }: SchemaFieldProps<T>) {
 	const { key, value, zod, readOnly } = field;
 
@@ -140,6 +143,15 @@ export function SchemaField<T extends z.ZodRawShape>({
 	) {
 		if (typeof value !== 'string' && typeof value !== 'undefined') {
 			return <WrongValueTypeMessage field={field} />;
+		}
+
+		if (customComponent) {
+			const CustomComponent = customComponent;
+			return (
+				<FieldWrapper explanation={explanation}>
+					<CustomComponent {...standardProps} value={value} />
+				</FieldWrapper>
+			);
 		}
 
 		if (options) {

--- a/apps/newsletters-ui/src/app/components/SchemaForm/index.tsx
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/index.tsx
@@ -6,6 +6,7 @@ import type {
 	FieldDef,
 	FieldValue,
 	NumberInputSettings,
+	StringCustomFieldComponent,
 	StringInputSettings,
 } from './util';
 
@@ -24,6 +25,7 @@ interface Props<T extends z.ZodRawShape> {
 	validationWarnings: Partial<Record<keyof T, string>>;
 	maxOptionsForRadioButtons?: number;
 	explanations?: Partial<Record<keyof T, ReactNode>>;
+	customComponents?: Partial<Record<keyof T, StringCustomFieldComponent>>;
 }
 
 /**
@@ -43,12 +45,11 @@ export function SchemaForm<T extends z.ZodRawShape>({
 	validationWarnings,
 	maxOptionsForRadioButtons = 0,
 	explanations = {},
+	customComponents = {},
 }: Props<T>) {
 	const fields: FieldDef[] = [];
 	for (const key in schema.shape) {
-		const zod: ZodType | undefined = schema.shape[key] as
-			| ZodType
-			| undefined;
+		const zod: ZodType | undefined = schema.shape[key] as ZodType | undefined;
 		if (!zod) {
 			continue;
 		}
@@ -79,6 +80,7 @@ export function SchemaForm<T extends z.ZodRawShape>({
 					validationWarning={validationWarnings[field.key]}
 					maxOptionsForRadioButtons={maxOptionsForRadioButtons}
 					explanation={explanations[field.key]}
+					customComponent={customComponents[field.key as keyof T]}
 				/>
 			))}
 		</article>

--- a/apps/newsletters-ui/src/app/components/SchemaForm/util.ts
+++ b/apps/newsletters-ui/src/app/components/SchemaForm/util.ts
@@ -1,5 +1,5 @@
-import type { FormEvent } from 'react';
-import type { ZodTypeAny } from 'zod';
+import type { FormEvent, FunctionComponent } from 'react';
+import type { ZodType } from 'zod';
 import {
 	ZodArray,
 	ZodBoolean,
@@ -8,6 +8,7 @@ import {
 	ZodEnum,
 	ZodNumber,
 	ZodObject,
+	ZodOptional,
 	ZodString,
 	ZodURL,
 } from 'zod';
@@ -20,7 +21,7 @@ import {
 } from '../../util';
 
 export interface FieldDef {
-	zod: ZodTypeAny;
+	zod: ZodType;
 	key: string;
 	value: unknown;
 	readOnly?: boolean;
@@ -45,6 +46,13 @@ export type StringInputSettings = {
 	inputType?: 'textInput' | 'textArea';
 };
 
+export type StringCustomFieldComponent = FunctionComponent<
+	FieldProps & {
+		value?: string;
+		inputHandler: (value?: string) => void;
+	}
+>;
+
 export function eventToNumber(event: FormEvent, defaultValue = 0): number {
 	const numericalValue = Number((event.target as HTMLInputElement).value);
 	return isNaN(numericalValue) ? defaultValue : numericalValue;
@@ -62,7 +70,7 @@ function fieldValueIsRightType(value: FieldValue, field: FieldDef): boolean {
 	const innerZod = recursiveUnwrap(field.zod);
 
 	if (innerZod instanceof ZodEnum) {
-		if (field.zod.isOptional() && typeof value === 'undefined') {
+		if (field.zod instanceof ZodOptional && typeof value === 'undefined') {
 			return true;
 		}
 
@@ -92,7 +100,7 @@ function fieldValueIsRightType(value: FieldValue, field: FieldDef): boolean {
 	}
 
 	if (innerZod instanceof ZodObject) {
-		if (field.zod.isOptional() && typeof value === 'undefined') {
+		if (field.zod instanceof ZodOptional && typeof value === 'undefined') {
 			return true;
 		}
 		// TODO - use field.recordSchema to validate item?
@@ -102,7 +110,7 @@ function fieldValueIsRightType(value: FieldValue, field: FieldDef): boolean {
 
 	switch (typeof value) {
 		case 'undefined':
-			return field.zod.isOptional();
+			return field.zod instanceof ZodOptional;
 		case 'string':
 			return (
 				innerZod instanceof ZodString ||

--- a/apps/newsletters-ui/src/app/components/SimpleForm.tsx
+++ b/apps/newsletters-ui/src/app/components/SimpleForm.tsx
@@ -2,7 +2,12 @@ import { Box, Button, Paper, Typography } from '@mui/material';
 import type { ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 import type { z } from 'zod';
-import type { FieldDef, FieldValue, StringInputSettings } from './SchemaForm';
+import type {
+	FieldDef,
+	FieldValue,
+	StringCustomFieldComponent,
+	StringInputSettings,
+} from './SchemaForm';
 import { getModification, SchemaForm } from './SchemaForm';
 
 type SchemaObjectType<T extends z.ZodRawShape> = z.infer<z.ZodObject<T>>;
@@ -18,6 +23,7 @@ interface Props<T extends z.ZodRawShape> {
 	maxOptionsForRadioButtons?: number;
 	stringConfig?: Partial<Record<keyof T, StringInputSettings>>;
 	explanations?: Partial<Record<keyof T, ReactNode>>;
+	customComponents?: Partial<Record<keyof T, StringCustomFieldComponent>>;
 }
 
 /**
@@ -38,6 +44,7 @@ export function SimpleForm<T extends z.ZodRawShape>({
 	maxOptionsForRadioButtons,
 	stringConfig = {},
 	explanations = {},
+	customComponents = {},
 }: Props<T>) {
 	const [parseInitialDataResult, setParseInitialDataResult] = useState<
 		ReturnType<z.ZodObject<T>['safeParse']> | undefined
@@ -139,6 +146,7 @@ export function SimpleForm<T extends z.ZodRawShape>({
 				maxOptionsForRadioButtons={maxOptionsForRadioButtons}
 				stringConfig={stringConfig}
 				explanations={explanations}
+				customComponents={customComponents}
 			/>
 			<Box sx={{ marginBottom: 2 }}>
 				<Button

--- a/apps/newsletters-ui/src/app/components/StateEditForm.tsx
+++ b/apps/newsletters-ui/src/app/components/StateEditForm.tsx
@@ -2,7 +2,12 @@ import { Box, Paper, Typography } from '@mui/material';
 import type { z } from 'zod';
 import { getValidationWarnings } from '@newsletters-nx/newsletters-data-client';
 import type { WizardFormData } from '@newsletters-nx/state-machine';
-import type { FieldDef, FieldValue, StringInputSettings } from './SchemaForm';
+import type {
+	FieldDef,
+	FieldValue,
+	StringCustomFieldComponent,
+	StringInputSettings,
+} from './SchemaForm';
 import { getModification, SchemaForm } from './SchemaForm';
 
 interface Props {
@@ -11,6 +16,7 @@ interface Props {
 	setFormData: { (newData: WizardFormData): void };
 	maxOptionsForRadioButtons?: number;
 	stringConfig?: Partial<Record<string, StringInputSettings>>;
+	customComponents?: Partial<Record<string, StringCustomFieldComponent>>;
 }
 
 export const StateEditForm = ({
@@ -19,6 +25,7 @@ export const StateEditForm = ({
 	setFormData,
 	maxOptionsForRadioButtons,
 	stringConfig = {},
+	customComponents = {},
 }: Props) => {
 	const changeFormData = (value: FieldValue, field: FieldDef) => {
 		const mod = getModification(value, field);
@@ -42,6 +49,7 @@ export const StateEditForm = ({
 				changeValue={changeFormData}
 				maxOptionsForRadioButtons={maxOptionsForRadioButtons}
 				stringConfig={stringConfig}
+				customComponents={customComponents}
 			/>
 		</Box>
 	);

--- a/apps/newsletters-ui/src/app/components/Wizard.tsx
+++ b/apps/newsletters-ui/src/app/components/Wizard.tsx
@@ -16,7 +16,11 @@ import type {
 } from '@newsletters-nx/state-machine';
 import { makeWizardStepRequest } from '../api-requests/make-wizard-step-request';
 import { MarkdownView } from './MarkdownView';
-import type { StringInputSettings } from './SchemaForm';
+import type {
+	StringCustomFieldComponent,
+	StringInputSettings,
+} from './SchemaForm';
+import { FrequencySelectInput } from './SchemaForm/FrequencySelectInput';
 import { SkipConfirmationDialog } from './SkipConfirmationDialog';
 import { StateEditForm } from './StateEditForm';
 import { StepNav } from './StepNav';
@@ -63,6 +67,12 @@ const FailureAlert = (props: {
 			)}
 		</Alert>
 	);
+};
+
+const wizardCustomComponents: Partial<
+	Record<string, StringCustomFieldComponent>
+> = {
+	frequency: FrequencySelectInput,
 };
 
 /**
@@ -246,6 +256,7 @@ export const Wizard: React.FC<WizardProps> = ({
 					setFormData={handleFormChange}
 					maxOptionsForRadioButtons={5}
 					stringConfig={stringConfig}
+					customComponents={wizardCustomComponents}
 				/>
 			)}
 

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/productionDetailsLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/productionDetailsLayout.ts
@@ -28,16 +28,20 @@ This is the case for most newsletters, but you may prefer to offer the newslette
 Alternatively, you might want the first send on web to preview it, but subsequent sends to be email-only.
 
 ### Frequency
-Specify how regularly the newsletter will be sent e.g.
-- Every day
-- Every weekday
+Select how often your newsletter will be sent. This will be displayed on the sign-up page, in-article sign-ups and the all newsletters page.
+
+If your schedule doesn’t fit the options below, choose **Custom frequency**.
+
+Options:
+- Daily
+- Weekdays
 - Weekly
+- Twice weekly
 - Fortnightly
 - Monthly
-- Weekly during election season
-- Weekly for eight weeks (in the case of an asynchronous newsletter)
+- Custom frequency
 
-The frequency you specify will be shown on thrashers, on the sign up page, and on the all newsletters page.
+**Custom frequency examples**: Weekly during election season; Weekly for eight weeks; Every two weeks on a specific day
 
 ![Frequency](https://i.guim.co.uk/img/uploads/2023/09/15/frequency.png?quality=85&dpr=2&width=300&s=e8c4bdd12b9c2f1f48d35a2d9b1ef1c7)
 
@@ -51,7 +55,7 @@ const staticMarkdown = markdownTemplate.replace(
 export const productionDetailsLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown,
 	label: 'Production Details',
-	dynamicMarkdown(requestData, responseData) {
+	dynamicMarkdown(_, responseData) {
 		if (!responseData) {
 			return staticMarkdown;
 		}

--- a/libs/newsletters-data-client/src/lib/schemas/legacy-newsletter-type.ts
+++ b/libs/newsletters-data-client/src/lib/schemas/legacy-newsletter-type.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z, ZodOptional } from 'zod';
 import { nonEmptyString } from '../zod-helpers/schema-helpers';
 import { emailEmbedSchema } from './email-embed-data-type';
 import { themeEnumSchema } from './theme-enum-data-type';
@@ -129,5 +129,5 @@ export function isLegacyCancelledNewsletter(
 export function isPropertyOptionalOnLegacy(
 	property: keyof LegacyNewsletter,
 ): boolean {
-	return legacyNewsletterSchema.shape[property].isOptional();
+	return legacyNewsletterSchema.shape[property] instanceof ZodOptional;
 }


### PR DESCRIPTION
## What does this change?

Adds a dropdown select input instead of a free text input field for the newsletter frequency input. Comes with some default options to select from and a custom option that if selected shows a text input field.

The new field should appear on the create and edit newsletters pages.

## Images
Before             |  After            |  After (custom)
:-------------------------:|:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/d946c02b-acb7-4edc-92f9-56a86fdd809f)  |  ![](https://github.com/user-attachments/assets/2b2d6e5c-a539-4e65-b9e7-b8e71389ea44)  |  ![](https://github.com/user-attachments/assets/9d04a7fd-1be7-4410-ab02-6a9f2151ed0a)


The frequency instructions have been updated to reflect these changes too:
<img width="1023" height="510" alt="Screenshot 2026-04-22 at 15 41 28" src="https://github.com/user-attachments/assets/ec5903d9-96a1-4f02-b878-876d2541d32b" />

