### PR TITLE
Split server and client code

### DIFF
--- a/apps/newsletters-api/src/app/routes/currentStep.ts
+++ b/apps/newsletters-api/src/app/routes/currentStep.ts
@@ -1,5 +1,5 @@
 import type { Express } from 'express';
-import { newslettersWorkflowStepLayout } from '@newsletters-nx/newsletter-workflow';
+import { newslettersWorkflowStepLayout } from '@newsletters-nx/newsletter-workflow/server';
 import { replaceNullWithUndefinedForUnknown } from '@newsletters-nx/newsletters-data-client';
 import type { UserProfile } from '@newsletters-nx/newsletters-data-client';
 import type {

--- a/apps/newsletters-api/src/app/routes/layouts.ts
+++ b/apps/newsletters-api/src/app/routes/layouts.ts
@@ -2,7 +2,7 @@ import type { Express } from 'express';
 import {
 	editionIdSchema,
 	layoutSchema,
-} from '@newsletters-nx/newsletters-data-client';
+} from '@newsletters-nx/newsletters-data-client/server';
 import { permissionService } from '../../services/permissions';
 import { layoutStore } from '../../services/storage';
 import { getUserProfile } from '../get-user-profile';

--- a/apps/newsletters-api/src/app/routes/notifications.ts
+++ b/apps/newsletters-api/src/app/routes/notifications.ts
@@ -1,6 +1,6 @@
 import type { Express, Request, Response } from 'express';
-import type { NewsletterMessageId } from '@newsletters-nx/email-builder';
-import { sendEmailNotifications } from '@newsletters-nx/email-builder';
+import type { NewsletterMessageId } from '@newsletters-nx/email-builder/server';
+import { sendEmailNotifications } from '@newsletters-nx/email-builder/server';
 import { makeEmailEnvInfo } from '../../services/notifications/email-env';
 import { makeSesClient } from '../../services/notifications/email-service';
 import { newsletterStore } from '../../services/storage';

--- a/apps/newsletters-api/src/services/storage/inMemoryStorageInstance.ts
+++ b/apps/newsletters-api/src/services/storage/inMemoryStorageInstance.ts
@@ -1,4 +1,4 @@
-import { InMemoryDraftStorage } from '@newsletters-nx/newsletters-data-client';
+import { InMemoryDraftStorage } from '@newsletters-nx/newsletters-data-client/server';
 
 export const makeInMemoryStorageInstance = () =>
 	new InMemoryDraftStorage([

--- a/apps/newsletters-api/src/services/storage/index.ts
+++ b/apps/newsletters-api/src/services/storage/index.ts
@@ -9,14 +9,14 @@ import type {
 	NewsletterData,
 	NewsletterStorage,
 	UserProfile,
-} from '@newsletters-nx/newsletters-data-client';
+} from '@newsletters-nx/newsletters-data-client/server';
 import {
 	DraftService,
 	InMemoryLayoutStorage,
 	InMemoryNewsletterStorage,
 	isNewsletterData,
 	LaunchService,
-} from '@newsletters-nx/newsletters-data-client';
+} from '@newsletters-nx/newsletters-data-client/server';
 import layoutsData from '../../../static/layouts.local.json';
 import newslettersSeedData from '../../../static/newsletters.seed.json';
 import { isUsingInMemoryStorage } from '../../apiDeploymentSettings';

