### PR TITLE
add simple API endpoint logging to newsletters-api

### DIFF
--- a/apps/newsletters-api/src/app/request-logging.ts
+++ b/apps/newsletters-api/src/app/request-logging.ts
@@ -1,0 +1,26 @@
+import type { RequestHandler } from 'express';
+
+export const requestLoggingMiddleware: RequestHandler = (req, res, next) => {
+	if (!req.path.startsWith('/api/')) {
+		next();
+		return;
+	}
+
+	const startedAt = Date.now();
+
+	res.on('finish', () => {
+		console.log(
+			JSON.stringify({
+				event: 'newsletters_api_request',
+				method: req.method,
+				path: req.path,
+				status: res.statusCode,
+				durationMs: Date.now() - startedAt,
+				referer: req.headers.referer,
+				userAgent: req.headers['user-agent'],
+			}),
+		);
+	});
+
+	next();
+};

--- a/apps/newsletters-api/src/main.ts
+++ b/apps/newsletters-api/src/main.ts
@@ -5,6 +5,7 @@ import {
 	isServingUI,
 } from './apiDeploymentSettings';
 import { setCacheControlHeaderMiddleware } from './app/headers';
+import { requestLoggingMiddleware } from './app/request-logging';
 import { registerCurrentStepRoute } from './app/routes/currentStep';
 import { registerDraftsRoutes } from './app/routes/drafts';
 import { registerHealthRoute } from './app/routes/health';
@@ -24,6 +25,7 @@ import { registerUIServer } from './register-ui-server';
 const app = ExpressApp();
 app.use(setCacheControlHeaderMiddleware);
 app.use(json());
+app.use(requestLoggingMiddleware);
 
 registerHealthRoute(app);
 


### PR DESCRIPTION
## What does this change?

Adds a small middleware helper to the newsletters-api express server. For any endpoint that starts with `/api` a simple console log is fired that contains basic information about the request like the path, referer, request method, response status, request duration and the user agent.

This should hopefully make it easier for us to track the API endpoint usage in the future.