### PR TITLE
Improve form UX

### DIFF
--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/DateInput.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/DateInput.tsx
@@ -47,7 +47,6 @@ export const StandDateInput: FunctionComponent<
 			}}
 			error={props.error}
 			isInvalid={!!props.error}
-			validationBehavior='aria'
 		/>
 	);
 };

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/DateInput.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/DateInput.tsx
@@ -45,6 +45,9 @@ export const StandDateInput: FunctionComponent<
 					props.inputHandler(inputDateToDate(date));
 				}
 			}}
+			error={props.error}
+			isInvalid={!!props.error}
+			validationBehavior='aria'
 		/>
 	);
 };

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/RadioSelectInput.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/RadioSelectInput.tsx
@@ -79,6 +79,8 @@ export const StandRadioSelectInput: FunctionComponent<
 				}
 				description={description ?? ''}
 				renderLabel={props.isNoted ? NotedLabel : undefined}
+				error={props.error}
+				isInvalid={!!props.error}
 			>
 				{/* Haven't seen this used but have preserved this way of doing it */}
 				{optional && <Radio value={EMPTY_STRING}>[none]</Radio>}

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/RecordInput.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/RecordInput.tsx
@@ -9,6 +9,7 @@ interface Props {
 	recordSchema: ZodObject<ZodRawShape>;
 	editRecord: { (record: PrimitiveRecord): void };
 	maxOptionsForRadioButtons?: number;
+	changed: boolean;
 }
 
 export const RecordInput = ({
@@ -16,6 +17,7 @@ export const RecordInput = ({
 	recordSchema,
 	editRecord,
 	maxOptionsForRadioButtons,
+	changed,
 }: Props) => {
 	const warnings = getValidationWarnings(record, recordSchema);
 	return (
@@ -35,6 +37,7 @@ export const RecordInput = ({
 				}
 				return editRecord({ ...record, ...mod });
 			}}
+			changed={changed}
 			maxOptionsForRadioButtons={maxOptionsForRadioButtons}
 		/>
 	);

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/RecordInput.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/RecordInput.tsx
@@ -9,7 +9,7 @@ interface Props {
 	recordSchema: ZodObject<ZodRawShape>;
 	editRecord: { (record: PrimitiveRecord): void };
 	maxOptionsForRadioButtons?: number;
-	changed: boolean;
+	showErrors: boolean;
 }
 
 export const RecordInput = ({
@@ -17,7 +17,7 @@ export const RecordInput = ({
 	recordSchema,
 	editRecord,
 	maxOptionsForRadioButtons,
-	changed,
+	showErrors,
 }: Props) => {
 	const warnings = getValidationWarnings(record, recordSchema);
 	return (
@@ -37,7 +37,7 @@ export const RecordInput = ({
 				}
 				return editRecord({ ...record, ...mod });
 			}}
-			changed={changed}
+			showErrors={showErrors}
 			maxOptionsForRadioButtons={maxOptionsForRadioButtons}
 		/>
 	);

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaField.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaField.tsx
@@ -141,6 +141,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 				{...standardProps}
 				value={parsed.value}
 				type={stringInputSettings.inputType}
+				error={validationWarning}
 			/>
 		);
 	}

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaField.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaField.tsx
@@ -57,7 +57,7 @@ interface SchemaFieldProps<T extends z.ZodRawShape> {
 	numberInputSettings?: NumberInputSettings;
 	stringInputSettings?: StringInputSettings;
 	validationWarning?: string;
-	changed: boolean;
+	showErrors: boolean;
 	maxOptionsForRadioButtons: number;
 	explanation?: string;
 	isNoted?: boolean;
@@ -103,7 +103,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 	numberInputSettings = {},
 	stringInputSettings = {},
 	validationWarning,
-	changed,
+	showErrors,
 	maxOptionsForRadioButtons,
 	explanation,
 	placeholder,
@@ -124,7 +124,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 		inputHandler,
 		readOnly,
 		optional: zod.isOptional(),
-		error: changed ? validationWarning : undefined,
+		error: showErrors ? validationWarning : undefined,
 		description: explanation,
 		isNoted,
 	};
@@ -272,7 +272,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 					{...standardProps}
 					recordSchema={innerZod}
 					value={value}
-					changed={changed}
+					showErrors={showErrors}
 				/>
 			</FieldWrapper>
 		);
@@ -301,7 +301,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 						value={value ?? []}
 						recordSchema={innerZod.element}
 						maxOptionsForRadioButtons={maxOptionsForRadioButtons}
-						changed={changed}
+						showErrors={showErrors}
 					/>
 				</FieldWrapper>
 			);

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaField.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaField.tsx
@@ -57,6 +57,7 @@ interface SchemaFieldProps<T extends z.ZodRawShape> {
 	numberInputSettings?: NumberInputSettings;
 	stringInputSettings?: StringInputSettings;
 	validationWarning?: string;
+	changed: boolean;
 	maxOptionsForRadioButtons: number;
 	explanation?: string;
 	isNoted?: boolean;
@@ -102,6 +103,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 	numberInputSettings = {},
 	stringInputSettings = {},
 	validationWarning,
+	changed,
 	maxOptionsForRadioButtons,
 	explanation,
 	placeholder,
@@ -122,7 +124,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 		inputHandler,
 		readOnly,
 		optional: zod.isOptional(),
-		error: validationWarning,
+		error: changed ? validationWarning : undefined,
 		description: explanation,
 		isNoted,
 	};
