### PR TITLE
[Stand Redesign]: Use alert banner for local/code

### DIFF
--- a/apps/newsletters-ui/src/app/Layout.tsx
+++ b/apps/newsletters-ui/src/app/Layout.tsx
@@ -1,3 +1,4 @@
+import { AlertBanner } from '@guardian/stand/AlertBanner';
 import { Layout as StandLayout } from '@guardian/stand/Layout';
 import { Box, css } from '@mui/material';
 import { useEffect } from 'react';
@@ -24,6 +25,13 @@ const frameCss = css`
 interface IRootRoute {
 	outlet?: undefined | React.ReactNode;
 }
+
+const StandAlertBanner = ({ isOnCode }: { isOnCode: boolean }) => (
+	<AlertBanner level="information" showIcon>
+		Environment: {isOnCode ? 'CODE' : 'LOCAL'} - Changes will not impact
+		https://www.theguardian.com/
+	</AlertBanner>
+);
 
 export function Layout(props: IRootRoute) {
 	// Not ideal to use the host name to determine environment.
@@ -61,6 +69,11 @@ export function Layout(props: IRootRoute) {
 	if (isUsingStand && isNewsletterData) {
 		return (
 			<StandLayout>
+				{(isOnCode || isOnLocal) && (
+					<StandLayout.AlertBanner>
+						<StandAlertBanner isOnCode={isOnCode} />
+					</StandLayout.AlertBanner>
+				)}
 				<StandLayout.TopBar>{Nav}</StandLayout.TopBar>
 				{props.outlet ?? <Outlet />}
 			</StandLayout>
@@ -69,6 +82,9 @@ export function Layout(props: IRootRoute) {
 
 	return (
 		<div css={frameCss}>
+			{(isOnCode || isOnLocal) && isUsingStand && (
+				<StandAlertBanner isOnCode={isOnCode} />
+			)}
 			{Nav}
 			<Box sx={{ pt: 8 }} component={'main'}>
 				{props.outlet ?? <Outlet />}


### PR DESCRIPTION
## What does this change?

Sets up the layout to use the AlertBanner to indicate if running on CODE/LOCAL environment when the stand switch is enabled

<table>
<tr>
<th> Create newsletters flow
<th> Homepage (old design, stand nav/alert)
<tr>
<td> 
<img width="2440" height="2092" alt="Screenshot 2026-06-08 at 15-29-22 Newsletters tool" src="https://github.com/user-attachments/assets/2331af30-7c54-466e-8a90-42b16a8d72f0" />

<td>
<img width="2440" height="2092" alt="Screenshot 2026-06-08 at 15-29-14 Newsletters tool" src="https://github.com/user-attachments/assets/65ac5f8a-c8c3-4d87-9111-2da5673580c7" />

</table>

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215511817965609