--- a/apps/newsletters-api/src/services/storage/s3StorageInstance.ts
+++ b/apps/newsletters-api/src/services/storage/s3StorageInstance.ts
@@ -2,7 +2,7 @@ import {
 	S3DraftStorage,
 	S3LayoutStorage,
 	S3NewsletterStorage,
-} from '@newsletters-nx/newsletters-data-client';
+} from '@newsletters-nx/newsletters-data-client/server';
 import { getS3Client } from './s3-client-factory';
 
 const getS3BucketName = (): string => {

--- a/apps/newsletters-e2e/src/ui/drafts.spec.ts
+++ b/apps/newsletters-e2e/src/ui/drafts.spec.ts
@@ -7,7 +7,7 @@ import {
 
 const DRAFT_NAME_PREFIX = 'Draft newsletter - playwright test';
 
-test.describe('Top nav - drafts', () => {
+test.describe.serial('Top nav - drafts', () => {
 	let listId: number;
 	let draftName: string;
 

--- a/apps/newsletters-ui/vite.config.ts
+++ b/apps/newsletters-ui/vite.config.ts
@@ -1,78 +1,9 @@
 /* eslint-disable -- We want default export for config files */
 /// <reference types="vitest" />
-import { defineConfig, type Plugin } from 'vite';
+import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import path from 'path';
-
-// @aws-sdk packages use Node.js built-ins (fs, crypto, etc.) unavailable in the
-// browser. The UI never calls AWS APIs directly — all AWS calls go via the API
-// server. This transform hook rewrites @aws-sdk value imports in project source
-// files to inline stub classes before Vite ever resolves or pre-bundles them,
-// avoiding both "missing export" and "Outdated Optimize Dep" (504) errors.
-const awsSdkBrowserStub = (): Plugin => ({
-	name: 'aws-sdk-browser-stub',
-	enforce: 'pre',
-	transform(code, id) {
-		if (id.includes('/node_modules/')) return null;
-		if (!code.includes('@aws-sdk/')) return null;
-
-		const result = code
-			// Named value imports — but NOT `import type { ... }`
-			.replace(
-				/^import\s+(?!type[\s{])(\{[^}]+\})\s+from\s+['"]@aws-sdk\/[^'"]+['"]\s*;?/gm,
-				(_, imports) =>
-					imports
-						.slice(1, -1)
-						.split(',')
-						.map((s: string) => s.trim())
-						.filter(Boolean)
-						.map((imp: string) => {
-							const local = imp.split(/\s+as\s+/).pop()!.trim();
-							return `const ${local} = class ${local} {};`;
-						})
-						.join('\n'),
-			)
-			// Namespace imports: import * as foo from '@aws-sdk/...'
-			.replace(
-				/^import\s+\*\s+as\s+(\w+)\s+from\s+['"]@aws-sdk\/[^'"]+['"]\s*;?/gm,
-				(_, name) =>
-					`const ${name} = new Proxy({}, { get: () => class {} });`,
-			);
-
-		return result !== code ? { code: result, map: null } : null;
-	},
-});
-
-// Rolldown rc.15 cannot analyse `export * from "./fromTokenFile"` when
-// fromTokenFile.js imports `node:fs`. This plugin stubs the two packages that
-// hit this bug inside the dep optimiser so the optimiser does not crash on
-// startup. It is only added to `optimizeDeps.rolldownOptions.plugins` and
-// never affects browser-served files (the transform plugin above handles those).
-const awsSdkOptimizerFix = (): Plugin => ({
-	name: 'aws-sdk-optimizer-fix',
-	enforce: 'pre',
-	resolveId(id) {
-		if (id === '@aws-sdk/credential-provider-web-identity')
-			// prepending the return with \0 (the null unicode character) prevents other
-			// plugins from reading the stub and signals that this is a virtual module
-			// not to be physically read from disk
-			return '\0cred-web-identity-stub';
-		if (id === 'node:fs') return '\0node-fs-stub';
-		if (id === 'node:fs/promises') return '\0node-fs-promises-stub';
-		return undefined;
-	},
-	load(id) {
-		if (id === '\0cred-web-identity-stub')
-			return `export const fromTokenFile = () => { throw new Error('not available in browser'); };
-export const fromWebToken = () => { throw new Error('not available in browser'); };`;
-		if (id === '\0node-fs-stub')
-			return `export const promises = {}; export const readFileSync = () => {}; export default {};`;
-		if (id === '\0node-fs-promises-stub')
-			return `export const readFile = async () => {}; export const writeFile = async () => {};`;
-		return undefined;
-	},
-});
 
 export default defineConfig({
 	root: __dirname,
@@ -111,16 +42,7 @@ export default defineConfig({
 			},
 		},
 	},
-	plugins: [react(), nxViteTsPaths(), awsSdkBrowserStub()],
-	optimizeDeps: {
-		rolldownOptions: {
-			// Fix Rolldown rc.15 crash: `export * from "./fromTokenFile"` fails when
-			// fromTokenFile.js imports `node:fs` in browser-platform mode. Stubbing
-			// credential-provider-web-identity and node:fs here lets the optimizer
-			// successfully bundle @aws-sdk/credential-providers without crashing.
-			plugins: [awsSdkOptimizerFix()],
-		},
-	},
+	plugins: [react(), nxViteTsPaths()],
 	// Uncomment this if you are using workers.
 	// worker: {
 	//  plugins: [

--- a/libs/email-builder/src/index.ts
+++ b/libs/email-builder/src/index.ts
@@ -1,2 +1,1 @@
 export * from './lib/types';
-export * from './lib/service';

--- a/libs/email-builder/src/server.ts
+++ b/libs/email-builder/src/server.ts
@@ -1,0 +1,5 @@
+// browser/shared types
+export * from './index';
+
+// server only stuff
+export * from './lib/service';

--- a/libs/newsletter-workflow/src/lib/executeCreate.ts
+++ b/libs/newsletter-workflow/src/lib/executeCreate.ts
@@ -1,15 +1,15 @@
-import { sendEmailNotifications } from '@newsletters-nx/email-builder';
+import { sendEmailNotifications } from '@newsletters-nx/email-builder/server';
 import type {
 	DraftNewsletterData,
 	DraftService,
 	FormDataRecord,
-} from '@newsletters-nx/newsletters-data-client';
+} from '@newsletters-nx/newsletters-data-client/server';
 import {
 	draftNewsletterDataToFormData,
 	formDataToDraftNewsletterData,
 	getEmptySchemaData,
 	newsletterDataSchema,
-} from '@newsletters-nx/newsletters-data-client';
+} from '@newsletters-nx/newsletters-data-client/server';
 import {
 	StateMachineError,
 	StateMachineErrorCode,

--- a/libs/newsletter-workflow/src/lib/executeLaunch.ts
+++ b/libs/newsletter-workflow/src/lib/executeLaunch.ts
@@ -1,10 +1,10 @@
-import type { NewsletterMessageId } from '@newsletters-nx/email-builder';
-import { sendEmailNotifications } from '@newsletters-nx/email-builder';
+import type { NewsletterMessageId } from '@newsletters-nx/email-builder/server';
+import { sendEmailNotifications } from '@newsletters-nx/email-builder/server';
 import type {
 	FormDataRecord,
 	LaunchService,
 	NewsletterData,
-} from '@newsletters-nx/newsletters-data-client';
+} from '@newsletters-nx/newsletters-data-client/server';
 import type { AsyncExecution } from '@newsletters-nx/state-machine';
 import { parseToNumber } from './util';
 

--- a/libs/newsletter-workflow/src/lib/executeModify.ts
+++ b/libs/newsletter-workflow/src/lib/executeModify.ts
@@ -2,11 +2,11 @@ import type {
 	DraftService,
 	DraftWithId,
 	LaunchService,
-} from '@newsletters-nx/newsletters-data-client';
+} from '@newsletters-nx/newsletters-data-client/server';
 import {
 	draftNewsletterDataToFormData,
 	formDataToDraftNewsletterData,
-} from '@newsletters-nx/newsletters-data-client';
+} from '@newsletters-nx/newsletters-data-client/server';
 import type {
 	AsyncExecution,
 	WizardExecutionFailure,

--- a/libs/newsletter-workflow/src/lib/executeSkip.ts
+++ b/libs/newsletter-workflow/src/lib/executeSkip.ts
@@ -1,5 +1,5 @@
-import { draftNewsletterDataToFormData } from '@newsletters-nx/newsletters-data-client';
-import type { DraftService } from '@newsletters-nx/newsletters-data-client';
+import { draftNewsletterDataToFormData } from '@newsletters-nx/newsletters-data-client/server';
+import type { DraftService } from '@newsletters-nx/newsletters-data-client/server';
 import type {
 	AsyncExecution,
 	WizardStepData,

--- a/libs/newsletter-workflow/src/lib/getDraftFromStorage.ts
+++ b/libs/newsletter-workflow/src/lib/getDraftFromStorage.ts
@@ -1,8 +1,8 @@
-import { draftNewsletterDataToFormData } from '@newsletters-nx/newsletters-data-client';
+import { draftNewsletterDataToFormData } from '@newsletters-nx/newsletters-data-client/server';
 import type {
 	DraftService,
 	FormDataRecord,
-} from '@newsletters-nx/newsletters-data-client';
+} from '@newsletters-nx/newsletters-data-client/server';
 import type { CurrentStepRouteRequest } from '@newsletters-nx/state-machine';
 import {
 	StateMachineError,

--- a/libs/newsletter-workflow/src/lib/newsletter-workflow.server.ts
+++ b/libs/newsletter-workflow/src/lib/newsletter-workflow.server.ts
@@ -1,0 +1,68 @@
+import type {
+	StepperConfig,
+	WizardLayout,
+	WizardStepLayout,
+} from '@newsletters-nx/state-machine';
+import {
+	getStartStepAndId,
+	getStepperConfig as makeStepperConfig,
+} from '@newsletters-nx/state-machine';
+import { launchLayout } from './steps/launchNewsletter/server';
+import { newsletterDataLayout } from './steps/newsletterData/server';
+import { renderingOptionsLayout } from './steps/renderingOptions/server';
+import { standRedesignLayout } from './steps/standRedesignNewsletterData/server';
+
+export const newslettersWorkflowStepLayout: Record<string, WizardLayout> = {
+	NEWSLETTER_DATA: newsletterDataLayout,
+	NEWSLETTER_DATA_STAND_REDESIGN: standRedesignLayout,
+	LAUNCH_NEWSLETTER: launchLayout,
+	RENDERING_OPTIONS: renderingOptionsLayout,
+};
+
+export type WizardId = keyof typeof newslettersWorkflowStepLayout;
+
+export const getFormSchema = (
+	wizardId: keyof typeof newslettersWorkflowStepLayout,
+	stepId: string,
+) => {
+	const wizard = newslettersWorkflowStepLayout[wizardId];
+	if (!wizard) {
+		return undefined;
+	}
+	const step = wizard[stepId];
+	return step?.schema;
+};
+
+export const getStepperConfig = (
+	wizardId: keyof typeof newslettersWorkflowStepLayout,
+): StepperConfig => {
+	const wizard = newslettersWorkflowStepLayout[wizardId];
+	if (!wizard) {
+		return { steps: [], isNonLinear: false, indicateStepsComplete: false };
+	}
+
+	return makeStepperConfig(wizard);
+};
+
+export const getStartStepId = (
+	layoutId: keyof typeof newslettersWorkflowStepLayout,
+	isEdit = false,
+) => {
+	const layout = newslettersWorkflowStepLayout[layoutId];
+	if (!layout) {
+		return undefined;
+	}
+	return getStartStepAndId(layout, isEdit).id;
+};
+
+export const getFieldDisplayOptions = (
+	wizardId: keyof typeof newslettersWorkflowStepLayout,
+	stepId: string,
+): WizardStepLayout['fieldDisplayOptions'] => {
+	const wizard = newslettersWorkflowStepLayout[wizardId];
+	if (!wizard) {
+		return undefined;
+	}
+	const step = wizard[stepId];
+	return step?.fieldDisplayOptions;
+};

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/doLaunchLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/doLaunchLayout.ts
@@ -1,6 +1,5 @@
 import type { LaunchService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
-import { executeLaunch } from '../../executeLaunch';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 
@@ -36,7 +35,6 @@ export const doLaunchLayout: WizardStepLayout<LaunchService> = {
 			buttonType: 'LAUNCH',
 			label: 'Request Launch',
 			stepToMoveTo: 'finish',
-			executeStep: executeLaunch,
 		},
 	},
 };

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/server.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/server.ts
@@ -1,0 +1,35 @@
+import type { LaunchService } from '@newsletters-nx/newsletters-data-client';
+import type { WizardLayout } from '@newsletters-nx/state-machine';
+import { executeLaunch } from '../../executeLaunch';
+import { brazeLayout } from './brazeLayout';
+import { cancelLayout } from './cancelLayout';
+import { doLaunchLayout } from './doLaunchLayout';
+import { editBrazeLayout } from './editBrazeLayout';
+import { editIdentityNameLayout } from './editIdentityNameLayout';
+import { finishLayout } from './finishLayout';
+import { identityNameLayout } from './identityNameLayout';
+import { isDataCompleteLayout } from './isDataCompleteLayout';
+import { launchNewsletterLayout } from './launchNewsletterLayout';
+import { noItemLayout } from './noItem';
+
+export const launchLayout: WizardLayout<LaunchService> = {
+	launchNewsletter: launchNewsletterLayout,
+	isDataComplete: isDataCompleteLayout,
+	identityName: identityNameLayout,
+	editIdentityName: editIdentityNameLayout,
+	braze: brazeLayout,
+	editBraze: editBrazeLayout,
+	doLaunch: {
+		...doLaunchLayout,
+		buttons: {
+			...doLaunchLayout.buttons,
+			next: {
+				...doLaunchLayout.buttons['next']!,
+				executeStep: executeLaunch,
+			},
+		},
+	},
+	noItem: noItemLayout,
+	cancel: cancelLayout,
+	finish: finishLayout,
+};

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/createDraftNewsletterLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/createDraftNewsletterLayout.ts
@@ -1,7 +1,6 @@
 import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import { getNextStepId } from '@newsletters-nx/state-machine';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
-import { executeCreate } from '../../executeCreate';
 import { formSchemas } from './formSchemas';
 
 export const createDraftNewsletterLayout: WizardStepLayout<DraftService> = {
@@ -21,11 +20,9 @@ The first step is to enter the name of your newsletter. For example,  **Down to 
 			buttonType: 'NEXT',
 			label: 'Save and Continue',
 			stepToMoveTo: getNextStepId,
-			executeStep: executeCreate,
 		},
 	},
 	schema: formSchemas.startDraftNewsletter,
 	canSkipTo: true,
 	skippingWillPersistLocalChanges: true,
-	executeSkip: executeCreate,
 };

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/dateLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/dateLayout.ts
@@ -4,8 +4,6 @@ import {
 	getPreviousOrEditStartStepId,
 } from '@newsletters-nx/state-machine';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
-import { executeModify } from '../../executeModify';
-import { executeSkip } from '../../executeSkip';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from './formSchemas';
@@ -17,7 +15,7 @@ const markdownTemplate = `
 
 When will the first send of **{{name}}** be? Please specify date. This needs to be in the UK timezone for the system.
 
-We will automatically add a testing period for the newsletter of 1 week before the first send so you can try out the template in Composer. Please also mark if the newsletter should be private if it’s confidential.
+We will automatically add a testing period for the newsletter of 1 week before the first send so you can try out the template in Composer. Please also mark if the newsletter should be private if it's confidential.
 
 ### Promotion
 
@@ -49,16 +47,13 @@ export const dateLayout: WizardStepLayout<DraftService> = {
 			buttonType: 'PREVIOUS',
 			label: 'Back to previous step',
 			stepToMoveTo: getPreviousOrEditStartStepId,
-			executeStep: executeSkip,
 		},
 		finish: {
 			buttonType: 'NEXT',
 			label: 'Save and Continue',
 			stepToMoveTo: getNextStepId,
-			executeStep: executeModify,
 		},
 	},
 	schema: formSchemas.promotionDates,
 	canSkipTo: true,
-	executeSkip: executeSkip,
 };

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/editDraftNewsletterLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/editDraftNewsletterLayout.ts
@@ -1,8 +1,6 @@
 import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { getNextStepId } from '@newsletters-nx/state-machine';
-import { executeModify } from '../../executeModify';
-import { executeSkip } from '../../executeSkip';
 import { getDraftFromStorage } from '../../getDraftFromStorage';
 import { formSchemas } from './formSchemas';
 
@@ -23,12 +21,10 @@ You can edit the name of the newsletter.
 			buttonType: 'NEXT',
 			label: 'Save and Continue',
 			stepToMoveTo: getNextStepId,
-			executeStep: executeModify,
 		},
 	},
 	schema: formSchemas.startDraftNewsletter,
 	role: 'EDIT_START',
 	getInitialFormData: getDraftFromStorage,
 	canSkipTo: true,
-	executeSkip: executeSkip,
 };

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/finishLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/finishLayout.ts
@@ -1,6 +1,5 @@
 import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
-import { executeSkip } from '../../executeSkip';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 
@@ -40,7 +39,6 @@ const finishLayout: WizardStepLayout<DraftService> = {
 			.replace(regExPatterns.listId, listId);
 	},
 	canSkipTo: true,
-	executeSkip: executeSkip,
 };
 
 export { finishLayout };

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/productionDetailsLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/productionDetailsLayout.ts
@@ -4,8 +4,6 @@ import {
 	getNextStepId,
 	getPreviousOrEditStartStepId,
 } from '@newsletters-nx/state-machine';
-import { executeModify } from '../../executeModify';
-import { executeSkip } from '../../executeSkip';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from './formSchemas';
@@ -30,7 +28,7 @@ Alternatively, you might want the first send on web to preview it, but subsequen
 ### Frequency
 Select how often your newsletter will be sent. This will be displayed on the sign-up page, in-article sign-ups and the all newsletters page.
 
-If your schedule doesn’t fit the options below, choose **Custom frequency**.
+If your schedule doesn't fit the options below, choose **Custom frequency**.
 
 Options:
 - Daily
@@ -67,16 +65,13 @@ export const productionDetailsLayout: WizardStepLayout<DraftService> = {
 			buttonType: 'PREVIOUS',
 			label: 'Back to previous step',
 			stepToMoveTo: getPreviousOrEditStartStepId,
-			executeStep: executeSkip,
 		},
 		finish: {
 			buttonType: 'NEXT',
 			label: 'Save and Continue',
 			stepToMoveTo: getNextStepId,
-			executeStep: executeModify,
 		},
 	},
 	schema: formSchemas.productionDetails,
 	canSkipTo: true,
-	executeSkip,
 };

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/promotionContentLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/promotionContentLayout.ts
@@ -4,8 +4,6 @@ import {
 	getNextStepId,
 	getPreviousOrEditStartStepId,
 } from '@newsletters-nx/state-machine';
-import { executeModify } from '../../executeModify';
-import { executeSkip } from '../../executeSkip';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from './formSchemas';
@@ -57,13 +55,11 @@ export const promotionContentLayout: WizardStepLayout<DraftService> = {
 			buttonType: 'PREVIOUS',
 			label: 'Back to previous step',
 			stepToMoveTo: getPreviousOrEditStartStepId,
-			executeStep: executeSkip,
 		},
 		next: {
 			buttonType: 'NEXT',
 			label: 'Save and Continue',
 			stepToMoveTo: getNextStepId,
-			executeStep: executeModify,
 		},
 	},
 	schema: formSchemas.promotionContent,
@@ -76,5 +72,4 @@ export const promotionContentLayout: WizardStepLayout<DraftService> = {
 		},
 	},
 	canSkipTo: true,
-	executeSkip: executeSkip,
 };

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/server.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/server.ts
@@ -1,0 +1,137 @@
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
+import type { WizardLayout } from '@newsletters-nx/state-machine';
+import { executeCreate } from '../../executeCreate';
+import { executeModify } from '../../executeModify';
+import { executeSkip } from '../../executeSkip';
+import { cancelLayout } from './cancelLayout';
+import { createDraftNewsletterLayout } from './createDraftNewsletterLayout';
+import { dateLayout } from './dateLayout';
+import { editDraftNewsletterLayout } from './editDraftNewsletterLayout';
+import { finishLayout } from './finishLayout';
+import { createDraftIntro } from './introLayout';
+import { productionDetailsLayout } from './productionDetailsLayout';
+import { promotionContentLayout } from './promotionContentLayout';
+import { tagsLayout } from './tagsLayout';
+import { targetingLayout } from './targetingLayout';
+import { thrashersLayout } from './thrashersLayout';
+
+export const newsletterDataLayout: WizardLayout<DraftService> = {
+	cancel: cancelLayout,
+	intro: createDraftIntro,
+	createDraftNewsletter: {
+		...createDraftNewsletterLayout,
+		executeSkip: executeCreate,
+		buttons: {
+			...createDraftNewsletterLayout.buttons,
+			next: {
+				...createDraftNewsletterLayout.buttons['next']!,
+				executeStep: executeCreate,
+			},
+		},
+	},
+	editDraftNewsletter: {
+		...editDraftNewsletterLayout,
+		executeSkip,
+		buttons: {
+			...editDraftNewsletterLayout.buttons,
+			next: {
+				...editDraftNewsletterLayout.buttons['next']!,
+				executeStep: executeModify,
+			},
+		},
+	},
+	productionDetails: {
+		...productionDetailsLayout,
+		executeSkip,
+		buttons: {
+			...productionDetailsLayout.buttons,
+			back: {
+				...productionDetailsLayout.buttons['back']!,
+				executeStep: executeSkip,
+			},
+			finish: {
+				...productionDetailsLayout.buttons['finish']!,
+				executeStep: executeModify,
+			},
+		},
+	},
+	dates: {
+		...dateLayout,
+		executeSkip,
+		buttons: {
+			...dateLayout.buttons,
+			back: {
+				...dateLayout.buttons['back']!,
+				executeStep: executeSkip,
+			},
+			finish: {
+				...dateLayout.buttons['finish']!,
+				executeStep: executeModify,
+			},
+		},
+	},
+	targeting: {
+		...targetingLayout,
+		executeSkip,
+		buttons: {
+			...targetingLayout.buttons,
+			back: {
+				...targetingLayout.buttons['back']!,
+				executeStep: executeSkip,
+			},
+			finish: {
+				...targetingLayout.buttons['finish']!,
+				executeStep: executeModify,
+			},
+		},
+	},
+	tags: {
+		...tagsLayout,
+		executeSkip,
+		buttons: {
+			...tagsLayout.buttons,
+			back: {
+				...tagsLayout.buttons['back']!,
+				executeStep: executeSkip,
+			},
+			finish: {
+				...tagsLayout.buttons['finish']!,
+				executeStep: executeModify,
+			},
+		},
+	},
+	thrasher: {
+		...thrashersLayout,
+		executeSkip,
+		buttons: {
+			...thrashersLayout.buttons,
+			back: {
+				...thrashersLayout.buttons['back']!,
+				executeStep: executeSkip,
+			},
+			next: {
+				...thrashersLayout.buttons['next']!,
+				executeStep: executeModify,
+			},
+		},
+	},
+	signUpPage: {
+		...promotionContentLayout,
+		executeSkip,
+		buttons: {
+			...promotionContentLayout.buttons,
+			back: {
+				...promotionContentLayout.buttons['back']!,
+				executeStep: executeSkip,
+			},
+			next: {
+				...promotionContentLayout.buttons['next']!,
+				executeStep: executeModify,
+			},
+		},
+	},
+	finish: {
+		...finishLayout,
+		executeSkip,
+	},
+};

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/tagsLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/tagsLayout.ts
@@ -4,8 +4,6 @@ import {
 	getNextStepId,
 	getPreviousOrEditStartStepId,
 } from '@newsletters-nx/state-machine';
-import { executeModify } from '../../executeModify';
-import { executeSkip } from '../../executeSkip';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from './formSchemas';
@@ -49,7 +47,6 @@ export const tagsLayout: WizardStepLayout<DraftService> = {
 			buttonType: 'PREVIOUS',
 			label: 'Back to previous step',
 			stepToMoveTo: getPreviousOrEditStartStepId,
-			executeStep: executeSkip,
 		},
 		finish: {
 			buttonType: 'NEXT',
@@ -86,10 +83,8 @@ export const tagsLayout: WizardStepLayout<DraftService> = {
 				}
 				return undefined;
 			},
-			executeStep: executeModify,
 		},
 	},
 	schema: formSchemas.tags,
 	canSkipTo: true,
-	executeSkip: executeSkip,
 };

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/targetingLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/targetingLayout.ts
@@ -4,8 +4,6 @@ import {
 	getPreviousOrStartStepId,
 } from '@newsletters-nx/state-machine';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
-import { executeModify } from '../../executeModify';
-import { executeSkip } from '../../executeSkip';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from './formSchemas';
@@ -24,7 +22,7 @@ Please then select a group for **{{name}}** to be listed under on the [Manage My
 
 ### Choose the Geo Focus for {{name}}
 
-What’s the geo focus of **{{name}}**? UK, US, Australia, Europe or International?
+What's the geo focus of **{{name}}**? UK, US, Australia, Europe or International?
 
 `.trim();
 
@@ -48,16 +46,13 @@ export const targetingLayout: WizardStepLayout<DraftService> = {
 			buttonType: 'PREVIOUS',
 			label: 'Back to previous step',
 			stepToMoveTo: getPreviousOrStartStepId,
-			executeStep: executeSkip,
 		},
 		finish: {
 			buttonType: 'NEXT',
 			label: 'Save and Continue',
 			stepToMoveTo: getNextStepId,
-			executeStep: executeModify,
 		},
 	},
 	schema: formSchemas.targeting,
 	canSkipTo: true,
-	executeSkip: executeSkip,
 };

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/thrashersLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/thrashersLayout.ts
@@ -4,8 +4,6 @@ import {
 	getNextStepId,
 	getPreviousOrEditStartStepId,
 } from '@newsletters-nx/state-machine';
