### PR TITLE
Add signup highlight card title field

### DIFF
--- a/apps/newsletters-api/static/newsletters.local.json
+++ b/apps/newsletters-api/static/newsletters.local.json
@@ -383,6 +383,7 @@
 		"tagCreationStatus": "COMPLETED",
 		"seriesTag": "tests/series/playwright-article-test-email",
 		"mailSuccessDescription": "You are signed up for Playwright Article Test.",
+		"highlightCardTitle": "Playwright Article Test highlight",
 		"renderingOptions": {
 			"displayDate": false,
 			"displayStandfirst": false,
@@ -422,6 +423,7 @@
 		"ophanCampaignCreationStatus": "COMPLETED",
 		"signupPageCreationStatus": "COMPLETED",
 		"tagCreationStatus": "COMPLETED",
-		"mailSuccessDescription": "You are signed up for Playwright Fronts Test."
+		"mailSuccessDescription": "You are signed up for Playwright Fronts Test.",
+		"highlightCardTitle": "Playwright Fronts Test highlight"
 	}
 ]

--- a/apps/newsletters-api/static/newsletters.seed.json
+++ b/apps/newsletters-api/static/newsletters.seed.json
@@ -37,6 +37,7 @@
 		"ophanCampaignCreationStatus": "COMPLETED",
 		"signupPageCreationStatus": "COMPLETED",
 		"tagCreationStatus": "NOT_REQUESTED",
