### PR TITLE
bump fast-uri to at least v 3.1.1 (vuln fix)

### DIFF
--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -16,7 +16,7 @@
         "@typescript-eslint/eslint-plugin": "^5.52.0",
         "@typescript-eslint/parser": "^5.52.0",
         "aws-cdk": "^2.1110.0",
-        "aws-cdk-lib": "^2.241.0",
+        "aws-cdk-lib": "^2.254.0",
         "constructs": "^10.5.1",
         "eslint": "^8.32.0",
         "jest": "^29.3.1",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -20,7 +20,7 @@
     "@typescript-eslint/eslint-plugin": "^5.52.0",
     "@typescript-eslint/parser": "^5.52.0",
     "aws-cdk": "^2.1110.0",
-    "aws-cdk-lib": "^2.241.0",
+    "aws-cdk-lib": "^2.254.0",
     "constructs": "^10.5.1",
     "eslint": "^8.32.0",
     "jest": "^29.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14060,9 +14060,9 @@
 			"dev": true
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
 			"dev": true,
 			"funding": [
 				{

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
 		"vitest": "^4.0.0"
 	},
 	"overrides": {
+		"fast-uri": ">=3.1.1",
 		"axios": "1.15.0",
 		"qs": "6.15.1",
 		"handlebars@^4": ">=4.7.9",


### PR DESCRIPTION
## What does this change?

Force bump fast-uri in the main package.json overrides object. Bump aws-cdk-lib in the cdk project. Ensures that we are using at least fast-uri version 3.1.1 as per the following dependabot vuln alert: https://github.com/guardian/newsletters-nx/security/dependabot/240