-import { executeModify } from '../../executeModify';
-import { executeSkip } from '../../executeSkip';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from './formSchemas';
@@ -46,13 +44,11 @@ export const thrashersLayout: WizardStepLayout<DraftService> = {
 			buttonType: 'PREVIOUS',
 			label: 'Back to previous step',
 			stepToMoveTo: getPreviousOrEditStartStepId,
-			executeStep: executeSkip,
 		},
 		next: {
 			buttonType: 'NEXT',
 			label: 'Save and Continue',
 			stepToMoveTo: getNextStepId,
-			executeStep: executeModify,
 		},
 	},
 	schema: formSchemas.thrashers,
@@ -62,5 +58,4 @@ export const thrashersLayout: WizardStepLayout<DraftService> = {
 		},
 	},
 	canSkipTo: true,
-	executeSkip: executeSkip,
 };

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/darkSectionLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/darkSectionLayout.ts
@@ -4,7 +4,6 @@ import {
 	getNextStepId,
 	getPreviousOrEditStartStepId,
 } from '@newsletters-nx/state-machine';
-import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
@@ -41,16 +40,13 @@ export const darkSectionLayout: WizardStepLayout<DraftService> = {
 			buttonType: 'PREVIOUS',
 			label: 'Back',
 			stepToMoveTo: getPreviousOrEditStartStepId,
-			executeStep: executeModify,
 		},
 		next: {
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
-			executeStep: executeModify,
 		},
 	},
 	schema: formSchemas.darkTheme,
 	canSkipTo: true,
