### PR TITLE
add Vite 8/Rolldown browser stubs for @aws-sdk

### DIFF
--- a/apps/newsletters-ui/vite.config.ts
+++ b/apps/newsletters-ui/vite.config.ts
@@ -1,9 +1,78 @@
 /* eslint-disable -- We want default export for config files */
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import path from 'path';
+
+// @aws-sdk packages use Node.js built-ins (fs, crypto, etc.) unavailable in the
+// browser. The UI never calls AWS APIs directly — all AWS calls go via the API
+// server. This transform hook rewrites @aws-sdk value imports in project source
+// files to inline stub classes before Vite ever resolves or pre-bundles them,
+// avoiding both "missing export" and "Outdated Optimize Dep" (504) errors.
+const awsSdkBrowserStub = (): Plugin => ({
+	name: 'aws-sdk-browser-stub',
+	enforce: 'pre',
+	transform(code, id) {
+		if (id.includes('/node_modules/')) return null;
+		if (!code.includes('@aws-sdk/')) return null;
+
+		const result = code
+			// Named value imports — but NOT `import type { ... }`
+			.replace(
+				/^import\s+(?!type[\s{])(\{[^}]+\})\s+from\s+['"]@aws-sdk\/[^'"]+['"]\s*;?/gm,
+				(_, imports) =>
+					imports
+						.slice(1, -1)
+						.split(',')
+						.map((s: string) => s.trim())
+						.filter(Boolean)
+						.map((imp: string) => {
+							const local = imp.split(/\s+as\s+/).pop()!.trim();
+							return `const ${local} = class ${local} {};`;
+						})
+						.join('\n'),
+			)
+			// Namespace imports: import * as foo from '@aws-sdk/...'
+			.replace(
+				/^import\s+\*\s+as\s+(\w+)\s+from\s+['"]@aws-sdk\/[^'"]+['"]\s*;?/gm,
+				(_, name) =>
+					`const ${name} = new Proxy({}, { get: () => class {} });`,
+			);
+
+		return result !== code ? { code: result, map: null } : null;
+	},
+});
+
+// Rolldown rc.15 cannot analyse `export * from "./fromTokenFile"` when
+// fromTokenFile.js imports `node:fs`. This plugin stubs the two packages that
+// hit this bug inside the dep optimiser so the optimiser does not crash on
+// startup. It is only added to `optimizeDeps.rolldownOptions.plugins` and
+// never affects browser-served files (the transform plugin above handles those).
+const awsSdkOptimizerFix = (): Plugin => ({
+	name: 'aws-sdk-optimizer-fix',
+	enforce: 'pre',
+	resolveId(id) {
+		if (id === '@aws-sdk/credential-provider-web-identity')
+			// prepending the return with \0 (the null unicode character) prevents other
+			// plugins from reading the stub and signals that this is a virtual module
+			// not to be physically read from disk
+			return '\0cred-web-identity-stub';
+		if (id === 'node:fs') return '\0node-fs-stub';
+		if (id === 'node:fs/promises') return '\0node-fs-promises-stub';
+		return undefined;
+	},
+	load(id) {
+		if (id === '\0cred-web-identity-stub')
+			return `export const fromTokenFile = () => { throw new Error('not available in browser'); };
+export const fromWebToken = () => { throw new Error('not available in browser'); };`;
+		if (id === '\0node-fs-stub')
+			return `export const promises = {}; export const readFileSync = () => {}; export default {};`;
+		if (id === '\0node-fs-promises-stub')
+			return `export const readFile = async () => {}; export const writeFile = async () => {};`;
+		return undefined;
+	},
+});
 
 export default defineConfig({
 	root: __dirname,
@@ -42,8 +111,16 @@ export default defineConfig({
 			},
 		},
 	},
-	plugins: [react(), nxViteTsPaths()],
-
+	plugins: [react(), nxViteTsPaths(), awsSdkBrowserStub()],
+	optimizeDeps: {
+		rolldownOptions: {
+			// Fix Rolldown rc.15 crash: `export * from "./fromTokenFile"` fails when
+			// fromTokenFile.js imports `node:fs` in browser-platform mode. Stubbing
+			// credential-provider-web-identity and node:fs here lets the optimizer
+			// successfully bundle @aws-sdk/credential-providers without crashing.
+			plugins: [awsSdkOptimizerFix()],
+		},
+	},
 	// Uncomment this if you are using workers.
 	// worker: {
 	//  plugins: [

--- a/libs/newsletters-data-client/package.json
+++ b/libs/newsletters-data-client/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@newsletters-nx/newsletters-data-client",
 	"version": "0.0.1",
-	"type": "commonjs"
+	"type": "commonjs",
+	"sideEffects": false
 }


### PR DESCRIPTION
## Background
The following dependency update pr (https://github.com/guardian/newsletters-nx/pull/643) introduced a bug when trying to run newsletters-nx locally via `npm run dev` failed.

Specifically the updates to the nx packages from version 22.6.5 to 22.7.2. The nx packages have a transitive dependency on vite which was bumped up to version 8 with the 22.7.2 version bump.

Vite version 8 changed the bundler it uses from esbuild to rolldown.

Rolldown (Vite 8's new bundler) does strict static analysis of re-export chains (which we have in libs/newsletters-data-client/src/index.ts and libs/util/src/index.ts) and throws an error when it encounters node:fs imports during dep optimisation (server imports in the client). This was silently ignored by esbuild (Vite ≤=7).

## What does this change?

Adds two plugins to Vite in vite.config.ts:
- awsSdkBrowserStub: runs during the dev server module graph (when the browser requests a file). Transforms @aws-sdk value imports in source files to inline stub classes so that the browser never requests any @aws-sdk paths
- awsSdkOptimizerFix: Intercepts @aws-sdk/credential-provider-web-identity and node:fs inside the optimiser before Rolldown hits the broken re-export chain. Without this, the optimiser processes @aws-sdk/credential-providers and in doing so tries to follow `export * from "./fromTokenFile"` which imports `node:fs` which Rolldown can't analyse in browser mode and crashes.

Also adds `sideEffects: false` to newsletters-data-client to improve
tree-shaking in production builds.