### PR TITLE
[Stand Redesign] Add custom/other optional input to radio

### DIFF
--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/RadioSelectInput.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/RadioSelectInput.tsx
@@ -1,40 +1,114 @@
+import { baseSpacing } from '@guardian/stand';
 import { Radio, RadioGroup } from '@guardian/stand/RadioGroup';
+import { TextInput } from '@guardian/stand/TextInput';
+import type { TextInputProps } from '@guardian/stand/TextInput';
+import { useEffect, useState } from 'react';
+import type { FormEventHandler } from 'react';
 import type { FunctionComponent } from 'react';
 import type { StandardFormProps } from './SchemaField';
 import type { FieldProps } from './util';
+import { eventToString } from './util';
 
 const EMPTY_STRING = '';
+const OTHER_OPTION_VALUE = '__other_option__';
 
 export const StandRadioSelectInput: FunctionComponent<
 	FieldProps &
 		StandardFormProps & {
 			value: string | undefined;
 			options: string[];
+			otherInputLabel?: string;
+			otherInputProps?: Omit<
+				TextInputProps,
+				'value' | 'onInput' | 'isInvalid' | 'error' | 'isDisabled' | 'label'
+			>;
 		}
 > = (props) => {
 	const {
 		value,
 		options,
+		otherInputLabel,
 		optional,
 		inputHandler,
 		label = 'value',
 		description,
 	} = props;
 
+	const hasCustomValue =
+		typeof value === 'string' &&
+		value !== EMPTY_STRING &&
+		!options.includes(value);
+	const [isOtherSelected, setIsOtherSelected] = useState(false);
+
+	useEffect(() => {
+		if (hasCustomValue) {
+			setIsOtherSelected(true);
+		}
+	}, [hasCustomValue]);
+
+	const showCustomInput =
+		otherInputLabel && (hasCustomValue || isOtherSelected);
+	const radioGroupValue =
+		otherInputLabel && (hasCustomValue || isOtherSelected)
+			? OTHER_OPTION_VALUE
+			: value;
+
+	const handleRadioChange = (newValue: string) => {
+		if (newValue === OTHER_OPTION_VALUE) {
+			setIsOtherSelected(true);
+			inputHandler(EMPTY_STRING);
+			return;
+		}
+		setIsOtherSelected(false);
+		inputHandler(newValue);
+	};
+
+	const handleCustomInput: FormEventHandler<HTMLInputElement> = (event) => {
+		inputHandler(eventToString(event));
+	};
+
 	return (
-		<RadioGroup
-			label={label}
-			onChange={inputHandler}
-			value={value}
-			description={description ?? ''}
-		>
-			{/* Haven't seen this used but have preserved this way of doing it */}
-			{optional && <Radio value={EMPTY_STRING}>[none]</Radio>}
-			{options.map((option) => (
-				<Radio key={option} value={option}>
-					{option}
-				</Radio>
-			))}
-		</RadioGroup>
+		<div>
+			<RadioGroup
+				label={label}
+				onChange={handleRadioChange}
+				value={radioGroupValue}
+				description={description ?? ''}
+			>
+				{/* Haven't seen this used but have preserved this way of doing it */}
+				{optional && <Radio value={EMPTY_STRING}>[none]</Radio>}
+				{options.map((option) => (
+					<Radio key={option} value={option}>
+						{option}
+					</Radio>
+				))}
+				{otherInputLabel && (
+					<Radio key={OTHER_OPTION_VALUE} value={OTHER_OPTION_VALUE}>
+						{otherInputLabel}
+					</Radio>
+				)}
+			</RadioGroup>
+			{showCustomInput && (
+				<TextInput
+					aria-label={`${otherInputLabel}`}
+					onInput={handleCustomInput}
+					value={typeof value === 'string' ? value : EMPTY_STRING}
+					isInvalid={!!props.error}
+					error={props.error}
+					isDisabled={props.readOnly}
+					{...props.otherInputProps}
+					theme={{
+						...props.otherInputProps?.theme,
+						shared: {
+							...props.otherInputProps?.theme?.shared,
+							// the designs call for 12px (0.75rem) between the radio group and the custom input
+							// by default the TextInput has 8px (0.5rem) margin-top and  the radio group has 8px (0.5rem) margin-bottom,
+							// so we replace the TextInput margin-top with 4px (0.25rem) to achieve the desired spacing
+							marginTop: baseSpacing['4Rem'],
+						},
+					}}
+				/>
+			)}
+		</div>
 	);
 };

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaField.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaField.tsx
@@ -144,6 +144,24 @@ export function SchemaField<T extends z.ZodRawShape>({
 			return <WrongValueTypeMessage field={field} />;
 		}
 
+		// Custom handling for frequency field to use radio input with custom option
+		if (key === 'frequency') {
+			return (
+				<StandRadioSelectInput
+					{...standardProps}
+					value={value}
+					options={[
+						'Weekly',
+						'Every fortnight',
+						'Every weekday',
+						'Monthly',
+						'Every day',
+					]}
+					otherInputLabel="Custom (please specify)"
+				/>
+			);
+		}
+
 		if (options) {
 			if (options.length <= maxOptionsForRadioButtons) {
 				return (


### PR DESCRIPTION
## What does this change?

Updates the radio input group to allow for a custom/other value for scenarios where the provided options are not sufficient

This is done by updating the `StandRadioSelectInput` which wraps the `@guardian/stand` `Radio` and `RadioGroup` to include a prop which enables the custom text input field when the option is selected.

Much of the work is down to managing the state of the component regarding the value and change of the value.

Applies it to the create newsletters flow `frequency` field:

https://github.com/user-attachments/assets/f1c00958-241b-4472-9629-1047f4e50e78




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215329238947031