-	executeSkip: executeModify,
 };

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/finishLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/finishLayout.ts
@@ -1,7 +1,6 @@
 import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import { getPreviousOrEditStartStepId } from '@newsletters-nx/state-machine';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
-import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 
@@ -26,7 +25,6 @@ const finishLayout: WizardStepLayout<DraftService> = {
 			buttonType: 'PREVIOUS',
 			label: 'Back',
 			stepToMoveTo: getPreviousOrEditStartStepId,
-			executeStep: executeModify,
 		},
 	},
 	dynamicMarkdown(requestData, responseData) {
@@ -41,7 +39,6 @@ const finishLayout: WizardStepLayout<DraftService> = {
 			.replace(regExPatterns.name, name)
 			.replace(regExPatterns.listId, listId);
 	},
-	executeSkip: executeModify,
 };
 
 export { finishLayout };

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/footerLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/footerLayout.ts
@@ -4,7 +4,6 @@ import {
 	getNextStepId,
 	getPreviousOrEditStartStepId,
 } from '@newsletters-nx/state-machine';
-import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
@@ -40,16 +39,13 @@ export const footerLayout: WizardStepLayout<DraftService> = {
 			buttonType: 'PREVIOUS',
 			label: 'Back',
 			stepToMoveTo: getPreviousOrEditStartStepId,
-			executeStep: executeModify,
 		},
 		finish: {
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
-			executeStep: executeModify,
 		},
 	},
 	schema: formSchemas.footer,
 	canSkipTo: true,
