### PR TITLE
chore(eslint/vscode): fix linting not showing up in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,10 @@
 	"deno.enable": false,
 	"deno.unstable": false,
 	"deno.enablePaths": ["./tools/scripts/deno"],
+	// We currently use ESLint v8 with .eslintrc.json,
+	// so we need to disable the new flat config support
+	// to allow the ide to find the config file and work properly
+	"eslint.useFlatConfig": false,
 	"editor.codeActionsOnSave": {
 		"source.fixAll.eslint": "explicit"
 	},


### PR DESCRIPTION
## What does this change?

The vscode ide wouldn't alert me to errors on a given file with eslint.

This is because the esling plugin for vscode was expecting a flat config file, since eslint v9, but this project is still using eslint v8 and .eslintrc.json file.

So we need to tell the plugin to allow using the old format by disabling the `eslint.useFlatConfig` flag

<table>
<tr>
<th> Before
<th> After
<tr>
<td>
<img width="546" height="203" alt="Screenshot 2026-06-09 at 11 30 17" src="https://github.com/user-attachments/assets/435a3c20-fc36-4a2f-9dee-d01d313aa1f9" />

<td>
<img width="699" height="138" alt="Screenshot 2026-06-09 at 11 29 50" src="https://github.com/user-attachments/assets/b4e778ab-32fc-4871-babf-aed4a07e7ed7" />

</table>

The longer term solution would be to update this project to ESLint v9+