+		"highlightCardTitle": "Playwright launched highlight",
 		"renderingOptions": {
 			"displayDate": true,
 			"displayStandfirst": false,

--- a/apps/newsletters-e2e/helpers/draft-newsletter.ts
+++ b/apps/newsletters-e2e/helpers/draft-newsletter.ts
@@ -55,6 +55,7 @@ interface SignUpPageFields {
 	signUpEmbedDescription: string;
 	signUpHeadline?: string;
 	mailSuccessDescription?: string;
+	highlightCardTitle?: string;
 }
 
 type StepFormDataMap = {

--- a/apps/newsletters-e2e/src/ui/createNewsletter.spec.ts
+++ b/apps/newsletters-e2e/src/ui/createNewsletter.spec.ts
@@ -187,6 +187,7 @@ async function completePromotionContentStep(page: Page, name: string) {
 	await expect(page.getByLabel('Sign-up description')).toBeVisible();
 	await expect(page.getByLabel('Sign up embed description')).toBeVisible();
 	await expect(page.getByLabel('Sign-up success message')).toBeVisible();
+	await expect(page.getByLabel('Sign-up highlight card title')).toBeVisible();
 	await expect(
 		page.getByLabel('URL of image the newsleter graphic/logo (5:3 format)'),
 	).toBeVisible();
@@ -199,6 +200,9 @@ async function completePromotionContentStep(page: Page, name: string) {
 	await page
 		.getByLabel('Sign up embed description')
 		.fill(`Embed description for ${name}.`);
+	await page
+		.getByLabel('Sign-up highlight card title')
+		.fill(`Highlight card for ${name}`);
 
 	await page.getByRole('button', { name: 'Save and Continue' }).click();
 }

--- a/apps/newsletters-e2e/src/ui/editArticleNewsletter.spec.ts
+++ b/apps/newsletters-e2e/src/ui/editArticleNewsletter.spec.ts
@@ -21,6 +21,7 @@ test.describe('Edit article-based newsletter', () => {
 			signUpEmbedDescription:
 				'Sign up for the Playwright Article Test newsletter.',
 			mailSuccessDescription: 'You are signed up for Playwright Article Test.',
+			highlightCardTitle: 'Playwright Article Test highlight',
 			seriesTag: 'tests/series/playwright-article-test-email',
 			composerTag: null,
 			composerCampaignTag: null,
@@ -72,6 +73,11 @@ test.describe('Edit article-based newsletter', () => {
 		await page
 			.getByLabel('Sign-up success message')
 			.fill('Thanks for signing up to Updated Article Test!');
+
+		await page
+			.getByLabel('Sign-up highlight card title')
+			.fill('Updated Article Test highlight');
+
 
 		await page
 			.getByLabel('Series tag (path)')

--- a/apps/newsletters-e2e/src/ui/editFrontsNewsletter.spec.ts
+++ b/apps/newsletters-e2e/src/ui/editFrontsNewsletter.spec.ts
@@ -21,6 +21,7 @@ test.describe('Edit fronts-based newsletter', () => {
 			signUpEmbedDescription:
 				'Sign up for the Playwright Fronts Test newsletter.',
 			mailSuccessDescription: 'You are signed up for Playwright Fronts Test.',
+			highlightCardTitle: 'Playwright Fronts Test highlight',
 			composerTag: null,
 			composerCampaignTag: null,
 			signupPage: '/global/sign-up-for-playwright-fronts-test',
@@ -69,6 +70,10 @@ test.describe('Edit fronts-based newsletter', () => {
 		await page
 			.getByLabel('Sign-up success message')
 			.fill('Thanks for signing up to Updated Fronts Test!');
+
+		await page
+			.getByLabel('Sign-up highlight card title')
+			.fill('Updated Fronts Test highlight');
 
 		await page
 			.getByLabel('Composer tag(s)')

--- a/apps/newsletters-e2e/src/ui/launched.spec.ts
+++ b/apps/newsletters-e2e/src/ui/launched.spec.ts
@@ -104,6 +104,11 @@ test.describe('Top nav - launched', () => {
 		});
 		await expect(signSuccessMessage).toBeEditable();
 
+		const signUpHighlightCardTitle = page.getByRole('textbox', {
+			name: 'Sign-up highlight card title',
+		});
+		await expect(signUpHighlightCardTitle).toBeEditable();
+
 		const brazeNewsletterName = page.getByRole('textbox', {
 			name: 'brazeNewsletterName',
 		});

--- a/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
+++ b/apps/newsletters-ui/src/app/components/NewsletterDataDetails.tsx
@@ -110,6 +110,7 @@ export const NewsletterDataDetails = ({ newsletter }: Props) => {
 					tooltip="The short message to display when the user signs up using a sign up embed."
 				/>
 				<DataPoint property="mailSuccessDescription" />
+				<DataPoint property="highlightCardTitle" />
 			</DetailAccordian>
 			<DetailAccordian title="Tags">
 				<DataPoint property="seriesTag" />

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/formSchemas.ts
@@ -80,6 +80,7 @@ export const formSchemas = {
 			signUpDescription: true,
 			signUpEmbedDescription: true,
 			mailSuccessDescription: true,
+			highlightCardTitle: true,
 			illustrationCard: true,
 			illustrationSquare: true,
 		})

--- a/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
@@ -161,6 +161,10 @@ export const newsletterDataSchema = z.object({
 		.string()
 		.optional()
 		.describe('Sign-up success message'),
+	highlightCardTitle: z
+		.string()
+		.optional()
+		.describe('Sign-up highlight card title'),
 	brazeCampaignCreationStatus: workflowStatusEnumSchema.describe(
 		'Braze campaign creation status',
 	),

--- a/libs/newsletters-data-client/src/lib/zod-helpers/user-data-schema.ts
+++ b/libs/newsletters-data-client/src/lib/zod-helpers/user-data-schema.ts
@@ -25,6 +25,7 @@ export const getUserEditSchema = (
 			signUpDescription: true,
 			signUpEmbedDescription: true,
 			mailSuccessDescription: true,
+			highlightCardTitle: true,
 			brazeCampaignCreationStatus: true,
 			brazeNewsletterName: true,
 			brazeSubscribeAttributeName: true,
@@ -49,6 +50,7 @@ export const getUserEditSchema = (
 			signupPage: true,
 			signUpDescription: true,
 			signUpEmbedDescription: true,
+			highlightCardTitle: true,
 			restricted: true,
 		});
 	}


### PR DESCRIPTION
## What does this change?

Adds a new optional `highlightCardTitle` field ("Sign-up highlight card title") to the newsletter data schema, positioned directly beneath the existing "Sign-up success message" field. The field is available in the original Material UI newsletter creation/edit workflow for both article-based and fronts-based newsletters. The stand redesign workflow is out of scope and can be updated separately.

## How has this change been tested?

Existing and new Playwright e2e tests cover:
- The field is visible and fillable in the create newsletter wizard (article and fronts journeys).
- The field is editable in the launched newsletter edit form.
- The article and fronts edit specs fill and reset the field in their `afterEach` cleanup.

Unit tests for `newsletters-data-client` (schema, transforms) continue to pass.

## How can we measure success?

The field appears in the promotion content step of the newsletter creation wizard and in the edit form for launched newsletters.

## Have we considered potential risks?

The field is optional and additive — no existing data is affected and no migrations are required.

## Images

N/A

## Accessibility

N/A — no visual or interaction changes beyond an additional text input consistent with existing form fields.

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

