### PR TITLE
react-router vulnerability fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
 				"react-aria-components": "1.17.0",
 				"react-dom": "18.3.1",
 				"react-markdown": "^10.1.0",
-				"react-router-dom": "^7.14.0",
+				"react-router-dom": "^7.17.0",
 				"react-table": "^7.8.0",
 				"remark-directive": "^4.0.0",
 				"tslib": "^2.8.1",
@@ -20674,9 +20674,9 @@
 			}
 		},
 		"node_modules/react-router": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.0.tgz",
-			"integrity": "sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==",
+			"version": "7.17.0",
+			"resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+			"integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
 			"license": "MIT",
 			"dependencies": {
 				"cookie": "^1.0.1",
@@ -20696,12 +20696,12 @@
 			}
 		},
 		"node_modules/react-router-dom": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.0.tgz",
-			"integrity": "sha512-2G3ajSVSZMEtmTjIklRWlNvo8wICEpLihfD/0YMDxbWK2UyP5EGfnoIn9AIQGnF3G/FX0MRbHXdFcD+rL1ZreQ==",
+			"version": "7.17.0",
+			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
+			"integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
 			"license": "MIT",
 			"dependencies": {
-				"react-router": "7.14.0"
+				"react-router": "7.17.0"
 			},
 			"engines": {
 				"node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"react-aria-components": "1.17.0",
 		"react-dom": "18.3.1",
 		"react-markdown": "^10.1.0",
-		"react-router-dom": "^7.14.0",
+		"react-router-dom": "^7.17.0",
 		"react-table": "^7.8.0",
 		"remark-directive": "^4.0.0",
 		"tslib": "^2.8.1",


### PR DESCRIPTION
## What does this change?
Bumps core `react-router-dom` dependency from version ^7.14.0 to ^7..15.0  in order to fix the following vulnerabilities with react-router, reported by dependabot: 

- https://github.com/guardian/newsletters-nx/security/dependabot/251
- https://github.com/guardian/newsletters-nx/security/dependabot/253