### PR TITLE
Side markdown notes - create newsletters flow 

### DIFF
--- a/apps/newsletters-ui/src/app/components/StandRedesignMarkdownView.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignMarkdownView.tsx
@@ -8,8 +8,7 @@ import ReactMarkdown from 'react-markdown';
 
 interface MarkdownViewProps {
 	markdown: string;
-	addIconToH3?: IconProps['symbol'];
-	id?: string ;
+	addHeadingIcon?: IconProps['symbol'];
 }
 
 const isExternal = (href?: string) => !href?.startsWith('/');
@@ -106,7 +105,7 @@ const TypographyStrong = (props: { children?: ReactNode }) => {
 
 export const StandRedesignMarkdownView: React.FC<MarkdownViewProps> = ({
 	markdown,
-	addIconToH3,
+	addHeadingIcon,
 }) => {
 	return (
 		<div
@@ -123,17 +122,17 @@ export const StandRedesignMarkdownView: React.FC<MarkdownViewProps> = ({
 				components={{
 					a: LinkWithNewTabIfExternal,
 					h1: ({ children }) => (
-						<H2 iconVariant={addIconToH3}>
+						<H2 iconVariant={addHeadingIcon}>
 							{children}
 						</H2>
 					),
 					h2: ({ children }) => (
-						<H2 iconVariant={addIconToH3}>
+						<H2 iconVariant={addHeadingIcon}>
 							{children}
 						</H2>
 					),
 					h3: ({ children }) => (
-						<H3 iconVariant={addIconToH3}>
+						<H3 iconVariant={addHeadingIcon}>
 							{children}
 						</H3>
 					),

--- a/apps/newsletters-ui/src/app/components/StandRedesignMarkdownView.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignMarkdownView.tsx
@@ -1,11 +1,15 @@
 import { css } from '@emotion/react';
 import { baseSpacing } from '@guardian/stand';
+import type { IconProps } from '@guardian/stand/Icon';
+import { Icon } from '@guardian/stand/Icon';
 import { Typography } from '@guardian/stand/Typography';
 import type { ReactNode } from 'react';
 import ReactMarkdown from 'react-markdown';
 
 interface MarkdownViewProps {
 	markdown: string;
+	addIconToH3?: IconProps['symbol'];
+	id?: string ;
 }
 
 const isExternal = (href?: string) => !href?.startsWith('/');
@@ -25,29 +29,35 @@ const LinkWithNewTabIfExternal = (props: {
 	);
 };
 
-const TypographyH2 = (props: { children?: ReactNode }) => {
+const H2 = (props: {iconVariant?: IconProps['symbol']; children?: ReactNode}) => {
 	return (
 		<Typography
 			element="h2"
 			variant="heading2Xl"
 			cssOverrides={css`
 				margin-bottom: ${baseSpacing['16Rem']};
+				display: inline-flex;
+				align-items: center;
+				gap: 7px;
 			`}
 		>
-			{props.children}
+			{props.iconVariant && <Icon aria-hidden={true} symbol={props.iconVariant}/>}{props.children}
 		</Typography>
 	);
 };
-const TypographyH3 = (props: { children?: ReactNode }) => {
+const H3 = (props: {iconVariant?: IconProps['symbol']; children?: ReactNode }) => {
 	return (
-		<Typography
+			<Typography
 			element="h3"
 			variant="headingMd"
 			cssOverrides={css`
 				margin-bottom: ${baseSpacing['12Rem']};
+				display: inline-flex;
+				align-items: center;
+				gap: 7px;
 			`}
 		>
-			{props.children}
+			{props.iconVariant && <Icon aria-hidden={true} symbol={props.iconVariant}/>}{props.children}
 		</Typography>
 	);
 };
@@ -96,6 +106,7 @@ const TypographyStrong = (props: { children?: ReactNode }) => {
 
 export const StandRedesignMarkdownView: React.FC<MarkdownViewProps> = ({
 	markdown,
+	addIconToH3,
 }) => {
 	return (
 		<div
@@ -111,9 +122,21 @@ export const StandRedesignMarkdownView: React.FC<MarkdownViewProps> = ({
 			<ReactMarkdown
 				components={{
 					a: LinkWithNewTabIfExternal,
-					h1: TypographyH2,
-					h2: TypographyH2,
-					h3: TypographyH3,
+					h1: ({ children }) => (
+						<H2 iconVariant={addIconToH3}>
+							{children}
+						</H2>
+					),
+					h2: ({ children }) => (
+						<H2 iconVariant={addIconToH3}>
+							{children}
+						</H2>
+					),
+					h3: ({ children }) => (
+						<H3 iconVariant={addIconToH3}>
+							{children}
+						</H3>
+					),
 					p: TypographyP,
 					ul: UlMarginOverride,
 					strong: TypographyStrong,

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/NotedLabel.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/NotedLabel.tsx
@@ -1,0 +1,8 @@
+import { css } from '@emotion/react';
+import { Icon } from '@guardian/stand/Icon';
+
+export const NotedLabel = (label: string) =>
+	<div css={css`display:flex; align-items: center; gap: 3px`} >
+		{label}
+		<Icon aria-hidden="true" symbol="text_snippet"/>
+	</div>

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaField.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaField.tsx
@@ -57,7 +57,7 @@ interface SchemaFieldProps<T extends z.ZodRawShape> {
 	validationWarning?: string;
 	maxOptionsForRadioButtons: number;
 	explanation?: string;
-	notedField?: boolean;
+	isNoted?: boolean;
 }
 
 const WrongValueTypeMessage = (props: { field: FieldDef }) => (
@@ -95,7 +95,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 	change,
 	options,
 	showUnsupported = false,
-	notedField = false,
+	isNoted = false,
 	numberInputSettings = {},
 	stringInputSettings = {},
 	validationWarning,
@@ -158,13 +158,13 @@ export function SchemaField<T extends z.ZodRawShape>({
 				);
 			}
 			return (
-				<StandSelectInput {...standardProps} value={value} isNoted={notedField} options={options} />
+				<StandSelectInput {...standardProps} value={value} isNoted={isNoted} options={options} />
 			);
 		}
 
 		return (
 			<StandStringInput
-				isNoted={notedField}
+				isNoted={isNoted}
 				{...standardProps}
 				value={value ?? ''}
 				inputType={stringInputSettings.inputType}

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaField.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaField.tsx
@@ -41,6 +41,7 @@ export type StandardFormProps = {
 	optional?: boolean;
 	error?: string;
 	description?: string;
+	isNoted?: boolean;
 };
 
 // T is the shape of the schema passed as a prop to the `SchemaForm`
@@ -56,6 +57,7 @@ interface SchemaFieldProps<T extends z.ZodRawShape> {
 	validationWarning?: string;
 	maxOptionsForRadioButtons: number;
 	explanation?: string;
+	notedField?: boolean;
 }
 
 const WrongValueTypeMessage = (props: { field: FieldDef }) => (
@@ -93,6 +95,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 	change,
 	options,
 	showUnsupported = false,
+	notedField = false,
 	numberInputSettings = {},
 	stringInputSettings = {},
 	validationWarning,
@@ -155,12 +158,13 @@ export function SchemaField<T extends z.ZodRawShape>({
 				);
 			}
 			return (
-				<StandSelectInput {...standardProps} value={value} options={options} />
+				<StandSelectInput {...standardProps} value={value} isNoted={notedField} options={options} />
 			);
 		}
 
 		return (
 			<StandStringInput
+				isNoted={notedField}
 				{...standardProps}
 				value={value ?? ''}
 				inputType={stringInputSettings.inputType}

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/StringInput.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/StringInput.tsx
@@ -1,6 +1,7 @@
 import { TextArea } from '@guardian/stand/TextArea';
 import { TextInput } from '@guardian/stand/TextInput';
 import type { FormEventHandler } from 'react';
+import { NotedLabel } from './NotedLabel';
 import type { StandardFormProps } from './SchemaField';
 import type { FieldProps } from './util';
 import { eventToString } from './util';
@@ -41,6 +42,7 @@ export const StandStringInput = (props: Props) => {
 				error={props.error}
 				isDisabled={props.readOnly}
 				isRequired={!props.optional}
+				renderLabel={props.isNoted ? NotedLabel : undefined }
 			/>
 		);
 	}

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/index.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/index.tsx
@@ -78,7 +78,7 @@ export function StandRedesignSchemaForm<T extends z.ZodRawShape>({
 		>
 			{fields.map((field) => (
 				<SchemaField
-					notedField={notedFields.includes(field.key)}
+					isNoted={notedFields.includes(field.key)}
 					key={field.key}
 					options={options[field.key]}
 					numberInputSettings={numberConfig[field.key]}

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/index.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/index.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { baseSpacing } from '@guardian/stand';
 import type { z, ZodType } from 'zod';
+import type { NotedFields } from '../StandRedesignWizard';
 // eslint-disable-next-line import/no-cycle -- schemaForm renders recursively for SchemaRecordArrayInput
 import { SchemaField } from './SchemaField';
 import type {
@@ -25,6 +26,7 @@ interface Props<T extends z.ZodRawShape> {
 	validationWarnings: Partial<Record<keyof T, string>>;
 	maxOptionsForRadioButtons?: number;
 	explanations?: Partial<Record<keyof T, string>>;
+	notedFields?: NotedFields;
 }
 
 /**
@@ -41,6 +43,7 @@ export function StandRedesignSchemaForm<T extends z.ZodRawShape>({
 	showUnsupported = false,
 	excludedKeys = [],
 	readOnlyKeys = [],
+	notedFields = [],
 	validationWarnings,
 	maxOptionsForRadioButtons = 0,
 	explanations = {},
@@ -75,6 +78,7 @@ export function StandRedesignSchemaForm<T extends z.ZodRawShape>({
 		>
 			{fields.map((field) => (
 				<SchemaField
+					notedField={notedFields.includes(field.key)}
 					key={field.key}
 					options={options[field.key]}
 					numberInputSettings={numberConfig[field.key]}

--- a/apps/newsletters-ui/src/app/components/StandRedesignStateEditForm.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignStateEditForm.tsx
@@ -10,6 +10,7 @@ import {
 	getModification,
 	StandRedesignSchemaForm,
 } from './StandRedesignSchemaForm';
+import type { NotedFields } from './StandRedesignWizard';
 
 interface Props {
 	formSchema: z.ZodObject<z.ZodRawShape>;
@@ -17,12 +18,14 @@ interface Props {
 	setFormData: { (newData: WizardFormData): void };
 	maxOptionsForRadioButtons?: number;
 	stringConfig?: Partial<Record<string, StringInputSettings>>;
+	notedFields?: NotedFields;
 }
 
 export const StandRedesignStateEditForm = ({
 	formSchema,
 	formData,
 	setFormData,
+	notedFields,
 	maxOptionsForRadioButtons,
 	stringConfig = {},
 }: Props) => {
@@ -44,6 +47,7 @@ export const StandRedesignStateEditForm = ({
 			changeValue={changeFormData}
 			maxOptionsForRadioButtons={maxOptionsForRadioButtons}
 			stringConfig={stringConfig}
+			notedFields={notedFields}
 			// ToDo: fix the types on the explanations prop so the keys are typed
 			explanations={{
 				regionFocus: 'Which region is this newsletter mainly designed for?',

--- a/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
@@ -1,14 +1,15 @@
 import { css } from '@emotion/react';
-import { baseSpacing } from '@guardian/stand';
+import { baseSpacing, semanticColors } from '@guardian/stand';
 import { Grid, Item } from '@guardian/stand/Grid';
 import { Layout } from '@guardian/stand/Layout';
 import { Alert, Box, Stack, Typography } from '@mui/material';
 import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import type { WizardId } from '@newsletters-nx/newsletter-workflow';
-import {
+import  {
 	getFieldDisplayOptions,
 	getFormSchema,
+	getNotedFields,
 	getStartStepId,
 	getStepperConfig,
 } from '@newsletters-nx/newsletter-workflow';
@@ -35,6 +36,7 @@ export const StandRedesignWizardContainer: React.FC<WizardProps> = ({
 	return <StandRedesignWizard wizardId={wizardId} id={listId} />;
 };
 
+export type NotedFields = string[];
 /**
  * Interface for the props passed to the `Wizard` component.
  */
@@ -90,6 +92,7 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 	const [formData, setFormData] = useState<WizardFormData | undefined>(
 		undefined,
 	);
+	const [notedFields, setNotedFields] = useState<string[]>([]);
 	const [currentStepHasBeenChanged, setCurrentStepHasBeenChanged] =
 		useState(false);
 	const [showSkipModalFor, setShowSkipModalFor] = useState<string | undefined>(
@@ -111,6 +114,7 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 
 				setServerData(data);
 				const schema = getFormSchema(wizardId, data.currentStepId);
+				const noted = getNotedFields(wizardId, data.currentStepId)
 				const blank = schema ? getEmptySchemaData(schema) : undefined;
 
 				setFormData({
@@ -119,6 +123,11 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 				});
 				setCurrentStepHasBeenChanged(false);
 				setShowSkipModalFor(undefined);
+				if (noted) {
+					setNotedFields(noted);
+				} else {
+					setNotedFields([]);
+				}
 			} catch (error: unknown /* FIXME! */) {
 				setServerErrorMessage('Wizard failed');
 				console.error('Error invoking next step of wizard:', error);
@@ -265,6 +274,7 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 						{formSchema && formData && (
 							<StandRedesignStateEditForm
 								formSchema={formSchema}
+								notedFields={notedFields}
 								formData={formData}
 								setFormData={handleFormChange}
 								maxOptionsForRadioButtons={5}
@@ -292,9 +302,18 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 						</Stack>
 					</Item>
 					<Item size={{ lg: 4 }} offset={{ lg: 1 }}>
-						<StandRedesignMarkdownView
-							markdown={serverData.markdownToDisplayInSidebar ?? ''}
-						/>
+						{serverData.markdownToDisplayInSidebar?.map(({field, markdown}) =>
+							<div css={css`
+							background: ${semanticColors.bg.raisedLevel1};
+							padding: ${baseSpacing['16Px']}
+							`}
+							key={field.toString()}
+							>
+								<StandRedesignMarkdownView
+									markdown={markdown}
+									addIconToH3="text_snippet"
+								/>
+							</div>)}
 					</Item>
 					<Item>
 						<SkipConfirmationDialog

--- a/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
@@ -123,11 +123,8 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 				});
 				setCurrentStepHasBeenChanged(false);
 				setShowSkipModalFor(undefined);
-				if (noted) {
-					setNotedFields(noted);
-				} else {
-					setNotedFields([]);
-				}
+				setNotedFields(noted ?? []);
+
 			} catch (error: unknown /* FIXME! */) {
 				setServerErrorMessage('Wizard failed');
 				console.error('Error invoking next step of wizard:', error);

--- a/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
@@ -311,7 +311,7 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 							>
 								<StandRedesignMarkdownView
 									markdown={markdown}
-									addIconToH3="text_snippet"
+									addHeadingIcon="text_snippet"
 								/>
 							</div>)}
 					</Item>

--- a/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
@@ -307,7 +307,7 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 							background: ${semanticColors.bg.raisedLevel1};
 							padding: ${baseSpacing['16Px']}
 							`}
-							key={field.toString()}
+							key={field}
 							>
 								<StandRedesignMarkdownView
 									markdown={markdown}

--- a/libs/newsletter-workflow/src/lib/newsletter-workflow.ts
+++ b/libs/newsletter-workflow/src/lib/newsletter-workflow.ts
@@ -66,3 +66,18 @@ export const getFieldDisplayOptions = (
 	const step = wizard[stepId];
 	return step?.fieldDisplayOptions;
 };
+
+export const getNotedFields = (
+	wizardId: keyof typeof newslettersWorkflowStepLayout,
+	stepId: string,
+): string[] | undefined => {
+	const wizard = newslettersWorkflowStepLayout[wizardId];
+	if (!wizard) {
+		return undefined;
+	}
+	const step = wizard[stepId];
+	if (!step?.staticSideMarkdown) {
+		return undefined;
+	}
+	return step.staticSideMarkdown.map(({field}) => field.toString());
+}

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/nameAndFrequencyLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/nameAndFrequencyLayout.ts
@@ -3,19 +3,19 @@ import { getNextStepId } from '@newsletters-nx/state-machine';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { formSchemas } from './formSchemas';
 
-export const nameAndFrequencyLayout: WizardStepLayout<DraftService> = {
+export const nameAndFrequencyLayout: WizardStepLayout<DraftService, typeof formSchemas.nameAndFrequency.shape> = {
 	staticMarkdown: `# Enter the newsletter's name
 
 The first step is to enter the name of your newsletter. For example,  **Down to Earth**.
 
 `,
 
-	staticSideMarkdown: `### Frequency
+	staticSideMarkdown: [{ markdown: `### Frequency
 
 The frequency you specify will be shown on the sign up page, and on the all newsletters page.
 
 ![Frequency](https://i.guim.co.uk/img/uploads/2023/09/15/frequency.png?quality=85&dpr=2&width=300&s=e8c4bdd12b9c2f1f48d35a2d9b1ef1c7)
-`,
+`, field: 'frequency' }],
 	label: 'Name & frequency',
 	buttons: {
 		cancel: {

--- a/libs/state-machine/src/lib/makeResponse.ts
+++ b/libs/state-machine/src/lib/makeResponse.ts
@@ -47,20 +47,16 @@ export const makeResponse = (
 		staticMarkdown,
 		dynamicMarkdown,
 		staticSideMarkdown,
-		dynamicSideMarkdown,
 	} = nextWizardStepLayout;
 
 	const markdown = dynamicMarkdown
 		? dynamicMarkdown(requestBody.formData, state.formData)
 		: staticMarkdown;
 
-	const sideMarkdown = dynamicSideMarkdown
-		? dynamicSideMarkdown(requestBody.formData, state.formData)
-		: staticSideMarkdown;
 
 	return {
 		markdownToDisplay: markdown,
-		markdownToDisplayInSidebar: sideMarkdown,
+		markdownToDisplayInSidebar: staticSideMarkdown,
 		currentStepId: state.currentStepId,
 		buttons: convertWizardStepLayoutButtonsToWizardButtons(
 			nextWizardStepLayout.buttons,

--- a/libs/state-machine/src/lib/types.ts
+++ b/libs/state-machine/src/lib/types.ts
@@ -97,7 +97,17 @@ export type WizardStepLayoutButton<
 	executeStep?: AsyncExecution<T> | Execution<T>;
 };
 
-export interface WizardStepLayout<T extends GenericStorageInterface = unknown> {
+export interface WizardStepLayout<
+	T extends GenericStorageInterface = unknown,
+	S extends ZodRawShape = ZodRawShape,
+> extends BaseWizardStepLayout<T> {
+	schema?: ZodObject<S>;
+	staticSideMarkdown?: Array<{field: keyof S; markdown: string}>;
+}
+
+export interface BaseWizardStepLayout<
+	T extends GenericStorageInterface = unknown,
+> {
 	indicateStepsCompleteOnThisWizard?: boolean;
 	label?: string;
 	role?: 'EDIT_START' | 'CREATE_START' | 'EARLY_EXIT';
@@ -106,10 +116,7 @@ export interface WizardStepLayout<T extends GenericStorageInterface = unknown> {
 	dynamicMarkdown?: {
 		(requestData?: WizardFormData, responseData?: WizardFormData): string;
 	};
-	staticSideMarkdown?: string;
-	dynamicSideMarkdown?: {
-		(requestData?: WizardFormData, responseData?: WizardFormData): string;
-	};
+	staticSideMarkdown?: Array<{field: string | number | symbol;  markdown: string}>;
 
 	buttons: Record<string, WizardStepLayoutButton<T>>;
 	schema?: ZodObject<ZodRawShape>;
@@ -132,7 +139,7 @@ export interface WizardStepLayout<T extends GenericStorageInterface = unknown> {
 
 export type WizardLayout<
 	T extends GenericStorageInterface = GenericStorageInterface,
-> = Record<string, WizardStepLayout<T>>;
+> = Record<string, BaseWizardStepLayout<T>>;
 
 /**
  * Interface for the data payload sent to by the client for a single step in the wizard.
@@ -174,7 +181,7 @@ export interface CurrentStepRouteResponse {
 	/** Markdown content to display for the current step in the right side panel
 	 * (redesign only)
 	 */
-	markdownToDisplayInSidebar?: string;
+	markdownToDisplayInSidebar?: Array<{field: string | number | symbol;  markdown:string}>;
 	/** Unique identifier for the current step. */
 	currentStepId: string;
 	/** Buttons to display for the current step. */

--- a/libs/state-machine/src/lib/types.ts
+++ b/libs/state-machine/src/lib/types.ts
@@ -102,7 +102,7 @@ export interface WizardStepLayout<
 	S extends ZodRawShape = ZodRawShape,
 > extends BaseWizardStepLayout<T> {
 	schema?: ZodObject<S>;
-	staticSideMarkdown?: Array<{field: keyof S; markdown: string}>;
+	staticSideMarkdown?: Array<{field: keyof S & string; markdown: string}>;
 }
 
 export interface BaseWizardStepLayout<
@@ -116,7 +116,7 @@ export interface BaseWizardStepLayout<
 	dynamicMarkdown?: {
 		(requestData?: WizardFormData, responseData?: WizardFormData): string;
 	};
-	staticSideMarkdown?: Array<{field: string | number | symbol;  markdown: string}>;
+	staticSideMarkdown?: Array<{field: string;  markdown: string}>;
 
 	buttons: Record<string, WizardStepLayoutButton<T>>;
 	schema?: ZodObject<ZodRawShape>;
@@ -181,7 +181,7 @@ export interface CurrentStepRouteResponse {
 	/** Markdown content to display for the current step in the right side panel
 	 * (redesign only)
 	 */
-	markdownToDisplayInSidebar?: Array<{field: string | number | symbol;  markdown:string}>;
+	markdownToDisplayInSidebar?: Array<{field: string;  markdown:string}>;
 	/** Unique identifier for the current step. */
 	currentStepId: string;
 	/** Buttons to display for the current step. */

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"@emotion/styled": "^11.14.1",
 				"@guardian/image": "^1.1.0",
 				"@guardian/source": "^12.2.1",
-				"@guardian/stand": "0.0.41",
+				"@guardian/stand": "0.0.0-canary-20260528130004",
 				"@mui/icons-material": "^9.0.0",
 				"@mui/material": "^9.0.0",
 				"@mui/x-date-pickers": "^9.0.0",
@@ -3975,9 +3975,9 @@
 			}
 		},
 		"node_modules/@guardian/stand": {
-			"version": "0.0.41",
-			"resolved": "https://registry.npmjs.org/@guardian/stand/-/stand-0.0.41.tgz",
-			"integrity": "sha512-ScigejT7s4ucT3wLRLIirOZKwo6bP3Jzp24/vgfZgjqctAhmqOYr4YDUnKs+ZVU1OeOIH38yzz3/ZR6Hu+pODQ==",
+			"version": "0.0.0-canary-20260528130004",
+			"resolved": "https://registry.npmjs.org/@guardian/stand/-/stand-0.0.0-canary-20260528130004.tgz",
+			"integrity": "sha512-bNeOUuokWHvCFe+2uczQ0AkoFg1T5Ck0H3BoThW1Bp6Tt+bzH+IEHlGlbe1P3L6COjFMPKufP1bOamMxUlsvPw==",
 			"peerDependencies": {
 				"@emotion/react": ">=11.11.4 <=11.14.0",
 				"@guardian/prosemirror-invisibles": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"@emotion/styled": "^11.14.1",
 				"@guardian/image": "^1.1.0",
 				"@guardian/source": "^12.2.1",
-				"@guardian/stand": "0.0.0-canary-20260528130004",
+				"@guardian/stand": "0.0.44",
 				"@mui/icons-material": "^9.0.0",
 				"@mui/material": "^9.0.0",
 				"@mui/x-date-pickers": "^9.0.0",
@@ -3975,9 +3975,9 @@
 			}
 		},
 		"node_modules/@guardian/stand": {
-			"version": "0.0.0-canary-20260528130004",
-			"resolved": "https://registry.npmjs.org/@guardian/stand/-/stand-0.0.0-canary-20260528130004.tgz",
-			"integrity": "sha512-bNeOUuokWHvCFe+2uczQ0AkoFg1T5Ck0H3BoThW1Bp6Tt+bzH+IEHlGlbe1P3L6COjFMPKufP1bOamMxUlsvPw==",
+			"version": "0.0.44",
+			"resolved": "https://registry.npmjs.org/@guardian/stand/-/stand-0.0.44.tgz",
+			"integrity": "sha512-bzoU5RezX3FZ2ArH0M/7WZojStgPKahvD1xSUEYcngTjgS7dzn/Q18gxK/gorA6aFycgXV2AcPi/p3hoHMRNTA==",
 			"peerDependencies": {
 				"@emotion/react": ">=11.11.4 <=11.14.0",
 				"@guardian/prosemirror-invisibles": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"@emotion/styled": "^11.14.1",
 		"@guardian/image": "^1.1.0",
 		"@guardian/source": "^12.2.1",
-		"@guardian/stand": "0.0.0-canary-20260528130004",
+		"@guardian/stand": "0.0.44",
 		"@mui/icons-material": "^9.0.0",
 		"@mui/material": "^9.0.0",
 		"@mui/x-date-pickers": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"@emotion/styled": "^11.14.1",
 		"@guardian/image": "^1.1.0",
 		"@guardian/source": "^12.2.1",
-		"@guardian/stand": "0.0.41",
+		"@guardian/stand": "0.0.0-canary-20260528130004",
 		"@mui/icons-material": "^9.0.0",
 		"@mui/material": "^9.0.0",
 		"@mui/x-date-pickers": "^9.0.0",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Update the model for the SideMarkdown 

```
markdown: string, 
field: string
```

This side markdown is then used to indicate which notes apply to which fields.
The fields with side markdown display an icon `text_snippet`

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

Tested locally, it is behind a feature switch currently

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

<img width="1128" height="471" alt="Screenshot 2026-06-02 at 15 57 54" src="https://github.com/user-attachments/assets/9f31a411-2635-4de9-9af9-707ac92fe419" />

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

The link between the note and the icon / label still needs to be worked out that will be in a different PR

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