-	executeSkip: executeModify,
 };

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/imageLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/imageLayout.ts
@@ -4,7 +4,6 @@ import {
 	getNextStepId,
 	getPreviousOrEditStartStepId,
 } from '@newsletters-nx/state-machine';
-import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
@@ -38,16 +37,13 @@ export const imageLayout: WizardStepLayout<DraftService> = {
 			buttonType: 'PREVIOUS',
 			label: 'Back',
 			stepToMoveTo: getPreviousOrEditStartStepId,
-			executeStep: executeModify,
 		},
 		finish: {
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
-			executeStep: executeModify,
 		},
 	},
 	schema: formSchemas.images,
 	canSkipTo: true,
-	executeSkip: executeModify,
 };

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/linkListLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/linkListLayout.ts
@@ -4,7 +4,6 @@ import {
 	getNextStepId,
 	getPreviousOrEditStartStepId,
 } from '@newsletters-nx/state-machine';
-import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
@@ -44,16 +43,13 @@ export const linkListLayout: WizardStepLayout<DraftService> = {
 			buttonType: 'PREVIOUS',
 			label: 'Back',
 			stepToMoveTo: getPreviousOrEditStartStepId,
-			executeStep: executeModify,
 		},
 		finish: {
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
-			executeStep: executeModify,
 		},
 	},
 	schema: formSchemas.linkList,
 	canSkipTo: true,
-	executeSkip: executeModify,
 };

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/newsletterHeaderLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/newsletterHeaderLayout.ts
@@ -4,7 +4,6 @@ import {
 	getNextStepId,
 	getPreviousOrEditStartStepId,
 } from '@newsletters-nx/state-machine';
-import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
@@ -53,16 +52,13 @@ export const newsletterHeaderLayout: WizardStepLayout<DraftService> = {
 			buttonType: 'PREVIOUS',
 			label: 'Back',
 			stepToMoveTo: getPreviousOrEditStartStepId,
-			executeStep: executeModify,
 		},
 		finish: {
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
-			executeStep: executeModify,
 		},
 	},
 	schema: formSchemas.newsletterHeader,
 	canSkipTo: true,
-	executeSkip: executeModify,
 };

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/paletteOverrideLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/paletteOverrideLayout.ts
@@ -4,7 +4,6 @@ import {
 	getNextStepId,
 	getPreviousOrEditStartStepId,
 } from '@newsletters-nx/state-machine';
