### PR TITLE
[StandRedesign] Add `review` page, update `finish` page, update `Wizard` routes

### DIFF
--- a/apps/newsletters-ui/src/app/Layout.tsx
+++ b/apps/newsletters-ui/src/app/Layout.tsx
@@ -44,9 +44,15 @@ export function Layout(props: IRootRoute) {
 		!!host?.toLowerCase().split('.').includes('local');
 
 	const location = useLocation();
-	const isNewsletterData = location.pathname.includes(
-		'/drafts/newsletter-data',
-	);
+
+	const isWizardRoute = (() => {
+		const wizardRoutes = [
+			'/drafts/newsletter-data',
+			'/drafts/newsletter-data-rendering',
+			'/drafts/launch-newsletter',
+		];
+		return wizardRoutes.some((route) => location.pathname.includes(route));
+	})();
 	const isUsingStand = isFeatureSwitchEnabled('switch-stand');
 
 	useEffect(() => {
@@ -66,7 +72,7 @@ export function Layout(props: IRootRoute) {
 		<MainNav isOnCode={isOnCode} isOnLocal={isOnLocal} />
 	);
 
-	if (isUsingStand && isNewsletterData) {
+	if (isUsingStand && isWizardRoute) {
 		return (
 			<StandLayout>
 				{(isOnCode || isOnLocal) && (

--- a/apps/newsletters-ui/src/app/components/StandRedesignReviewStep.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignReviewStep.tsx
@@ -1,0 +1,211 @@
+import { css } from '@emotion/react';
+import {
+	baseSizing,
+	semanticColors,
+	semanticRadius,
+	semanticSpacing,
+} from '@guardian/stand';
+import { Link } from '@guardian/stand/Link';
+import { Typography } from '@guardian/stand/Typography';
+import {
+	ZodArray,
+	ZodBoolean,
+	ZodDate,
+	ZodEnum,
+	ZodNumber,
+	ZodObject,
+	ZodString,
+	ZodURL,
+} from 'zod';
+import type { ZodTypeAny } from 'zod';
+import type { WizardId } from '@newsletters-nx/newsletter-workflow';
+import { getStepperConfig } from '@newsletters-nx/newsletter-workflow';
+import { recursiveUnwrap } from '@newsletters-nx/newsletters-data-client';
+import type { WizardFormData } from '@newsletters-nx/state-machine';
+
+const emptyValueDisplay = '-';
+const formatValueWithZod = (value: unknown, zod: ZodTypeAny): string => {
+	if (value === null || value === undefined) {
+		return emptyValueDisplay;
+	}
+	const innerZod = recursiveUnwrap(zod);
+	if (innerZod instanceof ZodBoolean) {
+		return value === true ? 'Yes' : value === false ? 'No' : emptyValueDisplay;
+	}
+	if (innerZod instanceof ZodDate) {
+		if (value instanceof Date) {
+			// format date as DD MMMM YYYY, e.g. 01 January 2024
+			return value.toLocaleDateString('en-GB', {
+				day: '2-digit',
+				month: 'long',
+				year: 'numeric',
+			});
+		}
+		if (typeof value === 'string') {
+			const date = new Date(value);
+			if (!isNaN(date.getTime())) {
+				return date.toLocaleDateString('en-GB', {
+					day: '2-digit',
+					month: 'long',
+					year: 'numeric',
+				});
+			}
+		}
+		return emptyValueDisplay;
+	}
+	if (innerZod instanceof ZodArray) {
+		if (!Array.isArray(value)) {
+			return emptyValueDisplay;
+		}
+		return value.length > 0 ? value.join(', ') : emptyValueDisplay;
+	}
+	if (innerZod instanceof ZodObject) {
+		return typeof value === 'object'
+			? JSON.stringify(value)
+			: emptyValueDisplay;
+	}
+	if (
+		innerZod instanceof ZodEnum ||
+		innerZod instanceof ZodString ||
+		innerZod instanceof ZodURL ||
+		innerZod instanceof ZodNumber
+	) {
+		return value === '' ? emptyValueDisplay : String(value as string | number);
+	}
+	// fallback for any unhandled types
+	if (typeof value === 'object') {
+		return JSON.stringify(value);
+	}
+	return value === '' ? emptyValueDisplay : String(value as string | number);
+};
+
+const sectionStyles = css`
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	align-self: stretch;
+	margin-bottom: ${semanticSpacing.stackMd};
+	border: ${baseSizing.size1Rem} solid ${semanticColors.border.weak};
+	border-radius: ${semanticRadius.cornerSm};
+`;
+
+const sectionHeaderStyles = css`
+	display: flex;
+	align-items: center;
+	width: 100%;
+	padding: ${semanticSpacing.stackMd};
+	align-self: stretch;
+	border-bottom: ${baseSizing.size1Rem} solid ${semanticColors.border.weak};
+	background: ${semanticColors.fill.neutralWeak};
+`;
+
+const headerOptionalStyles = css`
+	align-self: flex-end;
+	margin-left: ${semanticSpacing.stackXs};
+`;
+
+const sectionContentStyles = css`
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	justify-content: flex-start;
+	padding: ${semanticSpacing.stackMd};
+	gap: ${semanticSpacing.stackSm};
+`;
+
+const contentContainerStyles = css`
+	display: flex;
+	width: 100%;
+	gap: ${semanticSpacing.stackSm};
+`;
+
+const contentLabelStyles = css`
+	width: 100%;
+	max-width: 33%;
+`;
+
+interface Props {
+	wizardId: WizardId;
+	formData: WizardFormData;
+	handleStepClick: (stepId: string) => void;
+}
+
+export const StandRedesignReviewStep: React.FC<Props> = ({
+	wizardId,
+	formData,
+	handleStepClick: onStepClick,
+}) => {
+	const fieldGroups = getStepperConfig(wizardId)
+		.steps.filter(
+			(step) =>
+				step.schema &&
+				Object.keys(step.schema.shape).length > 0 &&
+				step.role !== 'EARLY_EXIT' &&
+				step.role !== 'EDIT_START',
+		)
+		.map((step) => ({
+			id: step.id,
+			label: step.label ?? step.id,
+			isOptional: step.isOptional,
+			fields: Object.keys(step.schema?.shape ?? {}).map((key) => {
+				const zod = step.schema?.shape[key] as ZodTypeAny;
+				return {
+					key,
+					label: zod.description ?? key,
+					zod,
+				};
+			}),
+		}));
+
+	return (
+		<>
+			{fieldGroups.map((group) => (
+				<section key={group.id} css={sectionStyles}>
+					<div css={sectionHeaderStyles}>
+						{/* header + edit link */}
+						<Typography variant="headingCompactMd">{group.label}</Typography>
+						{group.isOptional && (
+							<Typography
+								variant="bodyXs"
+								cssOverrides={headerOptionalStyles}
+								theme={{ color: 'grey' }}
+							>
+								Optional
+							</Typography>
+						)}
+
+						<Link
+							typography="bodySm"
+							onPress={() => {
+								onStepClick(group.id);
+							}}
+							cssOverrides={css`
+								margin-left: auto;
+							`}
+						>
+							Edit
+						</Link>
+					</div>
+					<div css={sectionContentStyles}>
+						{/* fields */}
+						{group.fields.map(({ key, label, zod }) => (
+							// flex container with label on left and value on right
+							<div key={key} css={contentContainerStyles}>
+								<Typography
+									variant="bodyBoldSm"
+									cssOverrides={contentLabelStyles}
+								>
+									{label}:
+								</Typography>
+								<Typography variant="bodySm">
+									{formatValueWithZod(formData[key], zod)}
+								</Typography>
+							</div>
+						))}
+					</div>
+				</section>
+			))}
+		</>
+	);
+};

--- a/apps/newsletters-ui/src/app/components/StandRedesignReviewStep.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignReviewStep.tsx
@@ -190,7 +190,6 @@ export const StandRedesignReviewStep: React.FC<Props> = ({
 					<div css={sectionContentStyles}>
 						{/* fields */}
 						{group.fields.map(({ key, label, zod }) => (
-							// flex container with label on left and value on right
 							<div key={key} css={contentContainerStyles}>
 								<Typography
 									variant="bodyBoldSm"

--- a/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
@@ -1,5 +1,10 @@
 import { css } from '@emotion/react';
-import { baseSpacing, semanticColors, semanticGrid } from '@guardian/stand';
+import {
+	baseSpacing,
+	semanticColors,
+	semanticGrid,
+	semanticSpacing,
+} from '@guardian/stand';
 import { Grid, Item } from '@guardian/stand/Grid';
 import { Layout } from '@guardian/stand/Layout';
 import { from } from '@guardian/stand/utils';
@@ -24,6 +29,7 @@ import type {
 import { makeWizardStepRequest } from '../api-requests/make-wizard-step-request';
 import type { StringInputSettings } from './SchemaForm';
 import { StandRedesignMarkdownView } from './StandRedesignMarkdownView';
+import { StandRedesignReviewStep } from './StandRedesignReviewStep';
 import { StandRedesignStateEditForm } from './StandRedesignStateEditForm';
 import { StandRedesignStepNav } from './StandRedesignStepNav';
 import { StandRedesignWizardActionButton } from './StandRedesignWizardActionButton';
@@ -96,8 +102,7 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 	const [notedFields, setNotedFields] = useState<string[]>([]);
 	const [currentStepHasBeenChanged, setCurrentStepHasBeenChanged] =
 		useState(false);
-	const [hasServerErrorMessages, setHasServerErrorMessages] =
-		useState(false);
+	const [hasServerErrorMessages, setHasServerErrorMessages] = useState(false);
 	const [showSkipModalFor, setShowSkipModalFor] = useState<string | undefined>(
 		undefined,
 	);
@@ -294,10 +299,7 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 								notedFields={notedFields}
 								formData={formData}
 								setFormData={handleFormChange}
-								showErrors={
-									currentStepHasBeenChanged ||
-									hasServerErrorMessages
-								}
+								showErrors={currentStepHasBeenChanged || hasServerErrorMessages}
 								maxOptionsForRadioButtons={5}
 								stringConfig={stringConfig}
 							/>
@@ -321,6 +323,19 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 								/>
 							))}
 						</Stack>
+						{serverData.isReviewStep && formData && (
+							<div
+								css={css`
+									margin-top: ${semanticSpacing.stackXl};
+								`}
+							>
+								<StandRedesignReviewStep
+									wizardId={wizardId}
+									formData={formData}
+									handleStepClick={handleStepClick}
+								/>
+							</div>
+						)}
 					</Item>
 					<Item
 						size={{ lg: 1 }}

--- a/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
@@ -10,7 +10,7 @@ import { Layout } from '@guardian/stand/Layout';
 import { from } from '@guardian/stand/utils';
 import { Alert, Box, Stack, Typography } from '@mui/material';
 import { useCallback, useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import type { WizardId } from '@newsletters-nx/newsletter-workflow';
 import {
 	getFieldDisplayOptions,
@@ -157,6 +157,8 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 		setListId(undefined);
 	}, [wizardId, id, fetchStep]);
 
+	const navigate = useNavigate();
+
 	if (serverData === undefined) {
 		return <p>'loading'</p>;
 	}
@@ -204,6 +206,11 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 	const handleButtonClick =
 		(buttonId: string, buttonType: WizardButtonType) => () => {
 			if (showSkipModalFor) {
+				return;
+			}
+			const navigateTo = serverData.buttons?.[buttonId]?.navigateTo;
+			if (navigateTo) {
+				void navigate(navigateTo);
 				return;
 			}
 			void fetchStep({

--- a/apps/newsletters-ui/src/app/components/StandRedesignWizardActionButton.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignWizardActionButton.tsx
@@ -11,7 +11,7 @@ export const StandRedesignWizardActionButton = ({ button, onClick }: Props) => {
 	const primaryActions: WizardButtonType[] = ['NEXT', 'LAUNCH'];
 
 	const variant = primaryActions.includes(button.buttonType)
-		? 'secondary'
+		? 'primary'
 		: 'tertiary';
 
 	return (

--- a/apps/newsletters-ui/src/app/routes/drafts.tsx
+++ b/apps/newsletters-ui/src/app/routes/drafts.tsx
@@ -30,11 +30,19 @@ export const draftRoute: RouteObject = {
 		},
 		{
 			path: 'newsletter-data/:listId',
-			element: <WizardContainer wizardId="NEWSLETTER_DATA" />,
+			element: isFeatureSwitchEnabled('switch-stand') ? (
+				<StandRedesignWizardContainer wizardId="NEWSLETTER_DATA_STAND_REDESIGN" />
+			) : (
+				<WizardContainer wizardId="NEWSLETTER_DATA" />
+			),
 		},
 		{
 			path: 'newsletter-data-rendering/:listId',
-			element: <WizardContainer wizardId="RENDERING_OPTIONS" />,
+			element: isFeatureSwitchEnabled('switch-stand') ? (
+				<StandRedesignWizardContainer wizardId="RENDERING_OPTIONS" />
+			) : (
+				<WizardContainer wizardId="RENDERING_OPTIONS" />
+			),
 		},
 		{
 			path: 'newsletter-data',
@@ -46,11 +54,19 @@ export const draftRoute: RouteObject = {
 		},
 		{
 			path: 'launch-newsletter/:listId',
-			element: <WizardContainer wizardId="LAUNCH_NEWSLETTER" />,
+			element: isFeatureSwitchEnabled('switch-stand') ? (
+				<StandRedesignWizardContainer wizardId="LAUNCH_NEWSLETTER" />
+			) : (
+				<WizardContainer wizardId="LAUNCH_NEWSLETTER" />
+			),
 		},
 		{
 			path: 'launch-newsletter',
-			element: <WizardContainer wizardId="LAUNCH_NEWSLETTER" />,
+			element: isFeatureSwitchEnabled('switch-stand') ? (
+				<StandRedesignWizardContainer wizardId="LAUNCH_NEWSLETTER" />
+			) : (
+				<WizardContainer wizardId="LAUNCH_NEWSLETTER" />
+			),
 		},
 	],
 };

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/finishLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/finishLayout.ts
@@ -22,7 +22,20 @@ const finishLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown: staticMarkdown,
 	indicateStepsCompleteOnThisWizard: true,
 	label: 'Finish',
-	buttons: {},
+	buttons: {
+		launch: {
+			buttonType: 'NEXT',
+			label: 'Go to launch wizard',
+			stepToMoveTo: 'finish',
+			getNavigateTo: (formData) => {
+				const listId =
+					typeof formData?.listId === 'number' ? formData.listId : undefined;
+				return typeof listId === 'number'
+					? `/drafts/launch-newsletter/${listId}`
+					: '/drafts/launch-newsletter';
+			},
+		},
+	},
 	dynamicMarkdown(requestData, responseData) {
 		if (!responseData) {
 			return staticMarkdown;
@@ -38,7 +51,7 @@ const finishLayout: WizardStepLayout<DraftService> = {
 			.replace(regExPatterns.name, name)
 			.replace(regExPatterns.listId, listId);
 	},
-	canSkip: true,
+	canSkip: false,
 };
 
 export { finishLayout };

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/index.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/index.ts
@@ -8,6 +8,7 @@ import { createDraftIntro } from './introLayout';
 import { nameAndFrequencyLayout } from './nameAndFrequencyLayout';
 import { productionDetailsLayout } from './productionDetailsLayout';
 import { promotionContentLayout } from './promotionContentLayout';
+import { reviewLayout } from './reviewLayout';
 import { tagsLayout } from './tagsLayout';
 import { targetingLayout } from './targetingLayout';
 
@@ -21,5 +22,6 @@ export const standRedesignLayout: WizardLayout<DraftService> = {
 	targeting: targetingLayout,
 	tags: tagsLayout,
 	signUpPage: promotionContentLayout,
+	review: reviewLayout,
 	finish: finishLayout,
 };

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/reviewLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/reviewLayout.ts
@@ -39,7 +39,7 @@ const reviewLayout: WizardStepLayout<DraftService> = {
 
 		return markdownTemplate.replace(regExPatterns.name, name);
 	},
-	canSkip: true,
+	canSkip: false,
 };
 
 export { reviewLayout };

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/reviewLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/reviewLayout.ts
@@ -1,0 +1,45 @@
+import type { DraftService } from '@newsletters-nx/newsletters-data-client';
+import type { WizardStepLayout } from '@newsletters-nx/state-machine';
+import {
+	getNextStepId,
+	getPreviousOrEditStartStepId,
+} from '@newsletters-nx/state-machine';
+import { getStringValuesFromRecord } from '../../getValuesFromRecord';
+import { regExPatterns } from '../../regExPatterns';
+
+const markdownTemplate = `# Review newsletter setup
+
+Before requesting launch, review your newsletter details for **{{name}}** below.
+`;
+
+const staticMarkdown = markdownTemplate.replace(regExPatterns.name, '');
+
+const reviewLayout: WizardStepLayout<DraftService> = {
+	staticMarkdown: staticMarkdown,
+	indicateStepsCompleteOnThisWizard: true,
+	isReviewStep: true,
+	label: 'Review',
+	buttons: {
+		back: {
+			buttonType: 'PREVIOUS',
+			label: 'Back to previous step',
+			stepToMoveTo: getPreviousOrEditStartStepId,
+		},
+		next: {
+			buttonType: 'NEXT',
+			label: 'Continue to launch review',
+			stepToMoveTo: getNextStepId,
+		},
+	},
+	dynamicMarkdown(requestData, responseData) {
+		if (!responseData) {
+			return staticMarkdown;
+		}
+		const [name = 'NAME'] = getStringValuesFromRecord(responseData, ['name']);
+
+		return markdownTemplate.replace(regExPatterns.name, name);
+	},
+	canSkip: true,
+};
+
+export { reviewLayout };

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/server.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/server.ts
@@ -1,5 +1,8 @@
 import type { DraftService } from '@newsletters-nx/newsletters-data-client';
-import type { AsyncExecution, WizardLayout } from '@newsletters-nx/state-machine';
+import type {
+	AsyncExecution,
+	WizardLayout,
+} from '@newsletters-nx/state-machine';
 import { executeCreate } from '../../executeCreate';
 import { executeModify } from '../../executeModify';
 import { executeSkip } from '../../executeSkip';
@@ -11,6 +14,7 @@ import { createDraftIntro } from './introLayout';
 import { nameAndFrequencyLayout } from './nameAndFrequencyLayout';
 import { productionDetailsLayout } from './productionDetailsLayout';
 import { promotionContentLayout } from './promotionContentLayout';
+import { reviewLayout } from './reviewLayout';
 import { tagsLayout } from './tagsLayout';
 import { targetingLayout } from './targetingLayout';
 
@@ -134,6 +138,21 @@ export const standRedesignLayout: WizardLayout<DraftService> = {
 			},
 			next: {
 				...promotionContentLayout.buttons['next']!,
+				executeStep: executeModify,
+			},
+		},
+	},
+	review: {
+		...reviewLayout,
+		executeSkip,
+		buttons: {
+			...reviewLayout.buttons,
+			back: {
+				...reviewLayout.buttons['back']!,
+				executeStep: executeSkip,
+			},
+			next: {
+				...reviewLayout.buttons['next']!,
 				executeStep: executeModify,
 			},
 		},

--- a/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
+++ b/libs/newsletters-data-client/src/lib/schemas/newsletter-data-type.ts
@@ -151,7 +151,7 @@ export const newsletterDataSchema = z.object({
 
 	launchDate: z.coerce.date().describe('Enter launch date'),
 	signUpPageDate: z.coerce.date().describe('Enter sign up page date'),
-	thrasherDate: z.coerce.date().describe('Thrasher date'),
+	thrasherDate: z.coerce.date().optional().describe('Thrasher date'),
 	privateUntilLaunch: z.boolean().describe('Needs to be private until launch?'),
 	onlineArticle: onlineArticleSchema.optional(),
 

--- a/libs/state-machine/src/lib/makeResponse.ts
+++ b/libs/state-machine/src/lib/makeResponse.ts
@@ -50,15 +50,15 @@ export const makeResponse = (
 		dynamicSideMarkdown,
 	} = nextWizardStepLayout;
 
-const markdown = dynamicMarkdown
-	? dynamicMarkdown(requestBody.formData, state.formData)
-	: staticMarkdown;
+	const markdown = dynamicMarkdown
+		? dynamicMarkdown(requestBody.formData, state.formData)
+		: staticMarkdown;
 
-const sideMarkdown = dynamicSideMarkdown
-	? dynamicSideMarkdown(requestBody.formData, state.formData)
-	: staticSideMarkdown;
+	const sideMarkdown = dynamicSideMarkdown
+		? dynamicSideMarkdown(requestBody.formData, state.formData)
+		: staticSideMarkdown;
 
-return {
+	return {
 		markdownToDisplay: markdown,
 		markdownToDisplayInSidebar: sideMarkdown,
 		currentStepId: state.currentStepId,
@@ -68,5 +68,6 @@ return {
 		errorMessage: state.errorMessage,
 		errorDetails: state.errorDetails,
 		formData: state.formData,
+		isReviewStep: nextWizardStepLayout.isReviewStep,
 	};
 };

--- a/libs/state-machine/src/lib/makeResponse.ts
+++ b/libs/state-machine/src/lib/makeResponse.ts
@@ -2,6 +2,7 @@ import type {
 	CurrentStepRouteRequest,
 	CurrentStepRouteResponse,
 	WizardButton,
+	WizardFormData,
 	WizardStepData,
 	WizardStepLayout,
 	WizardStepLayoutButton,
@@ -9,6 +10,7 @@ import type {
 
 const convertWizardStepLayoutButtonsToWizardButtons = (
 	layoutButtons: WizardStepLayout['buttons'],
+	formData: WizardFormData | undefined,
 ): CurrentStepRouteResponse['buttons'] => {
 	const convertButton = (
 		index: string,
@@ -18,6 +20,7 @@ const convertWizardStepLayoutButtonsToWizardButtons = (
 			id: index,
 			label: input.label,
 			buttonType: input.buttonType,
+			navigateTo: input.getNavigateTo?.(formData),
 		};
 	};
 
@@ -64,6 +67,7 @@ export const makeResponse = (
 		currentStepId: state.currentStepId,
 		buttons: convertWizardStepLayoutButtonsToWizardButtons(
 			nextWizardStepLayout.buttons,
+			state.formData,
 		),
 		errorMessage: state.errorMessage,
 		errorDetails: state.errorDetails,

--- a/libs/state-machine/src/lib/types.ts
+++ b/libs/state-machine/src/lib/types.ts
@@ -102,8 +102,13 @@ export interface WizardStepLayout<
 	S extends ZodRawShape = ZodRawShape,
 > extends BaseWizardStepLayout<T> {
 	schema?: ZodObject<S>;
-	staticSideMarkdown?: Array<{field?: keyof S & string; markdown: string}>;
-	dynamicSideMarkdown?: {(requestData?: WizardFormData, responseData?: WizardFormData): Array<{field?: keyof S & string; markdown: string}>};
+	staticSideMarkdown?: Array<{ field?: keyof S & string; markdown: string }>;
+	dynamicSideMarkdown?: {
+		(
+			requestData?: WizardFormData,
+			responseData?: WizardFormData,
+		): Array<{ field?: keyof S & string; markdown: string }>;
+	};
 }
 
 export interface BaseWizardStepLayout<
@@ -117,8 +122,13 @@ export interface BaseWizardStepLayout<
 	dynamicMarkdown?: {
 		(requestData?: WizardFormData, responseData?: WizardFormData): string;
 	};
-	staticSideMarkdown?: Array<{field?: string;  markdown: string}>;
-	dynamicSideMarkdown?: {(requestData?: WizardFormData, responseData?: WizardFormData): Array<{field?: string; markdown: string}>};
+	staticSideMarkdown?: Array<{ field?: string; markdown: string }>;
+	dynamicSideMarkdown?: {
+		(
+			requestData?: WizardFormData,
+			responseData?: WizardFormData,
+		): Array<{ field?: string; markdown: string }>;
+	};
 
 	buttons: Record<string, WizardStepLayoutButton<T>>;
 	schema?: ZodObject<ZodRawShape>;
@@ -138,6 +148,7 @@ export interface BaseWizardStepLayout<
 		): Promise<FormDataRecord>;
 	};
 	isIntro?: boolean;
+	isReviewStep?: boolean;
 }
 
 export type WizardLayout<
@@ -184,7 +195,7 @@ export interface CurrentStepRouteResponse {
 	/** Markdown content to display for the current step in the right side panel
 	 * (redesign only)
 	 */
-	markdownToDisplayInSidebar?: Array<{field?: string;  markdown:string}>;
+	markdownToDisplayInSidebar?: Array<{ field?: string; markdown: string }>;
 	/** Unique identifier for the current step. */
 	currentStepId: string;
 	/** Buttons to display for the current step. */
@@ -200,4 +211,6 @@ export interface CurrentStepRouteResponse {
 	/** Whether the request resulted in a persistent error (as a opposed temporary connectivity error
 	 *  or validation error on the user input), so the user should not be prompted to try again */
 	hasPersistentError?: boolean;
+	/** Whether this step should render a full data review, showing all prior step data in tables */
+	isReviewStep?: boolean;
 }

--- a/libs/state-machine/src/lib/types.ts
+++ b/libs/state-machine/src/lib/types.ts
@@ -40,6 +40,8 @@ export interface WizardButton {
 	label: string;
 	/** Type of the button, mapped to a specific background and border color. */
 	buttonType: WizardButtonType;
+	/** When set, clicking the button navigates to this URL instead of advancing the wizard. */
+	navigateTo?: string;
 }
 
 export interface WizardStepData {
@@ -92,6 +94,9 @@ export type WizardStepLayoutButton<
 	buttonType: WizardButtonType;
 	label: string;
 	stepToMoveTo: string | FindStepIdFunction;
+	/** When set, clicking the button navigates to this URL instead of advancing the wizard.
+	 *  Receives the current formData so dynamic URLs (e.g. containing an id) can be constructed. */
+	getNavigateTo?: (formData: WizardFormData | undefined) => string;
 	onAfterStepStartValidate?: AsyncValidator<T> | Validator<T>;
 	onBeforeStepChangeValidate?: AsyncValidator<T> | Validator<T>;
 	executeStep?: AsyncExecution<T> | Execution<T>;


### PR DESCRIPTION
## What does this change?

- Adds the Review step before the Finish step
  - Uses `isReviewStep` so we can differentiate this within the `StandRedesignWizard` and make sure it's propagated
  - Uses new `StandRedesignReviewStep` component to dynamically format and render the data from the previous steps
- Update `Finish` step to add a button that navigates to the Launch Wizard on create newsletter completion
- Switch all the `Wizard` routes to use the Stand Redesign Wizard by default (currently behind feature switch)
- Make thrasher date optional

This PR makes the create newsletters flow fully functional from start to finish!

<table>
<tr>
<th> Figma
<th> Local
<tr>
<td> 
<img width="1967" height="1600" alt="Max_ Large desktop" src="https://github.com/user-attachments/assets/ec665e01-1424-41a8-a69e-00a071e108cd" />
<td>
<img width="1951" height="1555" alt="Screenshot 2026-06-24 at 08-09-35 Newsletters tool" src="https://github.com/user-attachments/assets/b2d8d197-eb05-49e5-a140-80f15d9e8459" />
</table>

---

### Full flow video

From creation to launch, and shows the launch wizard using the new layout too:

https://github.com/user-attachments/assets/42189a2f-e574-424c-ada0-811e350e063e

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215835096534972