### PR TITLE
[StandRedesign] Use `@guardian/stand` `Modal` for `SkipConfirmationDialog`

### DIFF
--- a/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
@@ -23,11 +23,11 @@ import type {
 } from '@newsletters-nx/state-machine';
 import { makeWizardStepRequest } from '../api-requests/make-wizard-step-request';
 import type { StringInputSettings } from './SchemaForm';
-import { SkipConfirmationDialog } from './SkipConfirmationDialog';
 import { StandRedesignMarkdownView } from './StandRedesignMarkdownView';
 import { StandRedesignStateEditForm } from './StandRedesignStateEditForm';
 import { StandRedesignStepNav } from './StandRedesignStepNav';
 import { StandRedesignWizardActionButton } from './StandRedesignWizardActionButton';
+import { SkipConfirmationDialog } from './StandSkipConfirmationDialog';
 import { ZodIssuesReport } from './ZodIssuesReport';
 
 export const StandRedesignWizardContainer: React.FC<WizardProps> = ({
@@ -285,7 +285,7 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 						<StandRedesignMarkdownView
 							markdown={serverData.markdownToDisplay ?? ''}
 							bottomSpacing={'stackXl'}
-							componentTypographyOverrides={{H2: 'bodyMd'}}
+							componentTypographyOverrides={{ H2: 'bodyMd' }}
 						/>
 
 						{formSchema && formData && (
@@ -362,42 +362,15 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 							)}
 						</div>
 					</Item>
-					<Item
-						size={{ lg: 7 }}
-						cssOverrides={css`
-							margin-bottom: ${semanticGrid.margin.bottomSmPx};
-
-							${from.md} {
-								margin-bottom: ${semanticGrid.margin.bottomMdPx};
-							}
-
-							${from.lg} {
-								margin-bottom: ${semanticGrid.margin.bottomLgPx};
-							}
-						`}
-					>
-						<SkipConfirmationDialog
-							currentStepId={serverData.currentStepId}
-							targetStepId={showSkipModalFor}
-							handleCancelSkip={handleCancelSkip}
-							handleConfirmSkip={handleConfirmSkip}
-							stepperConfig={stepperConfig}
-						/>
-					</Item>
-					<Item
-						size={{ lg: 1 }}
-						cssOverrides={css`
-							display: none;
-							${from.lg} {
-								/* use negative margin to align with the top of the previous item i.e overriding the gap */
-								margin-top: -${baseSpacing['16Rem']};
-								border-right: 1px solid ${semanticColors.border.weak};
-								display: block;
-							}
-						`}
-					></Item>
 				</Grid>
 			</Layout.Main>
+			<SkipConfirmationDialog
+				currentStepId={serverData.currentStepId}
+				targetStepId={showSkipModalFor}
+				handleCancelSkip={handleCancelSkip}
+				handleConfirmSkip={handleConfirmSkip}
+				stepperConfig={stepperConfig}
+			/>
 		</>
 	);
 };

--- a/apps/newsletters-ui/src/app/components/StandSkipConfirmationDialog.tsx
+++ b/apps/newsletters-ui/src/app/components/StandSkipConfirmationDialog.tsx
@@ -1,0 +1,49 @@
+import { Button } from '@guardian/stand/Button';
+import { Dialog, Modal } from '@guardian/stand/Modal';
+import type { StepperConfig } from '@newsletters-nx/state-machine';
+
+interface Props {
+	currentStepId: string;
+	targetStepId?: string;
+	handleCancelSkip: () => void;
+	handleConfirmSkip: () => void;
+	stepperConfig: StepperConfig;
+}
+export const SkipConfirmationDialog = ({
+	currentStepId,
+	targetStepId,
+	handleCancelSkip,
+	handleConfirmSkip,
+	stepperConfig,
+}: Props) => {
+	const currentStepListing = stepperConfig.steps.find(
+		(step) => step.id === currentStepId,
+	);
+	const currentStepLabel = currentStepListing?.label ?? currentStepId;
+	const targetStepListing = stepperConfig.steps.find(
+		(step) => step.id === targetStepId,
+	);
+	const targetStepLabel = targetStepListing?.label ?? targetStepId;
+
+	return (
+		<Modal isOpen={!!targetStepId}>
+			<Dialog>
+				<Dialog.Dismiss
+					ariaLabel="Close and stay on this step"
+					onPress={handleCancelSkip}
+				/>
+				<Dialog.Header>Discard changes to {currentStepLabel}?</Dialog.Header>
+				<Dialog.Content>
+					Skipping to "{targetStepLabel}" will discard the changes made on "
+					{currentStepLabel}".
+				</Dialog.Content>
+				<Dialog.Buttons>
+					<Button variant="tertiary" slot="close" onPress={handleCancelSkip}>
+						Stay on this step
+					</Button>
+					<Button onPress={handleConfirmSkip}>Discard changes and skip</Button>
+				</Dialog.Buttons>
+			</Dialog>
+		</Modal>
+	);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"@emotion/styled": "^11.14.1",
 				"@guardian/image": "^1.1.0",
 				"@guardian/source": "^12.2.1",
-				"@guardian/stand": "0.0.48",
+				"@guardian/stand": "0.0.52",
 				"@internationalized/date": "^3.12.2",
 				"@mui/icons-material": "^9.0.0",
 				"@mui/material": "^9.0.0",
@@ -3913,9 +3913,9 @@
 			}
 		},
 		"node_modules/@guardian/stand": {
-			"version": "0.0.48",
-			"resolved": "https://registry.npmjs.org/@guardian/stand/-/stand-0.0.48.tgz",
-			"integrity": "sha512-RmwDiBUdc5knTnHCbMblgyQJ0tco4t/NzRsXQWbzAAiK4/zHp58yRPdiJty1SYXaHDS95oRoIoKmoaartIqPRw==",
+			"version": "0.0.52",
+			"resolved": "https://registry.npmjs.org/@guardian/stand/-/stand-0.0.52.tgz",
+			"integrity": "sha512-SnG1zhRWvy0eRosKg5sJEhZeQOurXi5WlmqEmiYXzUnjt8TjHxlCnMBcENxOEIOYOUANLxG3F/XEJJJYmBmEPQ==",
 			"peerDependencies": {
 				"@emotion/react": ">=11.11.4 <=11.14.0",
 				"@guardian/prosemirror-invisibles": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"@emotion/styled": "^11.14.1",
 		"@guardian/image": "^1.1.0",
 		"@guardian/source": "^12.2.1",
-		"@guardian/stand": "0.0.48",
+		"@guardian/stand": "0.0.52",
 		"@internationalized/date": "^3.12.2",
 		"@mui/icons-material": "^9.0.0",
 		"@mui/material": "^9.0.0",


### PR DESCRIPTION
## What does this change?

- Use the `@guardian/stand` [`Modal`](https://github.com/guardian/stand/pull/139) component for the `SkipConfirmationDialog`
  - Create a new file `StandSkipConfirmationDialog.tsx` to allow us to use the new component without affecting the existing flows

<img width="3490" height="2092" alt="Screenshot 2026-06-17 at 17-10-30 Newsletters tool" src="https://github.com/user-attachments/assets/09d5a4a3-2adf-4aae-883c-00910204c8f2" />

---

**TODO:**

- [x] Update the stand version when https://github.com/guardian/stand/pull/139 is merged in

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215511817965608