### PR TITLE
Stand step nav wide breakpoints

### DIFF
--- a/apps/newsletters-ui/src/app/Layout.tsx
+++ b/apps/newsletters-ui/src/app/Layout.tsx
@@ -55,7 +55,7 @@ export function Layout(props: IRootRoute) {
 			) : (
 				<MainNav isOnCode={isOnCode} isOnLocal={isOnLocal} />
 			)}
-			<Box sx={{ pt: 8 }} component={'main'}>
+			<Box sx={{ pt: isUsingStand ? 0 : 8 }} component={'main'}>
 				{props.outlet ?? <Outlet />}
 			</Box>
 		</div>

--- a/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
@@ -3,6 +3,7 @@ import { baseColors, semanticColors } from '@guardian/stand';
 import { Icon } from '@guardian/stand/icon';
 import { Typography } from '@guardian/stand/typography'
 import { CheckCircleOutlined, CircleSharp, WarningAmberOutlined } from '@mui/icons-material';
+import type { ReactNode} from 'react';
 import { useState } from 'react';
 import { Button } from 'react-aria-components';
 import { resolveStepStatus, StepStatus } from '@newsletters-nx/state-machine';
@@ -30,28 +31,62 @@ type StepProps = {
 	description: string;
 }
 
-const CompletionCaption = (props: { status: StepStatus; isDisabled: boolean}) => {
-	switch (props.status) {
+type StatusRowProps = {
+	label: string;
+	icon: ReactNode;
+	iconColor: string;
+	isDisabled: boolean;
+};
+
+const StatusRow = ({ label, icon, iconColor, isDisabled }: StatusRowProps) => (
+	<div css={css`display: flex; gap: 6px; align-items: center;`}>
+		<Typography
+			variant="body-sm"
+			element="span"
+			theme={{ color: isDisabled ? semanticColors.text.disabled : semanticColors.text.weak }}
+		>
+			{label}
+		</Typography>
+		<Icon
+			fill={isDisabled ? semanticColors.text.disabled : iconColor}
+			size="sm"
+			theme={{ sm: { size: '16px' } }}
+		>
+			{icon}
+		</Icon>
+	</div>
+);
+
+const CompletionCaption = ({status, isDisabled}: { status: StepStatus; isDisabled: boolean}) => {
+	switch (status) {
 		case StepStatus.NoFields:
 			return null;
 		case StepStatus.Optional:
 			return (
-				<div css={css`display: flex; gap: 6px; align-items: center;`}>
-					<Typography variant="body-sm" theme={{color: props.isDisabled ? semanticColors.text.disabled :  semanticColors.text.weak}} element="span">Optional</Typography> <Icon fill={props.isDisabled ? semanticColors.text.disabled : semanticColors.text['success-inverse']} size={"sm"} theme={{sm: {size: '16px'}}} ><CircleSharp/></Icon>
-				</div>
-
+				<StatusRow
+					label="Optional"
+					isDisabled={isDisabled}
+					iconColor={semanticColors.text['success-inverse']}
+					icon={<CircleSharp />}
+				/>
 			);
 		case StepStatus.Complete:
 			return (
-				<div css={css`display: flex; gap: 6px; align-items: center;`}>
-					<Typography variant="body-sm" theme={{color: props.isDisabled ? semanticColors.text.disabled :  semanticColors.text.weak}} element="span">Complete</Typography> <Icon fill={props.isDisabled ? semanticColors.text.disabled : semanticColors.text.success} size={"sm"} theme={{sm: {size: '16px'}}} ><CheckCircleOutlined/></Icon>
-				</div>
+				<StatusRow
+					label="Complete"
+					isDisabled={isDisabled}
+					iconColor={semanticColors.text.success}
+					icon={<CheckCircleOutlined />}
+				/>
 			);
 		case StepStatus.Incomplete:
 			return (
-				<div css={css`display: flex; gap: 6px; align-items: center;`}>
-					<Typography variant="body-sm" theme={{color: props.isDisabled ? semanticColors.text.disabled : semanticColors.text.weak}} element="span">Incomplete </Typography> <Icon fill={props.isDisabled ? semanticColors.text.disabled : semanticColors.text.error} size={"sm"} theme={{sm: {size: '16px'}}} ><WarningAmberOutlined/></Icon>
-				</div>
+				<StatusRow
+					label="Incomplete"
+					isDisabled={isDisabled}
+					iconColor={semanticColors.text.error}
+					icon={<WarningAmberOutlined />}
+				/>
 			);
 	}
 };

--- a/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
@@ -206,13 +206,14 @@ export const StandRedesignStepNav = ({
 				const isDisabled = !shouldRenderAsButton(step);
 				return (
 					<li key={step.id}>
-					<Step isDisabled={isDisabled}
-					      onClick={() => handleStepClick(step.id)}
-								index={index}
-								isCurrent={isCurrent(step)}
-								stepStatus={stepStatus}
-								ariaLabel={buildStepAriaLabel(description, isCurrent(step), stepStatus)}
-								description={description}
+					<Step
+						isDisabled={isDisabled}
+						onClick={() => handleStepClick(step.id)}
+						index={index}
+						isCurrent={isCurrent(step)}
+						stepStatus={stepStatus}
+						ariaLabel={buildStepAriaLabel(description, isCurrent(step), stepStatus)}
+						description={description}
 					/>
 					</li>
 				);

--- a/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
@@ -1,12 +1,13 @@
 import { css } from '@emotion/react'
-import { semanticColors } from '@guardian/stand';
+import { baseColors, semanticColors } from '@guardian/stand';
 import { Icon } from '@guardian/stand/icon';
 import { Typography } from '@guardian/stand/typography'
-import { CheckCircleOutlined, WarningAmberOutlined } from '@mui/icons-material';
+import { CheckCircleOutlined, CircleSharp, WarningAmberOutlined } from '@mui/icons-material';
 import {
 	Stepper
 } from '@mui/material';
 import { useState } from 'react';
+import { Button } from 'react-aria-components';
 import { resolveStepStatus, StepStatus } from '@newsletters-nx/state-machine';
 import type {
 	StepListing,
@@ -22,28 +23,38 @@ interface Props {
 	formData?: WizardFormData;
 }
 
-const CompletionCaption = (props: { status: StepStatus | undefined }) => {
+type StepProps = {
+	key: string;
+	isCurrent: boolean;
+	stepStatus?: StepStatus;
+	index: number;
+	onClick: () => void;
+	ariaLabel: string;
+	isDisabled: boolean;
+	description: string;
+}
+
+const CompletionCaption = (props: { status: StepStatus; isDisabled: boolean}) => {
 	switch (props.status) {
-		case undefined:
 		case StepStatus.NoFields:
 			return null;
 		case StepStatus.Optional:
 			return (
 				<div css={css`display: flex; gap: 6px; align-items: center;`}>
-					<Typography variant="body-sm" theme={{color: semanticColors.text.weak}} element="span">Optional</Typography> <Icon fill={semanticColors.text.success} size={"sm"} theme={{sm: {size: '16px'}}} ><WarningAmberOutlined/></Icon>
+					<Typography variant="body-sm" theme={{color: props.isDisabled ? semanticColors.text.disabled :  semanticColors.text.weak}} element="span">Optional</Typography> <Icon fill={props.isDisabled ? semanticColors.text.disabled : semanticColors.text['success-inverse']} size={"sm"} theme={{sm: {size: '16px'}}} ><CircleSharp/></Icon>
 				</div>
 
 			);
 		case StepStatus.Complete:
 			return (
 				<div css={css`display: flex; gap: 6px; align-items: center;`}>
-					<Typography variant="body-sm" theme={{color: semanticColors.text.weak}} element="span">Complete</Typography> <Icon fill={semanticColors.text.success} size={"sm"} theme={{sm: {size: '16px'}}} ><CheckCircleOutlined/></Icon>
+					<Typography variant="body-sm" theme={{color: props.isDisabled ? semanticColors.text.disabled :  semanticColors.text.weak}} element="span">Complete</Typography> <Icon fill={props.isDisabled ? semanticColors.text.disabled : semanticColors.text.success} size={"sm"} theme={{sm: {size: '16px'}}} ><CheckCircleOutlined/></Icon>
 				</div>
 			);
 		case StepStatus.Incomplete:
 			return (
 				<div css={css`display: flex; gap: 6px; align-items: center;`}>
-					<Typography variant="body-sm" theme={{color: semanticColors.text.weak}} element="span">Incomplete </Typography> <Icon fill={semanticColors.text.error} size={"sm"} theme={{sm: {size: '16px'}}} ><WarningAmberOutlined/></Icon>
+					<Typography variant="body-sm" theme={{color: props.isDisabled ? semanticColors.text.disabled : semanticColors.text.weak}} element="span">Incomplete </Typography> <Icon fill={props.isDisabled ? semanticColors.text.disabled : semanticColors.text.error} size={"sm"} theme={{sm: {size: '16px'}}} ><WarningAmberOutlined/></Icon>
 				</div>
 			);
 	}
@@ -158,36 +169,94 @@ export const StandRedesignStepNav = ({
 			{filteredStepList.map((step, index) => {
 				const stepStatus = completionRecord[step.id];
 				const description = step.label ?? step.id;
-
+				const isDisabled = !shouldRenderAsButton(step);
 				return (
-					<div
-						role={shouldRenderAsButton(step) ? 'button' : undefined}
-						key={step.id}
-						aria-label={ariaLabelForNonButtonStep(description, isCurrent(step), stepStatus)}
-						onClick={shouldRenderAsButton(step) ? () => handleStepClick(step.id) : undefined}
-					>
-
-							<div css={css`height: 72px;
-								border-bottom: 1px solid ${semanticColors.border.weak};
-								display: grid;
-								grid-template-columns: 32px 270px;
-							`}>
-								<Typography element="div" theme={{color: isCurrent(step) ? semanticColors.text['stronger-inverse'] : semanticColors.text.strong}}
-														cssOverrides={css`width: 32px;
-															height: 100%;
-															background-color: ${isCurrent(step) ? semanticColors.fill.selected : 'transparent'};
-															border-right: 1px solid ${semanticColors.border.weak};
-															display: flex; align-items: center; justify-content: center;`}>
-									{index}
-								</Typography>
-								<div css={css`gap: 4px; display: flex; flex-direction: column; justify-content: center; margin-left:12px`}>
-								<Typography element="div" variant="heading-md">{description}</Typography>
-									<CompletionCaption status={stepStatus} />
-								</div>
-							</div>
-					</div>
+					<Step isDisabled={isDisabled}
+								key={step.id}
+					      onClick={() => handleStepClick(step.id)}
+								index={index}
+								isCurrent={isCurrent(step)}
+								stepStatus={stepStatus}
+								ariaLabel={ariaLabelForNonButtonStep(description, isCurrent(step), stepStatus)}
+								description={description}
+					/>
 				);
 			})}
 		</Stepper>
 	);
 };
+
+
+
+export const Step = ({key, isDisabled, isCurrent, index, stepStatus, onClick, ariaLabel, description}: StepProps ) => {
+
+	const descriptionTypographyColor =
+		isCurrent || !isDisabled ? semanticColors.text.strong : semanticColors.text.disabled;
+	const backgroundColor =
+		isCurrent ? semanticColors.bg["raised-level-1"] : baseColors.neutral["900"]
+
+	const buttonStyles = css`
+		appearance: none;
+		-webkit-appearance: none;
+		background-color: ${backgroundColor} ;
+		height: 72px;
+		border: none;
+		border-bottom: 1px solid ${semanticColors.border.weak};
+		display: grid;
+		grid-template-columns: 32px 270px;
+		padding: 0;
+		margin: 0;
+		font: inherit;
+		color: inherit;
+		text-align: left;
+		width: 100%;
+		&[data-pressed] {
+			background-color: ${semanticColors.bg["raised-level-1"]};
+		}
+	`;
+	return (
+		<Button
+			css={buttonStyles}
+			isDisabled={isDisabled}
+			key={key}
+			aria-label={ariaLabel}
+			onClick={() => onClick()}
+		>{({isHovered}) => (
+			<>
+				<Typography
+					element="div"
+					theme={{
+						color: isHovered || isCurrent ? semanticColors.text['stronger-inverse'] : isDisabled ? semanticColors.text.disabled : semanticColors.text.strong
+					}}
+					cssOverrides={css`
+					width: 32px;
+					height: 100%;
+					background-color: ${isCurrent || isHovered
+						? semanticColors.fill.selected
+						: 'transparent'};
+					border-right: 1px solid ${semanticColors.border.weak};
+					display: flex;
+					align-items: center;
+					justify-content: center;
+				`}
+				>
+					{index}
+				</Typography>
+				<div
+					css={css`
+					gap: 4px;
+					display: flex;
+					flex-direction: column;
+					justify-content: center;
+					margin-left: 12px;
+				`}
+				>
+					<Typography element="div" theme={{color: descriptionTypographyColor}} variant="heading-md">
+						{description}
+					</Typography>
+					{stepStatus !== undefined && <CompletionCaption status={stepStatus} isDisabled={isDisabled && !isCurrent} />}
+				</div>
+			</>
+		)}
+		</Button>
+	)};

--- a/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
@@ -252,19 +252,21 @@ const Step = ({isDisabled, isCurrent, index, stepStatus, onClick, ariaLabel, des
 		isCurrent ? semanticColors.bg["raised-level-1"] : baseColors.neutral["900"]
 
 	const buttonStyles = css`
+		// override UA styles
 		appearance: none;
 		-webkit-appearance: none;
 		background-color: ${backgroundColor} ;
-		height: 72px;
+		font: inherit;
+		color: inherit;
 		border: none;
+		padding: 0;
+		margin: 0;
+		// our own styles
+		height: 72px;
 		cursor: ${isDisabled ? 'default' : 'pointer'};
 		border-bottom: 1px solid ${semanticColors.border.weak};
 		display: grid;
 		grid-template-columns: 32px 233px;
-		padding: 0;
-		margin: 0;
-		font: inherit;
-		color: inherit;
 		text-align: left;
 		width: 100%;
 		&[data-pressed] {

--- a/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
@@ -1,9 +1,13 @@
-import { css } from '@emotion/react'
+import { css } from '@emotion/react';
 import { baseColors, semanticColors } from '@guardian/stand';
 import { Icon } from '@guardian/stand/icon';
-import { Typography } from '@guardian/stand/typography'
-import { CheckCircleOutlined, CircleSharp, WarningAmberOutlined } from '@mui/icons-material';
-import type { ReactNode} from 'react';
+import { Typography } from '@guardian/stand/typography';
+import {
+	CheckCircleOutlined,
+	CircleSharp,
+	WarningAmberOutlined,
+} from '@mui/icons-material';
+import type { ReactNode } from 'react';
 import { useState } from 'react';
 import { Button } from 'react-aria-components';
 import { resolveStepStatus, StepStatus } from '@newsletters-nx/state-machine';
@@ -29,7 +33,7 @@ type StepProps = {
 	ariaLabel: string;
 	isDisabled: boolean;
 	description: string;
-}
+};
 
 type StatusRowProps = {
 	label: string;
@@ -39,11 +43,21 @@ type StatusRowProps = {
 };
 
 const StatusRow = ({ label, icon, iconColor, isDisabled }: StatusRowProps) => (
-	<div css={css`display: flex; gap: 6px; align-items: center;`}>
+	<div
+		css={css`
+			display: flex;
+			gap: 6px;
+			align-items: center;
+		`}
+	>
 		<Typography
 			variant="body-sm"
 			element="span"
-			theme={{ color: isDisabled ? semanticColors.text.disabled : semanticColors.text.weak }}
+			theme={{
+				color: isDisabled
+					? semanticColors.text.disabled
+					: semanticColors.text.weak,
+			}}
 		>
 			{label}
 		</Typography>
@@ -57,7 +71,13 @@ const StatusRow = ({ label, icon, iconColor, isDisabled }: StatusRowProps) => (
 	</div>
 );
 
-const CompletionCaption = ({status, isDisabled}: { status: StepStatus; isDisabled: boolean}) => {
+const CompletionCaption = ({
+	status,
+	isDisabled,
+}: {
+	status: StepStatus;
+	isDisabled: boolean;
+}) => {
 	switch (status) {
 		case StepStatus.NoFields:
 			return null;
@@ -96,7 +116,6 @@ const buildStepAriaLabel = (
 	active: boolean,
 	status?: StepStatus,
 ): string => {
-
 	const statusDescription =
 		status === StepStatus.Complete
 			? 'complete'
@@ -199,63 +218,99 @@ export const StandRedesignStepNav = ({
 			`}
 			aria-label="Newsletter creation steps"
 		>
-			<ol css={css`list-style: none; padding: 0; margin: 0;`}>
-			{filteredStepList.map((step, index) => {
-				const stepStatus = completionRecord[step.id];
-				const description = step.label ?? step.id;
-				const isDisabled = !shouldRenderAsButton(step);
-				return (
-					<li key={step.id}>
-					<Step
-						isDisabled={isDisabled}
-						onClick={() => handleStepClick(step.id)}
-						index={index}
-						isCurrent={isCurrent(step)}
-						stepStatus={stepStatus}
-						ariaLabel={buildStepAriaLabel(description, isCurrent(step), stepStatus)}
-						description={description}
-					/>
-					</li>
-				);
-			})}
+			<ol
+				css={css`
+					list-style: none;
+					padding: 0;
+					margin: 0;
+				`}
+			>
+				{filteredStepList.map((step, index) => {
+					const stepStatus = completionRecord[step.id];
+					const description = step.label ?? step.id;
+					const isDisabled = !shouldRenderAsButton(step);
+					return (
+						<li key={step.id}>
+							<Step
+								isDisabled={isDisabled}
+								onClick={() => handleStepClick(step.id)}
+								index={index}
+								isCurrent={isCurrent(step)}
+								stepStatus={stepStatus}
+								ariaLabel={buildStepAriaLabel(
+									description,
+									isCurrent(step),
+									stepStatus,
+								)}
+								description={description}
+							/>
+						</li>
+					);
+				})}
 			</ol>
 		</nav>
 	);
 };
 
-
-const StepNumber = ({stepNumber, isHovered, isCurrent, isDisabled}: {stepNumber: number; isHovered: boolean; isCurrent: boolean; isDisabled: boolean}) =>
+const StepNumber = ({
+	stepNumber,
+	isHovered,
+	isCurrent,
+	isDisabled,
+}: {
+	stepNumber: number;
+	isHovered: boolean;
+	isCurrent: boolean;
+	isDisabled: boolean;
+}) => (
 	<Typography
-	element="div"
-	theme={{
-		color: isHovered || isCurrent ? semanticColors.text['stronger-inverse'] : isDisabled ? semanticColors.text.disabled : semanticColors.text.strong
-	}}
-	cssOverrides={css`
-					width: 32px;
-					height: 100%;
-					background-color: ${isCurrent || isHovered
-		? semanticColors.fill.selected
-		: 'transparent'};
-					border-right: 1px solid ${semanticColors.border.weak};
-					display: flex;
-					align-items: center;
-					justify-content: center;
-				`}
->
-	{stepNumber}
-</Typography>
+		element="div"
+		theme={{
+			color:
+				isHovered || isCurrent
+					? semanticColors.text['stronger-inverse']
+					: isDisabled
+						? semanticColors.text.disabled
+						: semanticColors.text.strong,
+		}}
+		cssOverrides={css`
+			width: 32px;
+			height: 100%;
+			background-color: ${isCurrent || isHovered
+				? semanticColors.fill.selected
+				: 'transparent'};
+			border-right: 1px solid ${semanticColors.border.weak};
+			display: flex;
+			align-items: center;
+			justify-content: center;
+		`}
+	>
+		{stepNumber}
+	</Typography>
+);
 
-const Step = ({isDisabled, isCurrent, index, stepStatus, onClick, ariaLabel, description}: StepProps ) => {
+const Step = ({
+	isDisabled,
+	isCurrent,
+	index,
+	stepStatus,
+	onClick,
+	ariaLabel,
+	description,
+}: StepProps) => {
 	const descriptionTypographyColor =
-		isCurrent || !isDisabled ? semanticColors.text.strong : semanticColors.text.disabled;
-	const backgroundColor =
-		isCurrent ? semanticColors.bg["raised-level-1"] : baseColors.neutral["900"]
+		isCurrent || !isDisabled
+			? semanticColors.text.strong
+			: semanticColors.text.disabled;
+	const backgroundColor = isCurrent
+		? semanticColors.bg['raised-level-1']
+		: baseColors.neutral['900'];
 
 	const buttonStyles = css`
 		// override UA styles
 		appearance: none;
 		-webkit-appearance: none;
-		background-color: ${backgroundColor} ;
+		background-color: ${backgroundColor};
 		font: inherit;
 		color: inherit;
 		border: none;
@@ -270,7 +325,7 @@ const Step = ({isDisabled, isCurrent, index, stepStatus, onClick, ariaLabel, des
 		text-align: left;
 		width: 100%;
 		&[data-pressed] {
-			background-color: ${semanticColors.bg["raised-level-1"]};
+			background-color: ${semanticColors.bg['raised-level-1']};
 		}
 	`;
 	return (
@@ -281,24 +336,40 @@ const Step = ({isDisabled, isCurrent, index, stepStatus, onClick, ariaLabel, des
 			aria-label={ariaLabel}
 			aria-current={isCurrent ? 'step' : undefined}
 			onClick={() => onClick()}
-		>{({isHovered}) => (
-			<>
-				<StepNumber stepNumber={index} isHovered={isHovered} isCurrent={isCurrent} isDisabled={isDisabled}/>
-				<div
-					css={css`
-					gap: 4px;
-					display: flex;
-					flex-direction: column;
-					justify-content: center;
-					margin-left: 12px;
-				`}
-				>
-					<Typography element="div" theme={{color: descriptionTypographyColor}} variant="heading-md">
-						{description}
-					</Typography>
-					{stepStatus !== undefined && <CompletionCaption status={stepStatus} isDisabled={isDisabled && !isCurrent} />}
-				</div>
-			</>
-		)}
+		>
+			{({ isHovered }) => (
+				<>
+					<StepNumber
+						stepNumber={index}
+						isHovered={isHovered}
+						isCurrent={isCurrent}
+						isDisabled={isDisabled}
+					/>
+					<div
+						css={css`
+							gap: 4px;
+							display: flex;
+							flex-direction: column;
+							justify-content: center;
+							margin-left: 12px;
+						`}
+					>
+						<Typography
+							element="div"
+							theme={{ color: descriptionTypographyColor }}
+							variant="heading-md"
+						>
+							{description}
+						</Typography>
+						{stepStatus !== undefined && (
+							<CompletionCaption
+								status={stepStatus}
+								isDisabled={isDisabled && !isCurrent}
+							/>
+						)}
+					</div>
+				</>
+			)}
 		</Button>
-	)};
+	);
+};

--- a/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
@@ -24,7 +24,7 @@ type StepProps = {
 	isCurrent: boolean;
 	stepStatus?: StepStatus;
 	stepNumber: number;
-	onClick: () => void;
+	onPress: () => void;
 	ariaLabel: string;
 	isDisabled: boolean;
 	description: string;
@@ -236,7 +236,7 @@ export const StandRedesignStepNav = ({
 						<li key={step.id}>
 							<Step
 								isDisabled={isDisabled}
-								onClick={() => handleStepClick(step.id)}
+								onPress={() => handleStepClick(step.id)}
 								stepNumber={index}
 								isCurrent={isCurrent(step)}
 								stepStatus={stepStatus}
@@ -297,7 +297,7 @@ const Step = ({
 	isCurrent,
 	stepNumber,
 	stepStatus,
-	onClick,
+	onPress,
 	ariaLabel,
 	description,
 }: StepProps) => {
@@ -338,7 +338,7 @@ const Step = ({
 			isDisabled={isDisabled}
 			aria-label={ariaLabel}
 			aria-current={isCurrent ? 'step' : undefined}
-			onPress={() => onClick()}
+			onPress={onPress}
 		>
 			{({ isHovered }) => (
 				<>

--- a/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
@@ -1,9 +1,10 @@
+import { css } from '@emotion/react'
+import { semanticColors } from '@guardian/stand';
+import { Icon } from '@guardian/stand/icon';
+import { Typography } from '@guardian/stand/typography'
+import { CheckCircleOutlined, WarningAmberOutlined } from '@mui/icons-material';
 import {
-	Step,
-	StepButton,
-	StepLabel,
-	Stepper,
-	Typography,
+	Stepper
 } from '@mui/material';
 import { useState } from 'react';
 import { resolveStepStatus, StepStatus } from '@newsletters-nx/state-machine';
@@ -28,30 +29,22 @@ const CompletionCaption = (props: { status: StepStatus | undefined }) => {
 			return null;
 		case StepStatus.Optional:
 			return (
-				<Typography variant="caption">
-					Optional{' '}
-					<span role="img" aria-label="green-cross">
-						❎
-					</span>
-				</Typography>
+				<div css={css`display: flex; gap: 6px; align-items: center;`}>
+					<Typography variant="body-sm" theme={{color: semanticColors.text.weak}} element="span">Optional</Typography> <Icon fill={semanticColors.text.success} size={"sm"} theme={{sm: {size: '16px'}}} ><WarningAmberOutlined/></Icon>
+				</div>
+
 			);
 		case StepStatus.Complete:
 			return (
-				<Typography variant="caption">
-					Complete{' '}
-					<span role="img" aria-label="checkmark">
-						✅
-					</span>
-				</Typography>
+				<div css={css`display: flex; gap: 6px; align-items: center;`}>
+					<Typography variant="body-sm" theme={{color: semanticColors.text.weak}} element="span">Complete</Typography> <Icon fill={semanticColors.text.success} size={"sm"} theme={{sm: {size: '16px'}}} ><CheckCircleOutlined/></Icon>
+				</div>
 			);
 		case StepStatus.Incomplete:
 			return (
-				<Typography variant="caption">
-					Incomplete{' '}
-					<span role="img" aria-label="cross">
-						❌
-					</span>
-				</Typography>
+				<div css={css`display: flex; gap: 6px; align-items: center;`}>
+					<Typography variant="body-sm" theme={{color: semanticColors.text.weak}} element="span">Incomplete </Typography> <Icon fill={semanticColors.text.error} size={"sm"} theme={{sm: {size: '16px'}}} ><WarningAmberOutlined/></Icon>
+				</div>
 			);
 	}
 };
@@ -154,54 +147,45 @@ export const StandRedesignStepNav = ({
 	return (
 		<Stepper
 			sx={{ flexWrap: 'wrap' }}
+			css={css`
+				border-right: 1px solid ${semanticColors.border.strong};
+			`}
 			nonLinear={stepperConfig.isNonLinear}
 			connector={null}
 			component={'nav'}
 			orientation="vertical"
 		>
-			{filteredStepList.map((step) => {
+			{filteredStepList.map((step, index) => {
 				const stepStatus = completionRecord[step.id];
 				const description = step.label ?? step.id;
-				const isButton = shouldRenderAsButton(step);
-
-				const caption = stepperConfig.indicateStepsComplete ? (
-					<CompletionCaption status={stepStatus} />
-				) : undefined;
 
 				return (
-					<Step
-						sx={{
-							paddingBottom: 0.5,
-						}}
+					<div
+						role={shouldRenderAsButton(step) ? 'button' : undefined}
 						key={step.id}
-						active={isCurrent(step)}
-						component={isButton ? 'div' : 'section'}
-						aria-label={
-							isButton
-								? undefined
-								: ariaLabelForNonButtonStep(
-										description,
-										isCurrent(step),
-										stepStatus,
-									)
-						}
-						aria-live="polite"
+						aria-label={ariaLabelForNonButtonStep(description, isCurrent(step), stepStatus)}
+						onClick={shouldRenderAsButton(step) ? () => handleStepClick(step.id) : undefined}
 					>
-						{isButton ? (
-							<StepButton
-								aria-label={`skip to "${description}" step`}
-								className="left-aligned-step-button"
-								onClick={() => {
-									handleStepClick(step.id);
-								}}
-								optional={caption}
-							>
-								{description}
-							</StepButton>
-						) : (
-							<StepLabel optional={caption}> {description}</StepLabel>
-						)}
-					</Step>
+
+							<div css={css`height: 72px;
+								border-bottom: 1px solid ${semanticColors.border.weak};
+								display: grid;
+								grid-template-columns: 32px 270px;
+							`}>
+								<Typography element="div" theme={{color: isCurrent(step) ? semanticColors.text['stronger-inverse'] : semanticColors.text.strong}}
+														cssOverrides={css`width: 32px;
+															height: 100%;
+															background-color: ${isCurrent(step) ? semanticColors.fill.selected : 'transparent'};
+															border-right: 1px solid ${semanticColors.border.weak};
+															display: flex; align-items: center; justify-content: center;`}>
+									{index}
+								</Typography>
+								<div css={css`gap: 4px; display: flex; flex-direction: column; justify-content: center; margin-left:12px`}>
+								<Typography element="div" variant="heading-md">{description}</Typography>
+									<CompletionCaption status={stepStatus} />
+								</div>
+							</div>
+					</div>
 				);
 			})}
 		</Stepper>

--- a/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
@@ -342,7 +342,7 @@ const Step = ({
 			isDisabled={isDisabled}
 			aria-label={ariaLabel}
 			aria-current={isCurrent ? 'step' : undefined}
-			onClick={() => onClick()}
+			onPress={() => onClick()}
 		>
 			{({ isHovered }) => (
 				<>

--- a/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
@@ -28,7 +28,7 @@ interface Props {
 type StepProps = {
 	isCurrent: boolean;
 	stepStatus?: StepStatus;
-	index: number;
+	stepNumber: number;
 	onClick: () => void;
 	ariaLabel: string;
 	isDisabled: boolean;
@@ -234,7 +234,7 @@ export const StandRedesignStepNav = ({
 							<Step
 								isDisabled={isDisabled}
 								onClick={() => handleStepClick(step.id)}
-								index={index}
+								stepNumber={index}
 								isCurrent={isCurrent(step)}
 								stepStatus={stepStatus}
 								ariaLabel={buildStepAriaLabel(
@@ -292,7 +292,7 @@ const StepNumber = ({
 const Step = ({
 	isDisabled,
 	isCurrent,
-	index,
+	stepNumber,
 	stepStatus,
 	onClick,
 	ariaLabel,
@@ -340,7 +340,7 @@ const Step = ({
 			{({ isHovered }) => (
 				<>
 					<StepNumber
-						stepNumber={index}
+						stepNumber={stepNumber}
 						isHovered={isHovered}
 						isCurrent={isCurrent}
 						isDisabled={isDisabled}

--- a/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
@@ -3,9 +3,6 @@ import { baseColors, semanticColors } from '@guardian/stand';
 import { Icon } from '@guardian/stand/icon';
 import { Typography } from '@guardian/stand/typography'
 import { CheckCircleOutlined, CircleSharp, WarningAmberOutlined } from '@mui/icons-material';
-import {
-	Stepper
-} from '@mui/material';
 import { useState } from 'react';
 import { Button } from 'react-aria-components';
 import { resolveStepStatus, StepStatus } from '@newsletters-nx/state-machine';
@@ -24,7 +21,6 @@ interface Props {
 }
 
 type StepProps = {
-	key: string;
 	isCurrent: boolean;
 	stepStatus?: StepStatus;
 	index: number;
@@ -60,28 +56,32 @@ const CompletionCaption = (props: { status: StepStatus; isDisabled: boolean}) =>
 	}
 };
 
-const ariaLabelForNonButtonStep = (
+const buildStepAriaLabel = (
 	description: string,
 	active: boolean,
 	status?: StepStatus,
 ): string => {
+
+	const statusDescription =
+		status === StepStatus.Complete
+			? 'complete'
+			: status === StepStatus.Incomplete
+				? 'incomplete'
+				: status === StepStatus.Optional
+					? 'optional'
+					: undefined;
+
+	const parts = [description];
+
+	if (statusDescription) {
+		parts.push(statusDescription);
+	}
+
 	if (active) {
-		return `${description} (current step)`;
+		parts.push('current step');
 	}
 
-	let statusDecription = '';
-	switch (status) {
-		case StepStatus.Complete:
-			statusDecription = '(complete)';
-			break;
-		case StepStatus.Incomplete:
-			statusDecription = '(incomplete)';
-			break;
-		case StepStatus.Optional:
-			statusDecription = '(optional)';
-	}
-
-	return `${description} ${statusDecription}`;
+	return parts.join(', ');
 };
 
 export const StandRedesignStepNav = ({
@@ -156,39 +156,40 @@ export const StandRedesignStepNav = ({
 		!isCurrent(step);
 
 	return (
-		<Stepper
-			sx={{ flexWrap: 'wrap' }}
+		<nav
 			css={css`
 				border-right: 1px solid ${semanticColors.border.strong};
+				display: flex;
+				flex-direction: column;
 			`}
-			nonLinear={stepperConfig.isNonLinear}
-			connector={null}
-			component={'nav'}
-			orientation="vertical"
+			aria-label="Newsletter creation steps"
 		>
+			<ol css={css`list-style: none; padding: 0; margin: 0;`}>
 			{filteredStepList.map((step, index) => {
 				const stepStatus = completionRecord[step.id];
 				const description = step.label ?? step.id;
 				const isDisabled = !shouldRenderAsButton(step);
 				return (
+					<li key={step.id}>
 					<Step isDisabled={isDisabled}
-								key={step.id}
 					      onClick={() => handleStepClick(step.id)}
 								index={index}
 								isCurrent={isCurrent(step)}
 								stepStatus={stepStatus}
-								ariaLabel={ariaLabelForNonButtonStep(description, isCurrent(step), stepStatus)}
+								ariaLabel={buildStepAriaLabel(description, isCurrent(step), stepStatus)}
 								description={description}
 					/>
+					</li>
 				);
 			})}
-		</Stepper>
+			</ol>
+		</nav>
 	);
 };
 
 
 
-export const Step = ({key, isDisabled, isCurrent, index, stepStatus, onClick, ariaLabel, description}: StepProps ) => {
+export const Step = ({isDisabled, isCurrent, index, stepStatus, onClick, ariaLabel, description}: StepProps ) => {
 
 	const descriptionTypographyColor =
 		isCurrent || !isDisabled ? semanticColors.text.strong : semanticColors.text.disabled;
@@ -218,8 +219,8 @@ export const Step = ({key, isDisabled, isCurrent, index, stepStatus, onClick, ar
 		<Button
 			css={buttonStyles}
 			isDisabled={isDisabled}
-			key={key}
 			aria-label={ariaLabel}
+			aria-current={isCurrent ? 'step' : undefined}
 			onClick={() => onClick()}
 		>{({isHovered}) => (
 			<>

--- a/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
@@ -116,14 +116,21 @@ const buildStepAriaLabel = (
 	active: boolean,
 	status?: StepStatus,
 ): string => {
-	const statusDescription =
-		status === StepStatus.Complete
-			? 'complete'
-			: status === StepStatus.Incomplete
-				? 'incomplete'
-				: status === StepStatus.Optional
-					? 'optional'
-					: undefined;
+	const statusDescription = (() => {
+		switch (status) {
+			case StepStatus.Complete:
+				return 'complete';
+
+			case StepStatus.Incomplete:
+				return 'incomplete';
+
+			case StepStatus.Optional:
+				return 'optional';
+
+			default:
+				return undefined;
+		}
+	})();
 
 	const parts = [description];
 

--- a/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
@@ -188,9 +188,28 @@ export const StandRedesignStepNav = ({
 };
 
 
+const StepNumber = ({stepNumber, isHovered, isCurrent, isDisabled}: {stepNumber: number; isHovered: boolean; isCurrent: boolean; isDisabled: boolean}) =>
+	<Typography
+	element="div"
+	theme={{
+		color: isHovered || isCurrent ? semanticColors.text['stronger-inverse'] : isDisabled ? semanticColors.text.disabled : semanticColors.text.strong
+	}}
+	cssOverrides={css`
+					width: 32px;
+					height: 100%;
+					background-color: ${isCurrent || isHovered
+		? semanticColors.fill.selected
+		: 'transparent'};
+					border-right: 1px solid ${semanticColors.border.weak};
+					display: flex;
+					align-items: center;
+					justify-content: center;
+				`}
+>
+	{stepNumber}
+</Typography>
 
-export const Step = ({isDisabled, isCurrent, index, stepStatus, onClick, ariaLabel, description}: StepProps ) => {
-
+const Step = ({isDisabled, isCurrent, index, stepStatus, onClick, ariaLabel, description}: StepProps ) => {
 	const descriptionTypographyColor =
 		isCurrent || !isDisabled ? semanticColors.text.strong : semanticColors.text.disabled;
 	const backgroundColor =
@@ -205,7 +224,7 @@ export const Step = ({isDisabled, isCurrent, index, stepStatus, onClick, ariaLab
 		cursor: ${isDisabled ? 'default' : 'pointer'};
 		border-bottom: 1px solid ${semanticColors.border.weak};
 		display: grid;
-		grid-template-columns: 32px 270px;
+		grid-template-columns: 32px 233px;
 		padding: 0;
 		margin: 0;
 		font: inherit;
@@ -226,25 +245,7 @@ export const Step = ({isDisabled, isCurrent, index, stepStatus, onClick, ariaLab
 			onClick={() => onClick()}
 		>{({isHovered}) => (
 			<>
-				<Typography
-					element="div"
-					theme={{
-						color: isHovered || isCurrent ? semanticColors.text['stronger-inverse'] : isDisabled ? semanticColors.text.disabled : semanticColors.text.strong
-					}}
-					cssOverrides={css`
-					width: 32px;
-					height: 100%;
-					background-color: ${isCurrent || isHovered
-						? semanticColors.fill.selected
-						: 'transparent'};
-					border-right: 1px solid ${semanticColors.border.weak};
-					display: flex;
-					align-items: center;
-					justify-content: center;
-				`}
-				>
-					{index}
-				</Typography>
+				<StepNumber stepNumber={index} isHovered={isHovered} isCurrent={isCurrent} isDisabled={isDisabled}/>
 				<div
 					css={css`
 					gap: 4px;

--- a/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
@@ -202,6 +202,7 @@ export const Step = ({isDisabled, isCurrent, index, stepStatus, onClick, ariaLab
 		background-color: ${backgroundColor} ;
 		height: 72px;
 		border: none;
+		cursor: ${isDisabled ? 'default' : 'pointer'};
 		border-bottom: 1px solid ${semanticColors.border.weak};
 		display: grid;
 		grid-template-columns: 32px 270px;
@@ -216,6 +217,7 @@ export const Step = ({isDisabled, isCurrent, index, stepStatus, onClick, ariaLab
 		}
 	`;
 	return (
+		// Use a button instead of a link here because it is a single page application
 		<Button
 			css={buttonStyles}
 			isDisabled={isDisabled}

--- a/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
@@ -1,13 +1,8 @@
 import { css } from '@emotion/react';
 import { baseColors, semanticColors } from '@guardian/stand';
+import type { IconProps } from '@guardian/stand/icon';
 import { Icon } from '@guardian/stand/icon';
 import { Typography } from '@guardian/stand/typography';
-import {
-	CheckCircleOutlined,
-	CircleSharp,
-	WarningAmberOutlined,
-} from '@mui/icons-material';
-import type { ReactNode } from 'react';
 import { useState } from 'react';
 import { Button } from 'react-aria-components';
 import { resolveStepStatus, StepStatus } from '@newsletters-nx/state-machine';
@@ -35,9 +30,11 @@ type StepProps = {
 	description: string;
 };
 
+type StandIconSymbol = IconProps['symbol'];
+
 type StatusRowProps = {
 	label: string;
-	icon: ReactNode;
+	icon: StandIconSymbol;
 	iconColor: string;
 	isDisabled: boolean;
 };
@@ -65,9 +62,8 @@ const StatusRow = ({ label, icon, iconColor, isDisabled }: StatusRowProps) => (
 			fill={isDisabled ? semanticColors.text.disabled : iconColor}
 			size="sm"
 			theme={{ sm: { size: '16px' } }}
-		>
-			{icon}
-		</Icon>
+			symbol={icon}
+		/>
 	</div>
 );
 
@@ -87,7 +83,7 @@ const CompletionCaption = ({
 					label="Optional"
 					isDisabled={isDisabled}
 					iconColor={semanticColors.text['success-inverse']}
-					icon={<CircleSharp />}
+					icon="circle"
 				/>
 			);
 		case StepStatus.Complete:
@@ -96,7 +92,7 @@ const CompletionCaption = ({
 					label="Complete"
 					isDisabled={isDisabled}
 					iconColor={semanticColors.text.success}
-					icon={<CheckCircleOutlined />}
+					icon="check_circle"
 				/>
 			);
 		case StepStatus.Incomplete:
@@ -105,7 +101,7 @@ const CompletionCaption = ({
 					label="Incomplete"
 					isDisabled={isDisabled}
 					iconColor={semanticColors.text.error}
-					icon={<WarningAmberOutlined />}
+					icon="warning"
 				/>
 			);
 	}

--- a/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { baseSpacing, semanticColors } from '@guardian/stand';
-import { Alert, Box, Container, Stack, Typography } from '@mui/material';
+import { Alert, Box, Stack, Typography } from '@mui/material';
 import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import type { WizardId } from '@newsletters-nx/newsletter-workflow';
@@ -31,9 +31,7 @@ export const StandRedesignWizardContainer: React.FC<WizardProps> = ({
 }: WizardProps) => {
 	const { listId } = useParams();
 	return (
-		<Container>
 			<StandRedesignWizard wizardId={wizardId} id={listId} />
-		</Container>
 	);
 };
 
@@ -245,6 +243,7 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 	return (
 		<div
 			css={css`
+				height: 100%;
 				display: flex;
 				gap: 40px;
 			`}
@@ -256,11 +255,7 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 				handleStepClick={handleStepClick}
 				formData={formData}
 			/>
-			<div
-				css={css`
-					margin-top: ${baseSpacing['48-rem']};
-				`}
-			>
+			<div>
 				<StandRedesignMarkdownView
 					markdown={serverData.markdownToDisplay ?? ''}
 				/>

--- a/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
@@ -255,7 +255,11 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 				handleStepClick={handleStepClick}
 				formData={formData}
 			/>
-			<div>
+			<div
+				css={css`
+					margin-top: ${baseSpacing['48-rem']};
+				`}
+			>
 				<StandRedesignMarkdownView
 					markdown={serverData.markdownToDisplay ?? ''}
 				/>

--- a/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
@@ -30,9 +30,7 @@ export const StandRedesignWizardContainer: React.FC<WizardProps> = ({
 	wizardId,
 }: WizardProps) => {
 	const { listId } = useParams();
-	return (
-			<StandRedesignWizard wizardId={wizardId} id={listId} />
-	);
+	return <StandRedesignWizard wizardId={wizardId} id={listId} />;
 };
 
 /**


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Updates the Stand redesign flow to use a new stepper side nav component. This is part of the redesign seen here in [figma](https://www.figma.com/design/gmHnKr3tOzvnYp1FZeIl4t/Stand--Editorial-tool-Design-System--WIP%F0%9F%9A%A7-?node-id=446-10264&t=FipizOsPE5qgFMg0-0). 

- a button as the pages of the wizard do not have different urls.
- `<ol> <li> </li> </ol>` for some additional semantic meaning.
- aria-current="step" on the active button is the right signal.

TODO in another PR
- [ ]  mobile breakpoints

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

It has only been tested locally but this is all behind the feature switch so shouldn't affect any of the core flow for now.

Before this PR there is a bug in the stand flow where it breaks on step 2. This needs to be looked at separately.

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

Low risk as behind a feature switch.

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

<img width="337" height="743" alt="Screenshot 2026-05-08 at 13 06 32" src="https://github.com/user-attachments/assets/c8b5e513-ce79-4851-9c30-207c4dc767e2" />
<img width="319" height="695" alt="Screenshot 2026-05-08 at 13 06 14" src="https://github.com/user-attachments/assets/c48897ab-18d1-499d-8656-7734c5c50ff6" />
<img width="341" height="681" alt="Screenshot 2026-05-08 at 13 06 01" src="https://github.com/user-attachments/assets/ee04247b-6dff-4cec-860e-932295378add" />

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214229634760779