### PR TITLE
Fix | Stand Redesign |  Restore keyboard focus for RadioGroup when no value is selected

### DIFF
--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/RadioSelectInput.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/RadioSelectInput.tsx
@@ -3,7 +3,7 @@ import { Radio, RadioGroup } from '@guardian/stand/RadioGroup';
 import { TextInput } from '@guardian/stand/TextInput';
 import type { TextInputProps } from '@guardian/stand/TextInput';
 import { useEffect, useState } from 'react';
-import type { FormEventHandler, FunctionComponent} from 'react';
+import type { FormEventHandler, FunctionComponent } from 'react';
 import { NotedLabel } from './NotedLabel';
 import type { StandardFormProps } from './SchemaField';
 import type { FieldProps } from './util';
@@ -72,9 +72,13 @@ export const StandRadioSelectInput: FunctionComponent<
 			<RadioGroup
 				label={label}
 				onChange={handleRadioChange}
-				value={radioGroupValue}
+				value={
+					!optional && radioGroupValue === EMPTY_STRING
+						? undefined
+						: radioGroupValue
+				}
 				description={description ?? ''}
-				renderLabel={props.isNoted ? NotedLabel : undefined }
+				renderLabel={props.isNoted ? NotedLabel : undefined}
 			>
 				{/* Haven't seen this used but have preserved this way of doing it */}
 				{optional && <Radio value={EMPTY_STRING}>[none]</Radio>}


### PR DESCRIPTION
## What does this change?

When a field's initial value is an empty string "", react-aria's useRadio treated it as a controlled selection ("" != null), found no matching radio, and left every radio with tabIndex=-1, making the group unreachable by keyboard. Passing undefined instead of "" lets react-aria fall into its uncontrolled path and correctly assign tabIndex=0 to the first radio.

<table>
<tr>
<th> Before
<th> After
<tr>
<td>

https://github.com/user-attachments/assets/ca204130-c84a-40eb-a6c6-05c2beedc7e5

<td>

https://github.com/user-attachments/assets/9197da5f-c839-4553-95fe-e104ecf9ce01

</table>

Fixes: https://github.com/guardian/stand/issues/127

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215513748232166