### PR TITLE
Side nav collapsable on sm breakpoints

### DIFF
--- a/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
@@ -232,6 +232,7 @@ export const StandRedesignStepNav = ({
 			<Button
 				onPress={() => setOpen((current) => {return !current})}
 				aria-expanded={open}
+				aria-label={`Toggle step navigation${currentStep?.label ? ', step ' + currentStep.label : ''}, currently ${open ? 'expanded' : 'collapsed'}` }
 				aria-controls={stepNavId}
 				css={[buttonStyleReset, css`
 					border-bottom: 2px solid ${semanticColors.border.weak};

--- a/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
@@ -3,8 +3,8 @@ import { baseColors, semanticColors } from '@guardian/stand';
 import type { IconProps } from '@guardian/stand/Icon';
 import { Icon } from '@guardian/stand/Icon';
 import { Typography } from '@guardian/stand/Typography';
-import {from} from '@guardian/stand/utils';
-import { useState } from 'react';
+import { from } from '@guardian/stand/utils';
+import { useId, useState } from 'react';
 import { Button } from 'react-aria-components';
 import { resolveStepStatus, StepStatus } from '@newsletters-nx/state-machine';
 import type {
@@ -172,6 +172,8 @@ export const StandRedesignStepNav = ({
 	>({});
 	const [open, setOpen] = useState(false);
 
+	const stepNavId = useId();
+
 	const filteredStepList = stepperConfig.steps.filter((step) => {
 		if (step.parentStepId) {
 			return false;
@@ -228,10 +230,9 @@ export const StandRedesignStepNav = ({
 	return (
 		<>
 			<Button
-				onClick={() => setOpen((current) => {return !current})}
+				onPress={() => setOpen((current) => {return !current})}
 				aria-expanded={open}
-				aria-controls="step-nav-list"
-				aria-label="Toggle step navigation"
+				aria-controls={stepNavId}
 				css={[buttonStyleReset, css`
 					border-bottom: 2px solid ${semanticColors.border.weak};
 					display: flex;
@@ -271,7 +272,7 @@ export const StandRedesignStepNav = ({
 				}
 			`}
 			aria-label="Newsletter creation steps"
-			id="step-nav-list"
+			id={stepNavId}
 		>
 			<ol
 				css={css`

--- a/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
@@ -40,6 +40,17 @@ type StatusRowProps = {
 	isDisabled: boolean;
 };
 
+const buttonStyleReset = css`
+	appearance: none;
+	-webkit-appearance: none;
+	background-color: transparent;
+	font: inherit;
+	color: inherit;
+	border: none;
+	padding: 0;
+	margin: 0;
+`;
+
 const StatusRow = ({ label, icon, iconColor, isDisabled }: StatusRowProps) => (
 	<div
 		css={css`
@@ -221,16 +232,7 @@ export const StandRedesignStepNav = ({
 				aria-expanded={open}
 				aria-controls="step-nav-list"
 				aria-label="Toggle step navigation"
-				css={css`
-					// remove default border.
-					appearance: none;
-					-webkit-appearance: none;
-					border: 0;
-					border-radius: 0;
-					margin: 0;
-					font: inherit;
-					color: inherit;
-					//own styles
+				css={[buttonStyleReset, css`
 					border-bottom: 2px solid ${semanticColors.border.weak};
 					display: flex;
 					flex-direction: row;
@@ -252,7 +254,8 @@ export const StandRedesignStepNav = ({
 					&[data-pressed] {
 						background-color: ${baseColors.neutral["750"]};
 					}
-				`}
+				`]
+			}
 			>
 				<Typography element="div" variant={'bodyBoldSm'}>Create newsletter / {currentStep?.label}</Typography>
 				{open ? <Icon size="md" symbol="keyboard_arrow_up"/> : <Icon size="md" symbol="keyboard_arrow_down"/>}
@@ -360,16 +363,7 @@ const Step = ({
 		: baseColors.neutral['900'];
 
 	const buttonStyles = css`
-		// override UA styles
-		appearance: none;
-		-webkit-appearance: none;
 		background-color: ${backgroundColor};
-		font: inherit;
-		color: inherit;
-		border: none;
-		padding: 0;
-		margin: 0;
-		// our own styles
 		height: 72px;
 		cursor: ${isDisabled ? 'default' : 'pointer'};
 		border-bottom: 1px solid ${semanticColors.border.weak};
@@ -384,7 +378,7 @@ const Step = ({
 	return (
 		// Use a button instead of a link here because it is a single page application
 		<Button
-			css={buttonStyles}
+			css={[buttonStyleReset, buttonStyles]}
 			isDisabled={isDisabled}
 			aria-label={ariaLabel}
 			aria-current={isCurrent ? 'step' : undefined}

--- a/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
@@ -3,6 +3,7 @@ import { baseColors, semanticColors } from '@guardian/stand';
 import type { IconProps } from '@guardian/stand/Icon';
 import { Icon } from '@guardian/stand/Icon';
 import { Typography } from '@guardian/stand/Typography';
+import {from} from '@guardian/stand/utils';
 import { useState } from 'react';
 import { Button } from 'react-aria-components';
 import { resolveStepStatus, StepStatus } from '@newsletters-nx/state-machine';
@@ -158,6 +159,7 @@ export const StandRedesignStepNav = ({
 	const [completionRecord, setCompletionRecord] = useState<
 		Partial<Record<string, StepStatus>>
 	>({});
+	const [open, setOpen] = useState(false);
 
 	const filteredStepList = stepperConfig.steps.filter((step) => {
 		if (step.parentStepId) {
@@ -213,14 +215,60 @@ export const StandRedesignStepNav = ({
 		!isCurrent(step);
 
 	return (
+		<>
+			<Button
+				onClick={() => setOpen((current) => {return !current})}
+				aria-expanded={open}
+				aria-controls="step-nav-list"
+				aria-label="Toggle step navigation"
+				css={css`
+					// remove default border.
+					appearance: none;
+					-webkit-appearance: none;
+					border: 0;
+					border-radius: 0;
+					margin: 0;
+					font: inherit;
+					color: inherit;
+					//own styles
+					border-bottom: 2px solid ${semanticColors.border.weak};
+					display: flex;
+					flex-direction: row;
+					justify-content: space-between;
+					align-items: center;
+					height: 72px;
+					padding: 0 16px;
+					width: 100%;
+					background-color: ${semanticColors.bg.raisedLevel1};
+
+					${from.md} {
+						display: none;
+					}
+
+					&[data-hovered] {
+						background-color: ${semanticColors.bg.raisedLevel2};
+					}
+
+					&[data-pressed] {
+						background-color: ${baseColors.neutral["750"]};
+					}
+				`}
+			>
+				<Typography element="div" variant={'bodyBoldSm'}>Create newsletter / {currentStep?.label}</Typography>
+				{open ? <Icon size="md" symbol="keyboard_arrow_up"/> : <Icon size="md" symbol="keyboard_arrow_down"/>}
+			</Button>
 		<nav
 			css={css`
 				border-right: 1px solid ${semanticColors.border.strong};
-				display: flex;
 				flex-direction: column;
 				height: 100%;
+				display: ${open ? 'flex' : 'none'};
+				${from.md} {
+					display:flex;
+				}
 			`}
 			aria-label="Newsletter creation steps"
+			id="step-nav-list"
 		>
 			<ol
 				css={css`
@@ -253,6 +301,7 @@ export const StandRedesignStepNav = ({
 				})}
 			</ol>
 		</nav>
+		</>
 	);
 };
 
@@ -325,7 +374,7 @@ const Step = ({
 		cursor: ${isDisabled ? 'default' : 'pointer'};
 		border-bottom: 1px solid ${semanticColors.border.weak};
 		display: grid;
-		grid-template-columns: 32px 233px;
+		grid-template-columns: 32px 1fr;
 		text-align: left;
 		width: 100%;
 		&[data-pressed] {

--- a/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
@@ -232,7 +232,6 @@ export const StandRedesignStepNav = ({
 			<Button
 				onPress={() => setOpen((prev) => {return !prev})}
 				aria-expanded={open}
-				aria-label={`Toggle step navigation${currentStep?.label ? ', step ' + currentStep.label : ''}, currently ${open ? 'expanded' : 'collapsed'}` }
 				aria-controls={stepNavId}
 				css={[buttonStyleReset, css`
 					border-bottom: 2px solid ${semanticColors.border.weak};

--- a/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
@@ -230,7 +230,7 @@ export const StandRedesignStepNav = ({
 	return (
 		<>
 			<Button
-				onPress={() => setOpen((current) => {return !current})}
+				onPress={() => setOpen((prev) => {return !prev})}
 				aria-expanded={open}
 				aria-label={`Toggle step navigation${currentStep?.label ? ', step ' + currentStep.label : ''}, currently ${open ? 'expanded' : 'collapsed'}` }
 				aria-controls={stepNavId}

--- a/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
@@ -242,7 +242,7 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 
 	return (
 		<>
-			<Layout.Sidebar as="div">
+			<Layout.Sidebar as="div" layoutSmBreakpoint="above-grid">
 				<StandRedesignStepNav
 					currentStepId={serverData.currentStepId}
 					stepperConfig={stepperConfig}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a button to control the visibility of the side nav ordered list of steps. moves it above the content and is toggled by a button. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

Tested locally.

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## Have we considered potential risks?

 Low risk as behind a feature switch
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<img width="695" height="611" alt="Screenshot 2026-05-26 at 15 21 51" src="https://github.com/user-attachments/assets/f8ed6fb1-7faf-4c4d-8054-51306519cf5b" />
<img width="690" height="940" alt="Screenshot 2026-05-26 at 15 21 42" src="https://github.com/user-attachments/assets/7b786346-67a3-4d42-8fa4-7da65e5fbd1b" />




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214586439525036