### PR TITLE
[Stand Redesign] Add 1px right border to grid

### DIFF
--- a/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
@@ -1,7 +1,8 @@
 import { css } from '@emotion/react';
-import { baseSpacing, semanticColors } from '@guardian/stand';
+import { baseSpacing, semanticColors, semanticGrid } from '@guardian/stand';
 import { Grid, Item } from '@guardian/stand/Grid';
 import { Layout } from '@guardian/stand/Layout';
+import { from } from '@guardian/stand/utils';
 import { Alert, Box, Stack, Typography } from '@mui/material';
 import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
@@ -256,9 +257,28 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 					formData={formData}
 				/>
 			</Layout.Sidebar>
-			<Layout.Main as="main">
-				<Grid>
-					<Item size={{ sm: 12, md: 11, lg: 6 }} offset={{ lg: 1 }}>
+			<Layout.Main as="main" paddingTop={false} paddingBottom={false}>
+				<Grid
+					// This makes the grid take the full height of the main content area, allowing the border to stretch to the bottom of the page even if the content is short
+					css={css`
+						height: 100%;
+					`}
+				>
+					<Item
+						size={{ sm: 12, md: 11, lg: 6 }}
+						offset={{ lg: 1 }}
+						css={css`
+							margin-top: ${semanticGrid.margin.topSmPx};
+
+							${from.md} {
+								margin-top: ${semanticGrid.margin.topMdPx};
+							}
+
+							${from.lg} {
+								margin-top: ${semanticGrid.margin.topLgPx};
+							}
+						`}
+					>
 						<StandRedesignMarkdownView
 							markdown={serverData.markdownToDisplay ?? ''}
 						/>
@@ -293,20 +313,60 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 							))}
 						</Stack>
 					</Item>
-					<Item size={{ lg: 4 }} offset={{ lg: 1 }}>
-						<div css={css`display: flex; flex-direction: column; gap: ${baseSpacing['20Px']};`}>
-						{serverData.markdownToDisplayInSidebar?.map(({field, markdown}) =>
-							<div css={css`
-							background: ${semanticColors.bg.raisedLevel1};
-							padding: ${baseSpacing['16Px']}
+					<Item
+						size={{ lg: 1 }}
+						cssOverrides={css`
+							display: none;
+							${from.lg} {
+								border-right: 1px solid ${semanticColors.border.weak};
+								display: block;
+							}
+						`}
+					></Item>
+					<Item
+						size={{ lg: 4 }}
+						cssOverrides={css`
+							${from.lg} {
+								margin-top: ${semanticGrid.margin.topLgPx};
+							}
+						`}
+					>
+						<div
+							css={css`
+								display: flex;
+								flex-direction: column;
+								gap: ${baseSpacing['20Px']};
 							`}
-							key={field}
-							>
-								<StandRedesignMarkdownView markdown={markdown} />
-							</div>)}
+						>
+							{serverData.markdownToDisplayInSidebar?.map(
+								({ field, markdown }) => (
+									<div
+										css={css`
+											background: ${semanticColors.bg.raisedLevel1};
+											padding: ${baseSpacing['16Px']};
+										`}
+										key={field}
+									>
+										<StandRedesignMarkdownView markdown={markdown} />
+									</div>
+								),
+							)}
 						</div>
 					</Item>
-					<Item>
+					<Item
+						size={{ lg: 7 }}
+						cssOverrides={css`
+							margin-bottom: ${semanticGrid.margin.bottomSmPx};
+
+							${from.md} {
+								margin-bottom: ${semanticGrid.margin.bottomMdPx};
+							}
+
+							${from.lg} {
+								margin-bottom: ${semanticGrid.margin.bottomLgPx};
+							}
+						`}
+					>
 						<SkipConfirmationDialog
 							currentStepId={serverData.currentStepId}
 							targetStepId={showSkipModalFor}
@@ -315,6 +375,18 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 							stepperConfig={stepperConfig}
 						/>
 					</Item>
+					<Item
+						size={{ lg: 1 }}
+						cssOverrides={css`
+							display: none;
+							${from.lg} {
+								/* use negative margin to align with the top of the previous item i.e overriding the gap */
+								margin-top: -${baseSpacing['16Rem']};
+								border-right: 1px solid ${semanticColors.border.weak};
+								display: block;
+							}
+						`}
+					></Item>
 				</Grid>
 			</Layout.Main>
 		</>


### PR DESCRIPTION
## What does this change?

Adds the 1px right border to all the pages in the stand redesign wizard between the main form and the right side bar, only for `lg` breakpoint.

To accommodate this we removed all top/bottom spacing from the Layout, made the height of the grid `100%`, and instead applied the spacing to individual items instead to get the spacing correct. This could be backported to stand.

The border itself was applied by using an empty `<Item>` and applying the css on that due to the alignment of where the border was required according to the figma designs.

<table>
<tr>
<th> lg
<th> md
<th> sm
<tr>
<td>
<img width="2396" height="2092" alt="Screenshot 2026-06-08 at 14-42-31 Newsletters tool" src="https://github.com/user-attachments/assets/133df419-89f9-43bf-847c-c4537700f112" />
<td>
<img width="1736" height="2092" alt="Screenshot 2026-06-08 at 14-42-50 Newsletters tool" src="https://github.com/user-attachments/assets/7a7ead1d-b8bc-4e32-b18a-b96a313a4d1b" />
<td>
<img width="1450" height="2092" alt="Screenshot 2026-06-08 at 14-43-08 Newsletters tool" src="https://github.com/user-attachments/assets/d41813fd-8b13-465b-8e0c-a555dc3c949b" />
</table>

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215511324467940