@@ -141,7 +143,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 				{...standardProps}
 				value={parsed.value}
 				type={stringInputSettings.inputType}
-				error={validationWarning}
+				error={changed ? validationWarning : undefined}
 			/>
 		);
 	}

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaField.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaField.tsx
@@ -273,6 +273,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 					{...standardProps}
 					recordSchema={innerZod}
 					value={value}
+					changed={changed}
 				/>
 			</FieldWrapper>
 		);
@@ -301,6 +302,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 						value={value ?? []}
 						recordSchema={innerZod.element}
 						maxOptionsForRadioButtons={maxOptionsForRadioButtons}
+						changed={changed}
 					/>
 				</FieldWrapper>
 			);

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaField.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaField.tsx
@@ -143,7 +143,6 @@ export function SchemaField<T extends z.ZodRawShape>({
 				{...standardProps}
 				value={parsed.value}
 				type={stringInputSettings.inputType}
-				error={changed ? validationWarning : undefined}
 			/>
 		);
 	}

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaRecordArrayInput.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaRecordArrayInput.tsx
@@ -24,7 +24,7 @@ export const SchemaRecordArrayInput: FunctionComponent<
 		inputHandler: { (newValue: FieldValue): void };
 		recordSchema: ZodObject<ZodRawShape>;
 		maxOptionsForRadioButtons?: number;
-		changed: boolean;
+		showErrors: boolean;
 	}
 > = (props) => {
 	const {
@@ -33,7 +33,7 @@ export const SchemaRecordArrayInput: FunctionComponent<
 		inputHandler,
 		recordSchema,
 		maxOptionsForRadioButtons,
-		changed,
+		showErrors,
 	} = props;
 
 	const addNew = () => {
@@ -94,7 +94,7 @@ export const SchemaRecordArrayInput: FunctionComponent<
 										editRecordIndex(index, record);
 									}}
 									maxOptionsForRadioButtons={maxOptionsForRadioButtons}
-									changed={changed}
+									showErrors={showErrors}
 								/>
 							</Grid>
 							<Grid

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaRecordArrayInput.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaRecordArrayInput.tsx
@@ -24,6 +24,7 @@ export const SchemaRecordArrayInput: FunctionComponent<
 		inputHandler: { (newValue: FieldValue): void };
 		recordSchema: ZodObject<ZodRawShape>;
 		maxOptionsForRadioButtons?: number;
+		changed: boolean;
 	}
 > = (props) => {
 	const {
@@ -32,6 +33,7 @@ export const SchemaRecordArrayInput: FunctionComponent<
 		inputHandler,
 		recordSchema,
 		maxOptionsForRadioButtons,
+		changed,
 	} = props;
 
 	const addNew = () => {
@@ -92,6 +94,7 @@ export const SchemaRecordArrayInput: FunctionComponent<
 										editRecordIndex(index, record);
 									}}
 									maxOptionsForRadioButtons={maxOptionsForRadioButtons}
