### PR TITLE
changed back hover text to not overflow

### DIFF
--- a/apps/newsletters-ui/src/app/components/StandMainNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StandMainNav.tsx
@@ -87,6 +87,7 @@ export function StandMainNav() {
 			<TopBarToolName
 				name="Newsletter"
 				href="/"
+				collapsedHoverText={'Back'}
 				hoverText="Back to dashboard"
 				favicon={{
 					icon: 'email',


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->
## What does this change?

Updates hover text for responsive topbar to be "Back"

### Now
<img width="422" height="185" alt="Screenshot 2026-05-21 at 10 12 44" src="https://github.com/user-attachments/assets/59e2fa53-195c-43a9-9cef-dc2569b5dad2" />

### Before

<img width="438" height="204" alt="Screenshot 2026-05-21 at 10 13 01" src="https://github.com/user-attachments/assets/d1e3009d-17bd-4c38-9eb8-f2c248f4bba0" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214229632449670