### PR TITLE
bump @babel/plugin-transform-modules-systemjs to version 7.29.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1007,10 +1007,11 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-			"integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+			"version": "7.29.3",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+			"integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -1364,6 +1365,23 @@
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.27.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
+			"version": "7.29.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-7.29.3.tgz",
+			"integrity": "sha512-SRS46DFR4HqzUzCVgi90/xMoL+zeBDBvWdKYXSEzh79kXswNFEglUpMKxR04//dPqwYXWUBJ3mpUd933ru9Kmg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.28.6",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2113,10 +2131,11 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-systemjs": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-			"integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+			"version": "7.29.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+			"integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-module-transforms": "^7.28.6",
 				"@babel/helper-plugin-utils": "^7.28.6",
@@ -2641,18 +2660,20 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.29.2",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.2.tgz",
-			"integrity": "sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==",
+			"version": "7.29.5",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.5.tgz",
+			"integrity": "sha512-/69t2aEzGKHD76DyLbHysF/QH2LJOB8iFnYO37unDTKBTubzcMRv0f3H5EiN1Q6ajOd/eB7dAInF0qdFVS06kA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.29.0",
+				"@babel/compat-data": "^7.29.3",
 				"@babel/helper-compilation-targets": "^7.28.6",
 				"@babel/helper-plugin-utils": "^7.28.6",
 				"@babel/helper-validator-option": "^7.27.1",
 				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.28.5",
 				"@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
 				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
+				"@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^7.29.3",
 				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
 				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.6",
 				"@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
@@ -2684,7 +2705,7 @@
 				"@babel/plugin-transform-member-expression-literals": "^7.27.1",
 				"@babel/plugin-transform-modules-amd": "^7.27.1",
 				"@babel/plugin-transform-modules-commonjs": "^7.28.6",
-				"@babel/plugin-transform-modules-systemjs": "^7.29.0",
+				"@babel/plugin-transform-modules-systemjs": "^7.29.4",
 				"@babel/plugin-transform-modules-umd": "^7.27.1",
 				"@babel/plugin-transform-named-capturing-groups-regex": "^7.29.0",
 				"@babel/plugin-transform-new-target": "^7.27.1",


### PR DESCRIPTION
## What does this change?

bumps @babel/plugin-transform-modules-systemjs to version 7.29.4 by getting package-lock.json to update the version of @babel/preset-env (within the bounds of the ^7.23.2 constraint @nx/js places on it in package.json) by running `npm update @babel/preset-env`.

Fixes the following vulnerability: https://github.com/guardian/newsletters-nx/security/dependabot/243