-import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
@@ -36,16 +35,13 @@ export const paletteOverrideLayout: WizardStepLayout<DraftService> = {
 			buttonType: 'PREVIOUS',
 			label: 'Back',
 			stepToMoveTo: getPreviousOrEditStartStepId,
-			executeStep: executeModify,
 		},
 		finish: {
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
-			executeStep: executeModify,
 		},
 	},
 	schema: formSchemas.newsletterPaletteOverride,
 	canSkipTo: true,
-	executeSkip: executeModify,
 };

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/podcastLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/podcastLayout.ts
@@ -4,7 +4,6 @@ import {
 	getNextStepId,
 	getPreviousOrEditStartStepId,
 } from '@newsletters-nx/state-machine';
-import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
@@ -44,16 +43,13 @@ export const podcastLayout: WizardStepLayout<DraftService> = {
 			buttonType: 'PREVIOUS',
 			label: 'Back',
 			stepToMoveTo: getPreviousOrEditStartStepId,
-			executeStep: executeModify,
 		},
 		finish: {
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
-			executeStep: executeModify,
 		},
 	},
 	schema: formSchemas.podcast,
 	canSkipTo: true,
-	executeSkip: executeModify,
 };

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/readMoreLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/readMoreLayout.ts
@@ -4,7 +4,6 @@ import {
 	getNextStepId,
 	getPreviousOrEditStartStepId,
 } from '@newsletters-nx/state-machine';
-import { executeModify } from '../../executeModify';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
@@ -43,16 +42,13 @@ export const readMoreLayout: WizardStepLayout<DraftService> = {
 			buttonType: 'PREVIOUS',
 			label: 'Back',
 			stepToMoveTo: getPreviousOrEditStartStepId,
-			executeStep: executeModify,
 		},
 		next: {
 			buttonType: 'NEXT',
 			label: 'Next',
 			stepToMoveTo: getNextStepId,
-			executeStep: executeModify,
 		},
 	},
 	schema: formSchemas.readMore,
 	canSkipTo: true,
-	executeSkip: executeModify,
 };

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/server.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/server.ts
@@ -1,0 +1,102 @@
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
+import type { WizardLayout } from '@newsletters-nx/state-machine';
+import { executeModify } from '../../executeModify';
+import { cancelLayout } from './cancelLayout';
+import { darkSectionLayout } from './darkSectionLayout';
+import { finishLayout } from './finishLayout';
+import { footerLayout } from './footerLayout';
+import { imageLayout } from './imageLayout';
+import { linkListLayout } from './linkListLayout';
+import { newsletterHeaderLayout } from './newsletterHeaderLayout';
+import { paletteOverrideLayout } from './paletteOverrideLayout';
+import { podcastLayout } from './podcastLayout';
+import { readMoreLayout } from './readMoreLayout';
+import { startLayout } from './startLayout';
+
+export const renderingOptionsLayout: WizardLayout<DraftService> = {
+	start: {
+		...startLayout,
+		executeSkip: executeModify,
+	},
+	newsletterHeader: {
+		...newsletterHeaderLayout,
+		executeSkip: executeModify,
+		buttons: {
+			...newsletterHeaderLayout.buttons,
+			back: { ...newsletterHeaderLayout.buttons['back']!, executeStep: executeModify },
+			finish: { ...newsletterHeaderLayout.buttons['finish']!, executeStep: executeModify },
+		},
+	},
+	image: {
+		...imageLayout,
+		executeSkip: executeModify,
+		buttons: {
+			...imageLayout.buttons,
+			back: { ...imageLayout.buttons['back']!, executeStep: executeModify },
+			finish: { ...imageLayout.buttons['finish']!, executeStep: executeModify },
+		},
+	},
+	paletteOverride: {
+		...paletteOverrideLayout,
+		executeSkip: executeModify,
+		buttons: {
+			...paletteOverrideLayout.buttons,
+			back: { ...paletteOverrideLayout.buttons['back']!, executeStep: executeModify },
+			finish: { ...paletteOverrideLayout.buttons['finish']!, executeStep: executeModify },
+		},
+	},
+	readMore: {
+		...readMoreLayout,
+		executeSkip: executeModify,
+		buttons: {
+			...readMoreLayout.buttons,
+			back: { ...readMoreLayout.buttons['back']!, executeStep: executeModify },
+			next: { ...readMoreLayout.buttons['next']!, executeStep: executeModify },
+		},
+	},
+	linkList: {
+		...linkListLayout,
+		executeSkip: executeModify,
+		buttons: {
+			...linkListLayout.buttons,
+			back: { ...linkListLayout.buttons['back']!, executeStep: executeModify },
+			finish: { ...linkListLayout.buttons['finish']!, executeStep: executeModify },
+		},
+	},
+	podcast: {
+		...podcastLayout,
+		executeSkip: executeModify,
+		buttons: {
+			...podcastLayout.buttons,
+			back: { ...podcastLayout.buttons['back']!, executeStep: executeModify },
+			finish: { ...podcastLayout.buttons['finish']!, executeStep: executeModify },
+		},
+	},
+	darkTheme: {
+		...darkSectionLayout,
+		executeSkip: executeModify,
+		buttons: {
+			...darkSectionLayout.buttons,
+			back: { ...darkSectionLayout.buttons['back']!, executeStep: executeModify },
+			next: { ...darkSectionLayout.buttons['next']!, executeStep: executeModify },
+		},
+	},
+	footer: {
+		...footerLayout,
+		executeSkip: executeModify,
+		buttons: {
+			...footerLayout.buttons,
+			back: { ...footerLayout.buttons['back']!, executeStep: executeModify },
+			finish: { ...footerLayout.buttons['finish']!, executeStep: executeModify },
+		},
+	},
+	finish: {
+		...finishLayout,
+		executeSkip: executeModify,
+		buttons: {
+			...finishLayout.buttons,
+			back: { ...finishLayout.buttons['back']!, executeStep: executeModify },
+		},
+	},
+	cancel: cancelLayout,
+};

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/startLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/startLayout.ts
@@ -1,7 +1,6 @@
 import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { getNextStepId } from '@newsletters-nx/state-machine';
-import { executeModify } from '../../executeModify';
 import { getDraftFromStorage } from '../../getDraftFromStorage';
 
 export const startLayout: WizardStepLayout<DraftService> = {
@@ -25,5 +24,4 @@ This wizard is to choose the options for how an article-based newsletter will ap
 	},
 	role: 'EDIT_START',
 	getInitialFormData: getDraftFromStorage,
-	executeSkip: executeModify,
 };

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/dateLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/dateLayout.ts
@@ -4,8 +4,6 @@ import {
 	getPreviousOrEditStartStepId,
 } from '@newsletters-nx/state-machine';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
