### PR TITLE
add configurable unordered list style option for newsletters

### DIFF
--- a/libs/newsletters-data-client/src/lib/schemas/rendering-options-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/schemas/rendering-options-data-type.ts
@@ -40,6 +40,10 @@ export const renderingOptionsSchema = z.object({
 		.boolean()
 		.optional()
 		.describe('Display Newsletter name above headline?'),
+	unorderedListStyle: z
+		.enum(['bulleted', 'lined'])
+		.optional()
+		.describe('Unordered list style'),
 
 	paletteOverride: themeEnumSchema.optional().describe('Palette override'),
 	linkListSubheading: z
@@ -67,16 +71,17 @@ export const renderingOptionsSchema = z.object({
 		.optional()
 		.describe('The configuration for automated front sections'),
 
-	mainBannerUrl: z.url()
-		.optional()
-		.describe('URL for the main banner'),
-	mainBannerMobileUrl: z.url()
+	mainBannerUrl: z.url().optional().describe('URL for the main banner'),
+	mainBannerMobileUrl: z
+		.url()
 		.optional()
 		.describe('URL for the mobile size main banner'),
-	subheadingBannerUrl: z.url()
+	subheadingBannerUrl: z
+		.url()
 		.optional()
 		.describe('URL for standard subheading banner'),
-	darkSubheadingBannerUrl: z.url()
+	darkSubheadingBannerUrl: z
+		.url()
 		.optional()
 		.describe('URL for dark subheading banner'),
 });


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Since changing to the Kronos template for newletters like first thing, they are rendering with a lined list where the editors would prefer a bullet point list

## How has this change been tested?

Verified form field appeared locally

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