+									changed={changed}
 								/>
 							</Grid>
 							<Grid

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaRecordInput.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaRecordInput.tsx
@@ -15,9 +15,10 @@ export const SchemaRecordInput: FunctionComponent<
 		value: PrimitiveRecord | undefined;
 		inputHandler: { (newValue: FieldValue): void };
 		recordSchema: ZodObject<ZodRawShape>;
+		changed: boolean;
 	}
 > = (props) => {
-	const { value, label, inputHandler, recordSchema, readOnly, optional } =
+	const { changed, value, label, inputHandler, recordSchema, readOnly, optional } =
 		props;
 
 	const sendValue = (data: PrimitiveRecord) => {
@@ -65,6 +66,7 @@ export const SchemaRecordInput: FunctionComponent<
 							recordSchema={recordSchema}
 							record={value}
 							editRecord={sendValue}
+							changed={changed}
 						/>
 						{optional && (
 							<Button

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaRecordInput.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaRecordInput.tsx
@@ -15,10 +15,10 @@ export const SchemaRecordInput: FunctionComponent<
 		value: PrimitiveRecord | undefined;
 		inputHandler: { (newValue: FieldValue): void };
 		recordSchema: ZodObject<ZodRawShape>;
-		changed: boolean;
+		showErrors: boolean;
 	}
 > = (props) => {
-	const { changed, value, label, inputHandler, recordSchema, readOnly, optional } =
+	const { showErrors, value, label, inputHandler, recordSchema, readOnly, optional } =
 		props;
 
 	const sendValue = (data: PrimitiveRecord) => {
@@ -66,7 +66,7 @@ export const SchemaRecordInput: FunctionComponent<
 							recordSchema={recordSchema}
 							record={value}
 							editRecord={sendValue}
-							changed={changed}
+							showErrors={showErrors}
 						/>
 						{optional && (
 							<Button

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SelectInput.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SelectInput.tsx
@@ -39,6 +39,8 @@ export const StandSelectInput: FunctionComponent<
 			onChange={handleChange}
 			renderLabel={props.isNoted ? NotedLabel : undefined}
 			placeholder={props.placeholder}
+			error={props.error}
+			isInvalid={!!props.error}
 		>
 			{optional && <Option value={{ EMPTY_STRING }}>[none]</Option>}
 			{options.map((option) => (

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/StringInput.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/StringInput.tsx
@@ -46,7 +46,6 @@ export const StandStringInput = (props: Props) => {
 				isDisabled={props.readOnly}
 				isRequired={!props.optional}
 				renderLabel={props.isNoted ? NotedLabel : undefined }
-				validationBehavior='aria'
 			/>
 		);
 	}
@@ -59,7 +58,6 @@ export const StandStringInput = (props: Props) => {
 			onInput={sendValue}
 			value={props.value}
 			placeholder={props.placeholder}
-			validationBehavior={'aria'}
 			error={props.error}
 			isInvalid={!!props.error}
 			isDisabled={props.readOnly}

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/StringInput.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/StringInput.tsx
@@ -46,6 +46,7 @@ export const StandStringInput = (props: Props) => {
 				isDisabled={props.readOnly}
 				isRequired={!props.optional}
 				renderLabel={props.isNoted ? NotedLabel : undefined }
+				validationBehavior='aria'
 			/>
 		);
 	}
@@ -57,9 +58,10 @@ export const StandStringInput = (props: Props) => {
 			label={props.label}
 			onInput={sendValue}
 			value={props.value}
-			isInvalid={!!props.error}
 			placeholder={props.placeholder}
+			validationBehavior={'aria'}
 			error={props.error}
+			isInvalid={!!props.error}
 			isDisabled={props.readOnly}
 			isRequired={!props.optional}
 			renderLabel={props.isNoted ? NotedLabel : undefined }

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/index.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/index.tsx
@@ -11,6 +11,7 @@ import type {
 	StringInputSettings,
 } from './util';
 
+
 export * from './util';
 
 interface Props<T extends z.ZodRawShape> {
@@ -23,7 +24,7 @@ interface Props<T extends z.ZodRawShape> {
 	showUnsupported?: boolean;
 	excludedKeys?: string[];
 	readOnlyKeys?: string[];
-	validationWarnings: Partial<Record<keyof T, string>>;
+	validationWarnings: Record<string, string>;
 	maxOptionsForRadioButtons?: number;
 	explanations?: Partial<Record<keyof T, string>>;
 	placeholders?: Partial<Record<keyof T, string>>;

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/index.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/index.tsx
@@ -25,7 +25,7 @@ interface Props<T extends z.ZodRawShape> {
 	excludedKeys?: string[];
 	readOnlyKeys?: string[];
 	validationWarnings: Record<string, string>;
-	changed: boolean;
+	showErrors: boolean;
 	maxOptionsForRadioButtons?: number;
 	explanations?: Partial<Record<keyof T, string>>;
 	placeholders?: Partial<Record<keyof T, string>>;
@@ -48,7 +48,7 @@ export function StandRedesignSchemaForm<T extends z.ZodRawShape>({
 	readOnlyKeys = [],
 	notedFields = [],
 	validationWarnings,
-	changed,
+	showErrors,
 	maxOptionsForRadioButtons = 0,
 	explanations = {},
 	placeholders = {},
@@ -92,7 +92,7 @@ export function StandRedesignSchemaForm<T extends z.ZodRawShape>({
 					field={field}
 					showUnsupported={showUnsupported}
 					validationWarning={validationWarnings[field.key]}
-					changed={changed}
+					showErrors={showErrors}
 					maxOptionsForRadioButtons={maxOptionsForRadioButtons}
 					explanation={explanations[field.key]}
 					placeholder={placeholders[field.key]}

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/index.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/index.tsx
@@ -25,6 +25,7 @@ interface Props<T extends z.ZodRawShape> {
 	excludedKeys?: string[];
 	readOnlyKeys?: string[];
 	validationWarnings: Record<string, string>;
+	changed: boolean;
 	maxOptionsForRadioButtons?: number;
 	explanations?: Partial<Record<keyof T, string>>;
 	placeholders?: Partial<Record<keyof T, string>>;
@@ -47,6 +48,7 @@ export function StandRedesignSchemaForm<T extends z.ZodRawShape>({
 	readOnlyKeys = [],
 	notedFields = [],
 	validationWarnings,
+	changed,
 	maxOptionsForRadioButtons = 0,
 	explanations = {},
 	placeholders = {},
@@ -90,6 +92,7 @@ export function StandRedesignSchemaForm<T extends z.ZodRawShape>({
 					field={field}
 					showUnsupported={showUnsupported}
 					validationWarning={validationWarnings[field.key]}
+					changed={changed}
 					maxOptionsForRadioButtons={maxOptionsForRadioButtons}
 					explanation={explanations[field.key]}
 					placeholder={placeholders[field.key]}

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/util.ts
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/util.ts
@@ -1,5 +1,5 @@
 import type { FormEvent } from 'react';
-import type { ZodRawShape, ZodTypeAny } from 'zod';
+import type { ZodTypeAny } from 'zod';
 import {
 	ZodArray,
 	ZodBoolean,
@@ -18,9 +18,9 @@ import {
 	isStringArray,
 } from '../../util';
 
-export interface FieldDef<T extends ZodRawShape = ZodRawShape> {
+export interface FieldDef {
 	zod: ZodTypeAny;
-	key: keyof T & string;
+	key: string;
 	value: unknown;
 	readOnly?: boolean;
 }
@@ -57,7 +57,7 @@ export function eventToString(event: FormEvent): string {
 	return (event.target as HTMLInputElement).value;
 }
 
-function fieldValueIsRightType<T extends ZodRawShape>(value: FieldValue, field: FieldDef<T>): boolean {
+function fieldValueIsRightType(value: FieldValue, field: FieldDef): boolean {
 	const innerZod = recursiveUnwrap(field.zod);
 
 	if (innerZod instanceof ZodEnum) {
@@ -111,9 +111,9 @@ function fieldValueIsRightType<T extends ZodRawShape>(value: FieldValue, field: 
 	}
 }
 
-export function getModification<T extends ZodRawShape> (
+export function getModification (
 	value: FieldValue,
-	field: FieldDef<T>,
+	field: FieldDef,
 ): Record<string, FieldValue> {
 	if (fieldValueIsRightType(value, field)) {
 		const mod: Record<string, FieldValue> = {};

--- a/apps/newsletters-ui/src/app/components/StandRedesignStateEditForm.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignStateEditForm.tsx
@@ -17,6 +17,7 @@ interface Props {
 	formSchema: z.ZodObject<z.ZodRawShape>;
 	formData: WizardFormData;
 	setFormData: { (newData: WizardFormData): void };
+	changed: boolean;
 	maxOptionsForRadioButtons?: number;
 	stringConfig?: Partial<Record<string, StringInputSettings>>;
 	notedFields?: NotedFields;
@@ -26,6 +27,7 @@ export const StandRedesignStateEditForm = ({
 	formSchema,
 	formData,
 	setFormData,
+	changed,
 	notedFields,
 	maxOptionsForRadioButtons,
 	stringConfig = {},
@@ -76,6 +78,7 @@ export const StandRedesignStateEditForm = ({
 			schema={formSchema}
 			data={formData}
 			validationWarnings={getValidationWarnings(formData, formSchema)}
+			changed={changed}
 			changeValue={changeFormData}
 			maxOptionsForRadioButtons={maxOptionsForRadioButtons}
 			stringConfig={stringConfig}

--- a/apps/newsletters-ui/src/app/components/StandRedesignStateEditForm.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignStateEditForm.tsx
@@ -17,7 +17,7 @@ interface Props {
 	formSchema: z.ZodObject<z.ZodRawShape>;
 	formData: WizardFormData;
 	setFormData: { (newData: WizardFormData): void };
-	changed: boolean;
+	showErrors: boolean;
 	maxOptionsForRadioButtons?: number;
 	stringConfig?: Partial<Record<string, StringInputSettings>>;
 	notedFields?: NotedFields;
@@ -27,7 +27,7 @@ export const StandRedesignStateEditForm = ({
 	formSchema,
 	formData,
 	setFormData,
-	changed,
+	showErrors,
 	notedFields,
 	maxOptionsForRadioButtons,
 	stringConfig = {},
@@ -78,7 +78,7 @@ export const StandRedesignStateEditForm = ({
 			schema={formSchema}
 			data={formData}
 			validationWarnings={getValidationWarnings(formData, formSchema)}
-			changed={changed}
+			showErrors={showErrors}
 			changeValue={changeFormData}
 			maxOptionsForRadioButtons={maxOptionsForRadioButtons}
 			stringConfig={stringConfig}

--- a/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignStepNav.tsx
@@ -282,7 +282,7 @@ export const StandRedesignStepNav = ({
 				`}
 			>
 				{filteredStepList.map((step, index) => {
-					const stepStatus = completionRecord[step.id];
+					const stepStatus = !step.isIntro ? completionRecord[step.id]: undefined;
 					const description = step.label ?? step.id;
 					const isDisabled = !shouldRenderAsButton(step);
 					return (

--- a/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
@@ -96,7 +96,7 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 	const [notedFields, setNotedFields] = useState<string[]>([]);
 	const [currentStepHasBeenChanged, setCurrentStepHasBeenChanged] =
 		useState(false);
-	const [showValidationWarningsFromSubmitError, setShowValidationWarningsFromSubmitError] =
+	const [hasServerErrorMessages, setHasServerErrorMessages] =
 		useState(false);
 	const [showSkipModalFor, setShowSkipModalFor] = useState<string | undefined>(
 		undefined,
@@ -124,7 +124,7 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 					...blank,
 					...data.formData,
 				});
-				setShowValidationWarningsFromSubmitError(!!data.errorMessage);
+				setHasServerErrorMessages(!!data.errorMessage);
 				setCurrentStepHasBeenChanged(false);
 				setShowSkipModalFor(undefined);
 				setNotedFields(noted ?? []);
@@ -296,7 +296,7 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 								setFormData={handleFormChange}
 								changed={
 									currentStepHasBeenChanged ||
-									showValidationWarningsFromSubmitError
+									hasServerErrorMessages
 								}
 								maxOptionsForRadioButtons={5}
 								stringConfig={stringConfig}

--- a/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
@@ -341,13 +341,13 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 							`}
 						>
 							{serverData.markdownToDisplayInSidebar?.map(
-								({ field, markdown }) => (
+								({ field, markdown }, index) => (
 									<div
 										css={css`
 											background: ${semanticColors.bg.raisedLevel1};
 											padding: ${baseSpacing['16Px']};
 										`}
-										key={field}
+										key={field ?? `markdown-${index}`}
 									>
 										<StandRedesignMarkdownView markdown={markdown} />
 									</div>

--- a/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
@@ -294,7 +294,7 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 								notedFields={notedFields}
 								formData={formData}
 								setFormData={handleFormChange}
-								changed={
+								showErrors={
 									currentStepHasBeenChanged ||
 									hasServerErrorMessages
 								}

--- a/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
@@ -96,6 +96,8 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 	const [notedFields, setNotedFields] = useState<string[]>([]);
 	const [currentStepHasBeenChanged, setCurrentStepHasBeenChanged] =
 		useState(false);
+	const [showValidationWarningsFromSubmitError, setShowValidationWarningsFromSubmitError] =
+		useState(false);
 	const [showSkipModalFor, setShowSkipModalFor] = useState<string | undefined>(
 		undefined,
 	);
@@ -122,6 +124,7 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 					...blank,
 					...data.formData,
 				});
+				setShowValidationWarningsFromSubmitError(!!data.errorMessage);
 				setCurrentStepHasBeenChanged(false);
 				setShowSkipModalFor(undefined);
 				setNotedFields(noted ?? []);
@@ -291,6 +294,10 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 								notedFields={notedFields}
 								formData={formData}
 								setFormData={handleFormChange}
+								changed={
+									currentStepHasBeenChanged ||
+									showValidationWarningsFromSubmitError
+								}
 								maxOptionsForRadioButtons={5}
 								stringConfig={stringConfig}
 							/>

--- a/apps/newsletters-ui/src/app/components/StepNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StepNav.tsx
@@ -159,7 +159,7 @@ export const StepNav = ({
 			component={'nav'}
 		>
 			{filteredStepList.map((step) => {
-				const stepStatus = completionRecord[step.id];
+				const stepStatus = !step.isIntro ? completionRecord[step.id] : undefined;
 				const description = step.label ?? step.id;
 				const isButton = shouldRenderAsButton(step);
 

--- a/libs/newsletter-workflow/src/lib/newsletter-workflow.ts
+++ b/libs/newsletter-workflow/src/lib/newsletter-workflow.ts
@@ -79,5 +79,5 @@ export const getNotedFields = (
 	if (!step?.staticSideMarkdown) {
 		return undefined;
 	}
-	return step.staticSideMarkdown.map(({field}) => field.toString());
+	return step.staticSideMarkdown.map(({field}) => field).filter((field) => field !== undefined);
 }

--- a/libs/newsletter-workflow/src/lib/newsletter-workflow.ts
+++ b/libs/newsletter-workflow/src/lib/newsletter-workflow.ts
@@ -79,5 +79,7 @@ export const getNotedFields = (
 	if (!step?.staticSideMarkdown) {
 		return undefined;
 	}
-	return step.staticSideMarkdown.map(({field}) => field).filter((field) => field !== undefined);
+	return step.staticSideMarkdown
+		.map(({ field }) => field)
+		.filter((field): field is string => field !== undefined);
 }

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/formSchemas.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/formSchemas.ts
@@ -34,6 +34,7 @@ const pickAndPrefixThrasherOption = (
 };
 
 export const formSchemas = {
+	intro: dataCollectionSchema.pick({}).describe('Intro step'),
 	nameAndFrequency: dataCollectionSchema
 		.pick({
 			name: true,

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/introLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/introLayout.ts
@@ -1,6 +1,7 @@
 import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import { getNextStepId } from '@newsletters-nx/state-machine';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
+import { formSchemas } from './formSchemas';
 
 export const createDraftIntro: WizardStepLayout<DraftService> = {
 	staticMarkdown: `# Introduction
@@ -31,4 +32,7 @@ The below will guide you through in the first stage of creating a newsletter.
 		},
 	},
 	role: 'CREATE_START',
+	canSkip: true,
+	isIntro: true,
+	schema: formSchemas.intro
 };

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/nameAndFrequencyLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/nameAndFrequencyLayout.ts
@@ -28,5 +28,4 @@ The frequency you specify will be shown on the sign up page, and on the all news
 	},
 	schema: formSchemas.nameAndFrequency,
 	canSkip: true,
-	skippingWillPersistLocalChanges: true,
 };

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/server.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/server.ts
@@ -1,5 +1,5 @@
 import type { DraftService } from '@newsletters-nx/newsletters-data-client';
-import type { WizardLayout } from '@newsletters-nx/state-machine';
+import type { AsyncExecution, WizardLayout } from '@newsletters-nx/state-machine';
 import { executeCreate } from '../../executeCreate';
 import { executeModify } from '../../executeModify';
 import { executeSkip } from '../../executeSkip';
@@ -14,17 +14,41 @@ import { promotionContentLayout } from './promotionContentLayout';
 import { tagsLayout } from './tagsLayout';
 import { targetingLayout } from './targetingLayout';
 
+const executeCreateOrModify: AsyncExecution<DraftService> = async (
+	stepData,
+	stepLayout,
+	service,
+) => {
+	const listId = stepData.formData?.listId;
+
+	if (typeof listId === 'number') {
+		return executeModify(stepData, stepLayout, service);
+	}
+
+	return executeCreate(stepData, stepLayout, service);
+};
+
 export const standRedesignLayout: WizardLayout<DraftService> = {
 	cancel: cancelLayout,
-	intro: createDraftIntro,
+	intro: {
+		executeSkip: executeCreateOrModify,
+		...createDraftIntro,
+		buttons: {
+			...createDraftIntro.buttons,
+			next: {
+				...createDraftIntro.buttons['next']!,
+				executeStep: executeCreateOrModify,
+			},
+		},
+	},
 	nameAndFrequencyLayout: {
 		...nameAndFrequencyLayout,
-		executeSkip: executeCreate,
+		executeSkip: executeSkip,
 		buttons: {
 			...nameAndFrequencyLayout.buttons,
 			next: {
 				...nameAndFrequencyLayout.buttons['next']!,
-				executeStep: executeCreate,
+				executeStep: executeModify,
 			},
 		},
 	},

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/tagsLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/tagsLayout.ts
@@ -23,7 +23,7 @@ This section allows you to suggest the tags you think will work best to promote 
 Central Production will review the tags and confirm the final recommendation. They will set up any new tags in tag manager.
 
 The request to set up these tags will not sent till you select “finish”.
-`}, {field: 'seriesTag', markdown: `
+`}, {markdown: `
 ## :icon{symbol="text_snippet"} Series Tag
 Please share the series tag URL & description for the newsletter.
 For example [tv-and-radio/series/what-s-on-tv](https://www.theguardian.com/tv-and-radio/series/what-s-on-tv) for the What's On newsletter.

--- a/libs/newsletters-data-client/src/lib/zod-helpers/validation.ts
+++ b/libs/newsletters-data-client/src/lib/zod-helpers/validation.ts
@@ -1,11 +1,11 @@
 import type { ZodObject, ZodRawShape } from 'zod';
 
 export const getValidationWarnings = (
-	data: Partial<Record<string, unknown>>,
+	data: Record<string, unknown>,
 	schema: ZodObject<ZodRawShape>,
-): Partial<Record<string, string>> => {
+): Record<string, string> => {
 	const parseResult = schema.safeParse(data);
-	const validationWarnings: Partial<Record<string, string>> = {};
+	const validationWarnings: Record<string, string> = {};
 
 	if (!parseResult.success) {
 		parseResult.error.issues.forEach((issue) => {

--- a/libs/state-machine/src/lib/getStepList.ts
+++ b/libs/state-machine/src/lib/getStepList.ts
@@ -9,6 +9,7 @@ export type StepListing = {
 	parentStepId?: WizardStepLayout['parentStepId'];
 	canSkipTo?: boolean;
 	canSkipFrom?: boolean;
+	isIntro: boolean;
 	skippingWillPersistLocalChanges?: boolean;
 	schema?: ZodObject<ZodRawShape>;
 	isOptional: boolean;
@@ -32,6 +33,7 @@ export const getStepperConfig = (wizard: WizardLayout): StepperConfig => {
 					parentStepId: step.parentStepId,
 					canSkipTo: !!step.canSkip,
 					canSkipFrom: !!(step.canSkip ?? step.executeSkip),
+					isIntro: !!step.isIntro,
 					skippingWillPersistLocalChanges: step.skippingWillPersistLocalChanges,
 					schema: step.schema,
 					isOptional:

--- a/libs/state-machine/src/lib/getStepList.ts
+++ b/libs/state-machine/src/lib/getStepList.ts
@@ -9,7 +9,7 @@ export type StepListing = {
 	parentStepId?: WizardStepLayout['parentStepId'];
 	canSkipTo?: boolean;
 	canSkipFrom?: boolean;
-	isIntro: boolean;
+	isIntro?: boolean;
 	skippingWillPersistLocalChanges?: boolean;
 	schema?: ZodObject<ZodRawShape>;
 	isOptional: boolean;

--- a/libs/state-machine/src/lib/types.ts
+++ b/libs/state-machine/src/lib/types.ts
@@ -102,8 +102,8 @@ export interface WizardStepLayout<
 	S extends ZodRawShape = ZodRawShape,
 > extends BaseWizardStepLayout<T> {
 	schema?: ZodObject<S>;
-	staticSideMarkdown?: Array<{field: keyof S & string; markdown: string}>;
-	dynamicSideMarkdown?: {(requestData?: WizardFormData, responseData?: WizardFormData): Array<{field: keyof S & string; markdown: string}>};
+	staticSideMarkdown?: Array<{field?: keyof S & string; markdown: string}>;
+	dynamicSideMarkdown?: {(requestData?: WizardFormData, responseData?: WizardFormData): Array<{field?: keyof S & string; markdown: string}>};
 }
 
 export interface BaseWizardStepLayout<
@@ -117,8 +117,8 @@ export interface BaseWizardStepLayout<
 	dynamicMarkdown?: {
 		(requestData?: WizardFormData, responseData?: WizardFormData): string;
 	};
-	staticSideMarkdown?: Array<{field: string;  markdown: string}>;
-	dynamicSideMarkdown?: {(requestData?: WizardFormData, responseData?: WizardFormData): Array<{field: string; markdown: string}>};
+	staticSideMarkdown?: Array<{field?: string;  markdown: string}>;
+	dynamicSideMarkdown?: {(requestData?: WizardFormData, responseData?: WizardFormData): Array<{field?: string; markdown: string}>};
 
 	buttons: Record<string, WizardStepLayoutButton<T>>;
 	schema?: ZodObject<ZodRawShape>;
@@ -137,6 +137,7 @@ export interface BaseWizardStepLayout<
 			storageInstance: T,
 		): Promise<FormDataRecord>;
 	};
+	isIntro?: boolean;
 }
 
 export type WizardLayout<
@@ -183,7 +184,7 @@ export interface CurrentStepRouteResponse {
 	/** Markdown content to display for the current step in the right side panel
 	 * (redesign only)
 	 */
-	markdownToDisplayInSidebar?: Array<{field: string;  markdown:string}>;
+	markdownToDisplayInSidebar?: Array<{field?: string;  markdown:string}>;
 	/** Unique identifier for the current step. */
 	currentStepId: string;
 	/** Buttons to display for the current step. */


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add `isIntro` to step layouts and propagate it through step listings so intro steps don’t show completion status.

Add a `showErrors` flag through the stand redesign form stack so validation warnings only display after user edits or after a server-side validation error.

Make sidebar markdown `field` prop optional so content blocks can be displayed without coupling to a form field.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

Locally

## How can we measure success?

Testing the form with the feature switch. 

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215805194720709