-import { executeModify } from '../../executeModify';
-import { executeSkip } from '../../executeSkip';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from './formSchemas';
@@ -17,7 +15,7 @@ const markdownTemplate = `
 
 When will the first send of **{{name}}** be? Please specify date. This needs to be in the UK timezone for the system.
 
-We will automatically add a testing period for the newsletter of 1 week before the first send so you can try out the template in Composer. Please also mark if the newsletter should be private if it’s confidential.
+We will automatically add a testing period for the newsletter of 1 week before the first send so you can try out the template in Composer. Please also mark if the newsletter should be private if it's confidential.
 
 ### Promotion
 
@@ -49,16 +47,13 @@ export const dateLayout: WizardStepLayout<DraftService> = {
 			buttonType: 'PREVIOUS',
 			label: 'Back to previous step',
 			stepToMoveTo: getPreviousOrEditStartStepId,
-			executeStep: executeSkip,
 		},
 		finish: {
 			buttonType: 'NEXT',
 			label: 'Save and Continue',
 			stepToMoveTo: getNextStepId,
-			executeStep: executeModify,
 		},
 	},
 	schema: formSchemas.promotionDates,
 	canSkipTo: true,
-	executeSkip: executeSkip,
 };

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/editDraftNewsletterLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/editDraftNewsletterLayout.ts
@@ -1,8 +1,6 @@
 import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { getNextStepId } from '@newsletters-nx/state-machine';
-import { executeModify } from '../../executeModify';
-import { executeSkip } from '../../executeSkip';
 import { getDraftFromStorage } from '../../getDraftFromStorage';
 import { formSchemas } from './formSchemas';
 
@@ -23,12 +21,10 @@ You can edit the name of the newsletter.
 			buttonType: 'NEXT',
 			label: 'Save and Continue',
 			stepToMoveTo: getNextStepId,
-			executeStep: executeModify,
 		},
 	},
 	schema: formSchemas.nameAndFrequency,
 	role: 'EDIT_START',
 	getInitialFormData: getDraftFromStorage,
 	canSkipTo: true,
-	executeSkip: executeSkip,
 };

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/finishLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/finishLayout.ts
@@ -1,6 +1,5 @@
 import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
-import { executeSkip } from '../../executeSkip';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 
@@ -40,7 +39,6 @@ const finishLayout: WizardStepLayout<DraftService> = {
 			.replace(regExPatterns.listId, listId);
 	},
 	canSkipTo: true,
-	executeSkip: executeSkip,
 };
 
 export { finishLayout };

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/nameAndFrequencyLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/nameAndFrequencyLayout.ts
@@ -1,7 +1,6 @@
 import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import { getNextStepId } from '@newsletters-nx/state-machine';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
-import { executeCreate } from '../../executeCreate';
 import { formSchemas } from './formSchemas';
 
 export const nameAndFrequencyLayout: WizardStepLayout<DraftService> = {
@@ -28,11 +27,9 @@ The frequency you specify will be shown on the sign up page, and on the all news
 			buttonType: 'NEXT',
 			label: 'Save and Continue',
 			stepToMoveTo: getNextStepId,
-			executeStep: executeCreate,
 		},
 	},
 	schema: formSchemas.nameAndFrequency,
 	canSkipTo: true,
 	skippingWillPersistLocalChanges: true,
-	executeSkip: executeCreate,
 };

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/productionDetailsLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/productionDetailsLayout.ts
@@ -4,8 +4,6 @@ import {
 	getNextStepId,
 	getPreviousOrEditStartStepId,
 } from '@newsletters-nx/state-machine';
-import { executeModify } from '../../executeModify';
-import { executeSkip } from '../../executeSkip';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from './formSchemas';
@@ -63,16 +61,13 @@ export const productionDetailsLayout: WizardStepLayout<DraftService> = {
 			buttonType: 'PREVIOUS',
 			label: 'Back to previous step',
 			stepToMoveTo: getPreviousOrEditStartStepId,
-			executeStep: executeSkip,
 		},
 		finish: {
 			buttonType: 'NEXT',
 			label: 'Save and Continue',
 			stepToMoveTo: getNextStepId,
-			executeStep: executeModify,
 		},
 	},
 	schema: formSchemas.productionDetails,
 	canSkipTo: true,
-	executeSkip,
 };

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/promotionContentLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/promotionContentLayout.ts
@@ -4,8 +4,6 @@ import {
 	getNextStepId,
 	getPreviousOrEditStartStepId,
 } from '@newsletters-nx/state-machine';
-import { executeModify } from '../../executeModify';
-import { executeSkip } from '../../executeSkip';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from './formSchemas';
@@ -57,13 +55,11 @@ export const promotionContentLayout: WizardStepLayout<DraftService> = {
 			buttonType: 'PREVIOUS',
 			label: 'Back to previous step',
 			stepToMoveTo: getPreviousOrEditStartStepId,
-			executeStep: executeSkip,
 		},
 		next: {
 			buttonType: 'NEXT',
 			label: 'Save and Continue',
 			stepToMoveTo: getNextStepId,
-			executeStep: executeModify,
 		},
 	},
 	schema: formSchemas.promotionContent,
@@ -76,5 +72,4 @@ export const promotionContentLayout: WizardStepLayout<DraftService> = {
 		},
 	},
 	canSkipTo: true,
-	executeSkip: executeSkip,
 };

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/server.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/server.ts
@@ -1,0 +1,121 @@
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
+import type { WizardLayout } from '@newsletters-nx/state-machine';
+import { executeCreate } from '../../executeCreate';
+import { executeModify } from '../../executeModify';
+import { executeSkip } from '../../executeSkip';
+import { cancelLayout } from './cancelLayout';
+import { dateLayout } from './dateLayout';
+import { editDraftNewsletterLayout } from './editDraftNewsletterLayout';
+import { finishLayout } from './finishLayout';
+import { createDraftIntro } from './introLayout';
+import { nameAndFrequencyLayout } from './nameAndFrequencyLayout';
+import { productionDetailsLayout } from './productionDetailsLayout';
+import { promotionContentLayout } from './promotionContentLayout';
+import { tagsLayout } from './tagsLayout';
+import { targetingLayout } from './targetingLayout';
+
+export const standRedesignLayout: WizardLayout<DraftService> = {
+	cancel: cancelLayout,
+	intro: createDraftIntro,
+	nameAndFrequencyLayout: {
+		...nameAndFrequencyLayout,
+		executeSkip: executeCreate,
+		buttons: {
+			...nameAndFrequencyLayout.buttons,
+			next: {
+				...nameAndFrequencyLayout.buttons['next']!,
+				executeStep: executeCreate,
+			},
+		},
+	},
+	editDraftNewsletter: {
+		...editDraftNewsletterLayout,
+		executeSkip,
+		buttons: {
+			...editDraftNewsletterLayout.buttons,
+			next: {
+				...editDraftNewsletterLayout.buttons['next']!,
+				executeStep: executeModify,
+			},
+		},
+	},
+	productionDetails: {
+		...productionDetailsLayout,
+		executeSkip,
+		buttons: {
+			...productionDetailsLayout.buttons,
+			back: {
+				...productionDetailsLayout.buttons['back']!,
+				executeStep: executeSkip,
+			},
+			finish: {
+				...productionDetailsLayout.buttons['finish']!,
+				executeStep: executeModify,
+			},
+		},
+	},
+	dates: {
+		...dateLayout,
+		executeSkip,
+		buttons: {
+			...dateLayout.buttons,
+			back: {
+				...dateLayout.buttons['back']!,
+				executeStep: executeSkip,
+			},
+			finish: {
+				...dateLayout.buttons['finish']!,
+				executeStep: executeModify,
+			},
+		},
+	},
+	targeting: {
+		...targetingLayout,
+		executeSkip,
+		buttons: {
+			...targetingLayout.buttons,
+			back: {
+				...targetingLayout.buttons['back']!,
+				executeStep: executeSkip,
+			},
+			finish: {
+				...targetingLayout.buttons['finish']!,
+				executeStep: executeModify,
+			},
+		},
+	},
+	tags: {
+		...tagsLayout,
+		executeSkip,
+		buttons: {
+			...tagsLayout.buttons,
+			back: {
+				...tagsLayout.buttons['back']!,
+				executeStep: executeSkip,
+			},
+			finish: {
+				...tagsLayout.buttons['finish']!,
+				executeStep: executeModify,
+			},
+		},
+	},
+	signUpPage: {
+		...promotionContentLayout,
+		executeSkip,
+		buttons: {
+			...promotionContentLayout.buttons,
+			back: {
+				...promotionContentLayout.buttons['back']!,
+				executeStep: executeSkip,
+			},
+			next: {
+				...promotionContentLayout.buttons['next']!,
+				executeStep: executeModify,
+			},
+		},
+	},
+	finish: {
+		...finishLayout,
+		executeSkip,
+	},
+};

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/tagsLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/tagsLayout.ts
@@ -4,8 +4,6 @@ import {
 	getNextStepId,
 	getPreviousOrEditStartStepId,
 } from '@newsletters-nx/state-machine';
-import { executeModify } from '../../executeModify';
-import { executeSkip } from '../../executeSkip';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from './formSchemas';
@@ -49,7 +47,6 @@ export const tagsLayout: WizardStepLayout<DraftService> = {
 			buttonType: 'PREVIOUS',
 			label: 'Back to previous step',
 			stepToMoveTo: getPreviousOrEditStartStepId,
-			executeStep: executeSkip,
 		},
 		finish: {
 			buttonType: 'NEXT',
@@ -86,10 +83,8 @@ export const tagsLayout: WizardStepLayout<DraftService> = {
 				}
 				return undefined;
 			},
-			executeStep: executeModify,
 		},
 	},
 	schema: formSchemas.tags,
 	canSkipTo: true,
-	executeSkip: executeSkip,
 };

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/targetingLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/targetingLayout.ts
@@ -4,8 +4,6 @@ import {
 	getPreviousOrStartStepId,
 } from '@newsletters-nx/state-machine';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
-import { executeModify } from '../../executeModify';
-import { executeSkip } from '../../executeSkip';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from './formSchemas';
@@ -24,7 +22,7 @@ Please then select a group for **{{name}}** to be listed under on the [Manage My
 
 ### Choose the Geo Focus for {{name}}
 
-What’s the geo focus of **{{name}}**? UK, US, Australia, Europe or International?
+What's the geo focus of **{{name}}**? UK, US, Australia, Europe or International?
 
 `.trim();
 
