### PR TITLE
Fix registerUIServer startup crash if the dist directory does not exist

### DIFF
--- a/apps/newsletters-api/src/register-ui-server.ts
+++ b/apps/newsletters-api/src/register-ui-server.ts
@@ -26,16 +26,32 @@ const routeMap = {
 	'/layouts': ['', '/:id', '/edit/:id', '/edit-json/:id'],
 };
 
+const readIndexHtml = async (filePath: string): Promise<Buffer | null> => {
+	try {
+		const handler = await fs.promises.open(filePath);
+		const content = await handler.readFile();
+		await handler.close();
+		return content;
+	} catch {
+		return null;
+	}
+};
+
 export async function registerUIServer(app: Express) {
 	const pathToStaticFiles = path.join('./dist/apps/newsletters-ui');
 
 	app.use(serveStatic(pathToStaticFiles));
 
-	const handler = await fs.promises.open(
+	const indexHtml = await readIndexHtml(
 		path.join(pathToStaticFiles, 'index.html'),
 	);
-	const indexHtml = await handler.readFile();
-	await handler.close();
+
+	if (!indexHtml) {
+		console.warn(
+			'registerUIServer: index.html not found — UI routes not registered. In production, run `npm run build` first.',
+		);
+		return;
+	}
 
 	const serveIndexHtml = (_: Request, res: Response) => {
 		res.type('text/html').send(indexHtml);


### PR DESCRIPTION
## Preamble

As part of work to update various dependencies, specifically vite in this case. The github codeQL check in CI complained about register-ui-server.ts opening and reading the index.html file from the dist directory on every incoming request. Apparently it lumps all reading of files on every request into risk of a `path traversal` vulnerability where a ratbag could manipulate the path to read arbitrary files on the server. This couldn't have been exploited in our case as the path was hardcoded, however codeQL flags the pattern without doing any in depth analysis to see if the issue is actually exploitable. 

So work was done to read the file once when the server starts and cache the contents onthe server for subsequent requests.

_Interesting side note that I didn't realise until I dug into the codeQL warning, code QL only seems to run on files that you make changes to and not the whole codebase._ 

## What does this change?

Previously, reading index.html at startup would throw if the dist directory had not been built, crashing the server. The file read is now wrapped in a helper function that returns null on failure, allowing the server to start gracefully in dev mode where vite serves the UI instead.

This was and still is not an issue in prod where the dist index.html file always exists as the build step is always run before deployment.

## huh?
<img width="500" height="281" alt="huh_cat" src="https://github.com/user-attachments/assets/29a6383d-b5a2-4888-ae77-c1385f8348c1" />

...basically if you were running newsletters-nx locally and ran `npm run dev` and hadn't run `npm run build` beforehand the site wouldn't load properly (again not a problem in prod)

Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/e6fbbc4c-d3da-4fff-8f24-3f13081ae8d3)  |  ![](https://github.com/user-attachments/assets/f700d936-8d99-43ad-9219-b20610fc7f1b)