@@ -48,16 +46,13 @@ export const targetingLayout: WizardStepLayout<DraftService> = {
 			buttonType: 'PREVIOUS',
 			label: 'Back to previous step',
 			stepToMoveTo: getPreviousOrStartStepId,
-			executeStep: executeSkip,
 		},
 		finish: {
 			buttonType: 'NEXT',
 			label: 'Save and Continue',
 			stepToMoveTo: getNextStepId,
-			executeStep: executeModify,
 		},
 	},
 	schema: formSchemas.targeting,
 	canSkipTo: true,
-	executeSkip: executeSkip,
 };

--- a/libs/newsletter-workflow/src/server.ts
+++ b/libs/newsletter-workflow/src/server.ts
@@ -1,0 +1,1 @@
+export * from './lib/newsletter-workflow.server';

--- a/libs/newsletters-data-client/src/server.ts
+++ b/libs/newsletters-data-client/src/server.ts
@@ -1,3 +1,4 @@
+// Browser safe exports (mirrors index.ts without the type only re-exports)
 export * from './lib/api-response-type';
 export * from './lib/derive-newsletter-fields';
 export * from './lib/draft-to-newsletter';
@@ -20,8 +21,11 @@ export * from './lib/user-profile';
 export * from './lib/wizard-button-type';
 export * from './lib/zod-helpers';
 export * from './lib/zod-helpers/user-data-schema';
-// Type only exports so the client/browser can use these as type
-// parameters without bundling any server-side (AWS SDK) code
-export type { DraftService } from './lib/draft-service';
-export type { LaunchService } from './lib/launch-service';
-export type { DraftWithId } from './lib/draft-storage/DraftStorage';
+
+// Server only exports
+export * from './lib/draft-service';
+export * from './lib/launch-service';
+export * from './lib/newsletter-storage';
+export * from './lib/draft-storage';
+export { LayoutStorage, InMemoryLayoutStorage, S3LayoutStorage } from './lib/layout-storage';
+export * from './lib/generic-s3-functions';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,11 +21,20 @@
 			"@newsletters-nx/email-builder": [
 				"./libs/email-builder/src/index.ts"
 			],
+			"@newsletters-nx/email-builder/server": [
+				"./libs/email-builder/src/server.ts"
+			],
 			"@newsletters-nx/newsletter-workflow": [
 				"./libs/newsletter-workflow/src/index.ts"
 			],
+			"@newsletters-nx/newsletter-workflow/server": [
+				"./libs/newsletter-workflow/src/server.ts"
+			],
 			"@newsletters-nx/newsletters-data-client": [
 				"./libs/newsletters-data-client/src/index.ts"
+			],
+			"@newsletters-nx/newsletters-data-client/server": [
+				"./libs/newsletters-data-client/src/server.ts"
 			],
 			"@newsletters-nx/state-machine": [
 				"./libs/state-machine/src/index.ts"


### PR DESCRIPTION
## Context
The following pr (https://github.com/guardian/newsletters-nx/pull/643) fixed a vulnerability in a transitive dependency axios by updating some core dependencies, namely the nx packages. As a consequence of bumping the nx packages another transitive dependency of those nx packages (vite) also updated a major version from v7 to v8 ... v8 of vite changed the bundler that is uses from from esbuild to rolldown ... Rolldown does strict static analysis of re-export chains (which we had in libs/newsletters-data-client/src/index.ts and libs/util/src/index.ts) and throws an error when it encounters node:fs imports during dep optimisation (server imports in the client). This was silently ignored by esbuild (Vite ≤=7).

So the following pr was created (https://github.com/guardian/newsletters-nx/pull/643/changes) to fix the issue by stubbing the server imports on the client/browser. 

It was agreed that stubbing the server imports was probably not a proper long term fix, and so ....

## What does this change?
Properly separates out the client/browser code from the server code. 

The email-builder, newsletter-workflow, and newsletters-data-client libraries all used a single barrel export (`export * from './src/allovertheplace';`) that mixed browser-safe types with server-only code (AWS SDK clients, DraftService, LaunchService, S3 storage). This caused the browser bundle to transitively include node/AWS modules it had no business importing.

Added /server subpath exports to each lib so server code imports from for example `@newsletters-nx/newsletters-data-client/server` while the browser continues to import from the main entry point (`index.ts`)
