### PR TITLE
[StandRedesign] Number of minor changes

### DIFF
--- a/apps/newsletters-e2e/src/ui/createNewsletterStandRedesign.spec.ts
+++ b/apps/newsletters-e2e/src/ui/createNewsletterStandRedesign.spec.ts
@@ -1,0 +1,335 @@
+import { expect, type Page, test } from '@playwright/test';
+import { cleanupStaleTestDrafts } from '../../helpers/draft-newsletter';
+
+const DRAFT_NAME_PREFIX = 'Playwright Create Test';
+const CREATE_URL = '/drafts/newsletter-data?switch-stand=true';
+
+async function completeIntroStep(page: Page) {
+	const startButton = page.getByRole('button', { name: 'Continue' });
+	await expect(startButton).toBeVisible();
+	await startButton.click();
+}
+
+async function completeNameFrequencyStep(
+	page: Page,
+	name: string,
+	frequency: string,
+) {
+	await expect(
+		page.getByRole('heading', { name: 'Name and frequency' }),
+	).toBeVisible();
+	const nameInput = page.getByLabel('Name the newsletter');
+	await expect(nameInput).toBeVisible();
+	await nameInput.fill(name);
+
+	const frequencyRadioGroup = page.getByLabel('Set the frequency');
+	await expect(frequencyRadioGroup).toBeVisible();
+	await frequencyRadioGroup.getByText(frequency).click();
+
+	await page.getByRole('button', { name: 'Save and Continue' }).click();
+}
+
+async function completeProductionDetailsStep(
+	page: Page,
+	category: 'article-based' | 'fronts-based' | 'manual-send' | 'other',
+) {
+	await expect(
+		page.getByRole('heading', { name: 'Production details' }),
+	).toBeVisible();
+
+	const categoryGroup = page.getByLabel('Type of newsletter');
+	await expect(categoryGroup).toBeVisible();
+	await expect(categoryGroup.getByText('article-based')).toBeVisible();
+	await expect(categoryGroup.getByText('fronts-based')).toBeVisible();
+	await expect(categoryGroup.getByText('manual-send')).toBeVisible();
+	await expect(categoryGroup.getByText('other')).toBeVisible();
+
+	await categoryGroup.getByText(category).click();
+
+	const articleLocationGroup = page.getByLabel('Location of newsletter');
+	await expect(articleLocationGroup).toBeVisible();
+	await expect(articleLocationGroup.getByText('Email only')).toBeVisible();
+	await expect(
+		articleLocationGroup.getByText('Web for first send only'),
+	).toBeVisible();
+	await expect(
+		articleLocationGroup.getByText('Web for all sends'),
+	).toBeVisible();
+
+	await articleLocationGroup.getByText('Email only').click();
+
+	await page.getByRole('button', { name: 'Save and Continue' }).click();
+}
+
+async function completeDatesStep(page: Page) {
+	await expect(
+		page.getByRole('heading', { name: 'Launch / Promotion details' }),
+	).toBeVisible();
+
+	const launchDateInput = page
+		.getByRole('group', { name: 'Launch date' })
+		.first();
+	const signUpDateInput = page
+		.getByRole('group', { name: 'Sign up page date' })
+		.first();
+
+	await expect(launchDateInput).toBeVisible();
+	await expect(signUpDateInput).toBeVisible();
+	await expect(
+		page.getByRole('checkbox', { name: 'Needs to be private until launch?' }),
+	).toBeVisible();
+
+	const futureDate = '03062122';
+	await launchDateInput.getByRole('spinbutton').first().click();
+	await launchDateInput.pressSequentially(futureDate);
+	await signUpDateInput.getByRole('spinbutton').first().click();
+	await signUpDateInput.pressSequentially(futureDate);
+
+	await page.getByRole('button', { name: 'Save and Continue' }).click();
+}
+
+async function completeTargetingStep(page: Page) {
+	await expect(page.getByRole('heading', { name: 'Targeting' })).toBeVisible();
+
+	const regionFocusGroup = page.getByLabel('Region focus');
+	await expect(regionFocusGroup).toBeVisible();
+	await expect(regionFocusGroup.getByText('UK', { exact: true })).toBeVisible();
+	await expect(regionFocusGroup.getByText('AU', { exact: true })).toBeVisible();
+	await expect(regionFocusGroup.getByText('US', { exact: true })).toBeVisible();
+	await expect(
+		regionFocusGroup.getByText('INT', { exact: true }),
+	).toBeVisible();
+	await expect(
+		regionFocusGroup.getByText('EUR', { exact: true }),
+	).toBeVisible();
+
+	await regionFocusGroup.getByText('UK').click();
+
+	const pillarSelect = page.getByLabel('Pillar');
+	await expect(pillarSelect).toBeVisible();
+	await pillarSelect.click();
+	await page.getByRole('option', { name: 'news' }).click();
+
+	const groupSelect = page.getByLabel('Group for MMA page');
+	await expect(groupSelect).toBeVisible();
+	await groupSelect.click();
+	await page.getByRole('option', { name: 'News in depth' }).click();
+
+	await page.getByRole('button', { name: 'Save and Continue' }).click();
+}
+
+async function completeTagsStep(page: Page) {
+	await expect(
+		page.getByRole('heading', { name: 'Propose the tags for the newsletter' }),
+	).toBeVisible();
+
+	await expect(page.getByLabel('Add the series tag').first()).toBeVisible();
+	await expect(
+		page.getByLabel('Add the Series tag description').first(),
+	).toBeVisible();
+	await expect(page.getByLabel('Campaign tag').first()).toBeVisible();
+	await expect(page.getByLabel('Campaign description').first()).toBeVisible();
+
+	await page.getByRole('button', { name: 'Save and Continue' }).click();
+}
+
+async function completePromotionContentStep(page: Page, name: string) {
+	await expect(
+		page.getByRole('heading', { name: `Sign up page for ${name}.` }),
+	).toBeVisible();
+
+	await expect(page.getByLabel('Headline')).toBeVisible();
+	await expect(page.getByLabel(/^Description/)).toBeVisible();
+	await expect(page.getByLabel('Embed description')).toBeVisible();
+	await expect(page.getByLabel('Success message')).toBeVisible();
+	await expect(page.getByLabel('Highlight card message')).toBeVisible();
+	await expect(
+		page.getByLabel('URL of image the newsleter graphic/logo (5:3 format)'),
+	).toBeVisible();
+	await expect(
+		page.getByLabel('URL of image the newsleter graphic/logo (1:1 format)'),
+	).toBeVisible();
+
+	await page.getByLabel('Headline').fill(`${name} newsletter`);
+	await page.getByLabel(/^Description/).fill(`Sign up for ${name}.`);
+	await page
+		.getByLabel('Embed description')
+		.fill(`Embed description for ${name}.`);
+	await page
+		.getByLabel('Highlight card message')
+		.fill(`Highlight card for ${name}`);
+
+	await page.getByRole('button', { name: 'Save and Continue' }).click();
+}
+
+async function completeReviewPage(page: Page) {
+	await expect(
+		page.getByRole('heading', { name: 'Review newsletter setup' }),
+	).toBeVisible();
+
+	await page.getByRole('button', { name: 'Continue to launch review' }).click();
+}
+
+// ─── Tests ───
+
+test.describe('Create draft newsletter journey', () => {
+	let draftName: string;
+
+	test.beforeAll(async ({ request }) => {
+		await cleanupStaleTestDrafts(request, DRAFT_NAME_PREFIX);
+	});
+
+	// eslint-disable-next-line no-empty-pattern -- stuck between 'no-empty-pattern' (eslint) and 'First argument must use the object destructuring pattern' (playwright)
+	test.beforeEach(({}, testInfo) => {
+		draftName = `${DRAFT_NAME_PREFIX} - ${testInfo.title}`;
+	});
+
+	test.afterEach(async ({ request }) => {
+		await cleanupStaleTestDrafts(request, draftName);
+	});
+
+	test('completes the full journey for an article based newsletter', async ({
+		page,
+	}) => {
+		await page.goto(CREATE_URL);
+
+		await completeIntroStep(page);
+		await completeNameFrequencyStep(page, draftName, 'Weekly');
+		await completeProductionDetailsStep(page, 'article-based');
+		await completeDatesStep(page);
+		await completeTargetingStep(page);
+		await completeTagsStep(page);
+		await completePromotionContentStep(page, draftName);
+		await completeReviewPage(page);
+
+		await expect(
+			page.getByRole('heading', { name: "You're finished!" }),
+		).toBeVisible();
+		await expect(
+			page.getByText(
+				`Congratulations, you have reached the end of the wizard for newsletter ${draftName}`,
+			),
+		).toBeVisible();
+
+		await expect(
+			page.getByRole('link', { name: 'rendering options' }),
+		).toBeVisible();
+
+		// Link to the draft detail page should be visible
+		await expect(
+			page.getByRole('link', { name: 'details page' }),
+		).toBeVisible();
+	});
+
+	test('completes the full journey for a fronts based newsletter', async ({
+		page,
+	}) => {
+		await page.goto(CREATE_URL);
+
+		await completeIntroStep(page);
+		await completeNameFrequencyStep(page, draftName, 'Weekly');
+		await completeProductionDetailsStep(page, 'fronts-based');
+		await completeDatesStep(page);
+		await completeTargetingStep(page);
+		await completeTagsStep(page);
+		await completePromotionContentStep(page, draftName);
+		await completeReviewPage(page);
+
+		await expect(
+			page.getByRole('heading', { name: "You're finished!" }),
+		).toBeVisible();
+		await expect(
+			page.getByText(
+				`Congratulations, you have reached the end of the wizard for newsletter ${draftName}`,
+			),
+		).toBeVisible();
+
+		await expect(
+			page.getByRole('link', { name: 'rendering options' }),
+		).not.toBeVisible();
+	});
+
+	test('shows a validation error when submitting the name step without entering a name', async ({
+		page,
+	}) => {
+		await page.goto(CREATE_URL);
+
+		await completeIntroStep(page);
+
+		await expect(page.getByRole('textbox', { name: 'Name' })).toBeVisible();
+		await page.getByRole('button', { name: 'Save and Continue' }).click();
+
+		await expect(page.getByRole('alert')).toBeVisible();
+		await expect(page.getByRole('textbox', { name: 'Name' })).toBeVisible();
+	});
+});
+
+test.describe('Wizard step nav skip functionality', () => {
+	let draftName: string;
+
+	test.beforeAll(async ({ request }) => {
+		await cleanupStaleTestDrafts(request, DRAFT_NAME_PREFIX);
+	});
+
+	// eslint-disable-next-line no-empty-pattern -- stuck between 'no-empty-pattern' (eslint) and 'First argument must use the object destructuring pattern' (playwright)
+	test.beforeEach(({}, testInfo) => {
+		draftName = `${DRAFT_NAME_PREFIX} - ${testInfo.title}`;
+	});
+
+	test.afterEach(async ({ request }) => {
+		await cleanupStaleTestDrafts(request, draftName);
+	});
+
+	test('step nav items are not clickable on a non-skippable step', async ({
+		page,
+	}) => {
+		await page.goto(CREATE_URL);
+
+		await expect(page.locator('.left-aligned-step-button')).not.toBeVisible();
+	});
+
+	test('step nav items become skip buttons when on a skippable step', async ({
+		page,
+	}) => {
+		await page.goto(CREATE_URL);
+		await completeIntroStep(page);
+		await completeNameFrequencyStep(page, draftName, 'Weekly');
+
+		// Wait for the production details step to confirm the wizard has advanced.
+		await expect(
+			page.getByRole('heading', { name: /Production details/ }),
+		).toBeVisible();
+
+		// get the nav
+		const sideNav = page.getByLabel('Newsletter creation steps');
+		await expect(sideNav).toBeVisible();
+
+		await expect(sideNav.getByText('Launch/Promotion Dates')).toBeVisible();
+		await expect(sideNav.getByText('Targeting')).toBeVisible();
+		await expect(sideNav.getByText('Tag Setting')).toBeVisible();
+	});
+
+	test('clicking a step nav button navigates to that step', async ({
+		page,
+	}) => {
+		await page.goto(CREATE_URL);
+		await completeIntroStep(page);
+		await completeNameFrequencyStep(page, draftName, 'Weekly');
+
+		// Wait for the production details step to confirm the wizard has advanced.
+		await expect(
+			page.getByRole('heading', { name: /Production details/ }),
+		).toBeVisible();
+
+		// get the nav
+		const sideNav = page.getByLabel('Newsletter creation steps');
+		await expect(sideNav).toBeVisible();
+
+		// Skip from Production Details to Targeting.
+		await sideNav.getByText('Targeting').click();
+
+		await expect(
+			page.getByRole('heading', { name: /Targeting/ }),
+		).toBeVisible();
+	});
+});

--- a/apps/newsletters-ui/src/app/components/StandMainNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StandMainNav.tsx
@@ -7,37 +7,15 @@ import {
 	TopBarNavigation,
 	TopBarToolName,
 } from '@guardian/stand/TopBar';
+import { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
-import { useProfile } from '../hooks/user-hooks';
+import { usePermissions, useProfile } from '../hooks/user-hooks';
 import '@guardian/stand/util/reset.css';
 
 interface NavLink {
 	path: string;
 	label: string;
 }
-
-const navLinks: NavLink[] = [
-	{ path: '/launched', label: 'Launched Newsletters' },
-	{ path: '/drafts', label: 'Draft Newsletters' },
-	{ path: '/templates', label: 'Email Templates' },
-	{ path: '/layouts', label: 'All Newsletter Page Layouts' },
-	{
-		path: '/drafts/newsletter-data',
-		label: 'Create New Newsletter',
-	},
-];
-
-const menuItemIsSelected = (path: string, pathname: string): boolean => {
-	if (!pathname.startsWith(path)) {
-		return false;
-	}
-	return !navLinks.some(
-		(link) =>
-			link.path !== path &&
-			pathname.startsWith(link.path) &&
-			link.path.length > path.length,
-	);
-};
 
 const topBarTheme: TopBarTheme = {
 	backgroundColor: baseColors.cyan[200],
@@ -80,7 +58,32 @@ const topBarTheme: TopBarTheme = {
 export function StandMainNav() {
 	const userProfile = useProfile();
 	const userName = userProfile?.name ?? 'Logged in user';
+	const permissions = usePermissions();
 	const { pathname } = useLocation();
+
+	const navLinks: NavLink[] = [
+		{ path: '/launched', label: 'Launched Newsletters' },
+		{ path: '/drafts', label: 'Draft Newsletters' },
+		{ path: '/templates', label: 'Email Templates' },
+		{ path: '/layouts', label: 'Newsletter Layouts' },
+		permissions?.writeToDrafts
+			? { path: '/drafts/newsletter-data', label: 'Create New Newsletter' }
+			: null,
+	].filter((link): link is NavLink => link !== null);
+
+	const menuItemIsSelected = useMemo(() => {
+		return (path: string, pathname: string): boolean => {
+			if (!pathname.startsWith(path)) {
+				return false;
+			}
+			return !navLinks.some(
+				(link) =>
+					link.path !== path &&
+					pathname.startsWith(link.path) &&
+					link.path.length > path.length,
+			);
+		};
+	}, [navLinks]);
 
 	return (
 		<TopBar theme={topBarTheme}>

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaField.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/SchemaField.tsx
@@ -3,9 +3,11 @@ import {
 	ZodArray,
 	ZodBoolean,
 	ZodDate,
+	ZodEmail,
 	ZodEnum,
 	ZodNumber,
 	ZodObject,
+	ZodOptional,
 	ZodString,
 	ZodURL,
 } from 'zod';
@@ -113,7 +115,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 		if (readOnly) {
 			return;
 		}
-		if (zod.isOptional() && newValue === '') {
+		if (zod instanceof ZodOptional && newValue === '') {
 			return change(undefined, field);
 		}
 		change(newValue, field);
@@ -123,7 +125,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 		label: zod.description ?? key,
 		inputHandler,
 		readOnly,
-		optional: zod.isOptional(),
+		optional: zod instanceof ZodOptional,
 		error: showErrors ? validationWarning : undefined,
 		description: explanation,
 		isNoted,
@@ -147,7 +149,11 @@ export function SchemaField<T extends z.ZodRawShape>({
 		);
 	}
 
-	if (innerZod instanceof ZodString || innerZod instanceof ZodURL) {
+	if (
+		innerZod instanceof ZodString ||
+		innerZod instanceof ZodURL ||
+		innerZod instanceof ZodEmail
+	) {
 		if (typeof value !== 'string' && typeof value !== 'undefined') {
 			return <WrongValueTypeMessage field={field} />;
 		}
@@ -183,7 +189,13 @@ export function SchemaField<T extends z.ZodRawShape>({
 				);
 			}
 			return (
-				<StandSelectInput placeholder={placeholder} {...standardProps} value={value} isNoted={isNoted} options={options} />
+				<StandSelectInput
+					placeholder={placeholder}
+					{...standardProps}
+					value={value}
+					isNoted={isNoted}
+					options={options}
+				/>
 			);
 		}
 
@@ -202,7 +214,13 @@ export function SchemaField<T extends z.ZodRawShape>({
 		if (typeof value !== 'boolean' && typeof value !== 'undefined') {
 			return <WrongValueTypeMessage field={field} />;
 		}
-		return <StandBooleanInput isNoted={isNoted} {...standardProps} value={value ?? false} />;
+		return (
+			<StandBooleanInput
+				isNoted={isNoted}
+				{...standardProps}
+				value={value ?? false}
+			/>
+		);
 	}
 
 	if (innerZod instanceof ZodNumber) {
@@ -210,7 +228,7 @@ export function SchemaField<T extends z.ZodRawShape>({
 			return <WrongValueTypeMessage field={field} />;
 		}
 
-		if (zod.isOptional()) {
+		if (zod instanceof ZodOptional) {
 			return (
 				<StandOptionalNumberInput
 					{...standardProps}
@@ -279,7 +297,11 @@ export function SchemaField<T extends z.ZodRawShape>({
 	}
 
 	if (innerZod instanceof ZodArray) {
-		if (innerZod.element instanceof ZodString || innerZod.element instanceof ZodURL) {
+		if (
+			innerZod.element instanceof ZodString ||
+			innerZod.element instanceof ZodURL ||
+			innerZod.element instanceof ZodEmail
+		) {
 			if (!isStringArray(value) && typeof value !== 'undefined') {
 				return <WrongValueTypeMessage field={field} />;
 			}

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/index.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/index.tsx
@@ -11,7 +11,6 @@ import type {
 	StringInputSettings,
 } from './util';
 
-
 export * from './util';
 
 interface Props<T extends z.ZodRawShape> {
@@ -26,6 +25,7 @@ interface Props<T extends z.ZodRawShape> {
 	readOnlyKeys?: string[];
 	validationWarnings: Record<string, string>;
 	showErrors: boolean;
+	touchedFields?: Set<string>;
 	maxOptionsForRadioButtons?: number;
 	explanations?: Partial<Record<keyof T, string>>;
 	placeholders?: Partial<Record<keyof T, string>>;
@@ -49,6 +49,7 @@ export function StandRedesignSchemaForm<T extends z.ZodRawShape>({
 	notedFields = [],
 	validationWarnings,
 	showErrors,
+	touchedFields,
 	maxOptionsForRadioButtons = 0,
 	explanations = {},
 	placeholders = {},
@@ -92,7 +93,7 @@ export function StandRedesignSchemaForm<T extends z.ZodRawShape>({
 					field={field}
 					showUnsupported={showUnsupported}
 					validationWarning={validationWarnings[field.key]}
-					showErrors={showErrors}
+					showErrors={showErrors || (touchedFields?.has(field.key) ?? false)}
 					maxOptionsForRadioButtons={maxOptionsForRadioButtons}
 					explanation={explanations[field.key]}
 					placeholder={placeholders[field.key]}

--- a/apps/newsletters-ui/src/app/components/StandRedesignStateEditForm.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignStateEditForm.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import type { z } from 'zod';
 import type { NewsletterData } from '@newsletters-nx/newsletters-data-client';
 import { getValidationWarnings } from '@newsletters-nx/newsletters-data-client';
@@ -32,6 +33,8 @@ export const StandRedesignStateEditForm = ({
 	maxOptionsForRadioButtons,
 	stringConfig = {},
 }: Props) => {
+	const [touchedFields, setTouchedFields] = useState<Set<string>>(new Set());
+
 	const changeFormData = (value: FieldValue, field: FieldDef) => {
 		const mod = getModification(value, field);
 		const revisedData = {
@@ -39,6 +42,7 @@ export const StandRedesignStateEditForm = ({
 			...mod,
 		};
 
+		setTouchedFields((prev) => new Set(prev).add(field.key));
 		setFormData(revisedData);
 	};
 
@@ -54,23 +58,31 @@ export const StandRedesignStateEditForm = ({
 		onlineArticle: 'Where will readers access the newsletter?',
 		launchDate: 'When will the newsletter first send to readers?',
 		signUpPageDate: 'When should promotions go live?',
-		seriesTag: 'This is usually always the name of the newsletter and determines where it sits on the website.',
-		seriesTagDescription: 'Reader facing, one sentence, description of what the newsletter is about ',
+		seriesTag:
+			'This is usually always the name of the newsletter and determines where it sits on the website.',
+		seriesTagDescription:
+			'Reader facing, one sentence, description of what the newsletter is about ',
 		composerTag: 'Add the newsletter name and then (newsletter sign up)',
 		signUpHeadline: 'The larger text at the top of the newsletter sign up.',
 		signUpDescription: 'The smaller text below the headline',
-		illustrationCard: 'Search the grid for the 5:4 art work which will accompany the newsletter',
-		mailSuccessDescription: 'The text a reader sees when they have signed up for a newsletter',
+		illustrationCard:
+			'Search the grid for the 5:4 art work which will accompany the newsletter',
+		mailSuccessDescription:
+			'The text a reader sees when they have signed up for a newsletter',
 	};
 	const placeholders: Partial<Record<keyof NewsletterData, string>> = {
 		seriesTag: 'e.g Feast / Feast Newsletter',
-		seriesTagDescription: 'e.g A weekly email about food news, trends and recipes',
+		seriesTagDescription:
+			'e.g A weekly email about food news, trends and recipes',
 		composerTag: 'Today In Focus (newsletter sign up)',
-		signUpHeadline: 'e.g Sign up for the First Edition newsletter: our free daily news email',
-		signUpDescription: 'e.g Archie Bland and Nimo Omer take you through the top stories and what they mean.',
-		mailSuccessDescription: 'e.g Subscription confirmed. We’ll send you First Edition every weekday.',
+		signUpHeadline:
+			'e.g Sign up for the First Edition newsletter: our free daily news email',
+		signUpDescription:
+			'e.g Archie Bland and Nimo Omer take you through the top stories and what they mean.',
+		mailSuccessDescription:
+			'e.g Subscription confirmed. We’ll send you First Edition every weekday.',
 		illustrationCard: 'URL of the newsletter graphic 5:4',
-		illustrationSquare: 'URL of the newsletter graphic 1:1'
+		illustrationSquare: 'URL of the newsletter graphic 1:1',
 	};
 
 	return (
@@ -79,6 +91,7 @@ export const StandRedesignStateEditForm = ({
 			data={formData}
 			validationWarnings={getValidationWarnings(formData, formSchema)}
 			showErrors={showErrors}
+			touchedFields={touchedFields}
 			changeValue={changeFormData}
 			maxOptionsForRadioButtons={maxOptionsForRadioButtons}
 			stringConfig={stringConfig}

--- a/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
@@ -292,6 +292,7 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 						offset={{ lg: 1 }}
 						css={css`
 							margin-top: ${semanticGrid.margin.topSmPx};
+							margin-bottom: ${semanticSpacing.stackMd};
 
 							${from.md} {
 								margin-top: ${semanticGrid.margin.topMdPx};
@@ -299,6 +300,7 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 
 							${from.lg} {
 								margin-top: ${semanticGrid.margin.topLgPx};
+								margin-bottom: ${semanticGrid.margin.bottomLgPx};
 							}
 						`}
 					>
@@ -376,6 +378,12 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 					<Item
 						size={{ lg: 4 }}
 						cssOverrides={css`
+							margin-bottom: ${semanticGrid.margin.bottomSmPx};
+
+							${from.md} {
+								margin-bottom: ${semanticGrid.margin.bottomMdPx};
+							}
+
 							${from.lg} {
 								margin-top: ${semanticGrid.margin.topLgPx};
 							}

--- a/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
@@ -108,6 +108,7 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 	const [currentStepHasBeenChanged, setCurrentStepHasBeenChanged] =
 		useState(false);
 	const [hasServerErrorMessages, setHasServerErrorMessages] = useState(false);
+	const [showAllErrors, setShowAllErrors] = useState(false);
 	const [showSkipModalFor, setShowSkipModalFor] = useState<string | undefined>(
 		undefined,
 	);
@@ -136,6 +137,7 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 				});
 				setHasServerErrorMessages(!!data.errorMessage);
 				setCurrentStepHasBeenChanged(false);
+				setShowAllErrors(false);
 				setShowSkipModalFor(undefined);
 				setNotedFields(noted ?? []);
 			} catch (error: unknown /* FIXME! */) {
@@ -218,6 +220,7 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 				void navigate(navigateTo);
 				return;
 			}
+			setShowAllErrors(true);
 			void fetchStep({
 				wizardId: wizardId,
 				id: id,
@@ -307,11 +310,12 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 
 						{formSchema && formData && (
 							<StandRedesignStateEditForm
+								key={serverData.currentStepId}
 								formSchema={formSchema}
 								notedFields={notedFields}
 								formData={formData}
 								setFormData={handleFormChange}
-								showErrors={currentStepHasBeenChanged || hasServerErrorMessages}
+								showErrors={showAllErrors || hasServerErrorMessages}
 								maxOptionsForRadioButtons={5}
 								stringConfig={stringConfig}
 							/>

--- a/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
@@ -7,8 +7,9 @@ import {
 } from '@guardian/stand';
 import { Grid, Item } from '@guardian/stand/Grid';
 import { Layout } from '@guardian/stand/Layout';
+import { Typography } from '@guardian/stand/Typography';
 import { from } from '@guardian/stand/utils';
-import { Alert, Box, Stack, Typography } from '@mui/material';
+import { Alert } from '@mui/material';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import type { WizardId } from '@newsletters-nx/newsletter-workflow';
@@ -74,13 +75,17 @@ const FailureAlert = (props: {
 				<ZodIssuesReport issues={errorDetails.zodIssues} />
 			)}
 			{errorDetails?.problemList && (
-				<Stack spacing={1} component={'ul'}>
+				<div
+					css={css`
+						display: flex;
+						flex-direction: column;
+						gap: ${semanticSpacing.stackXs};
+					`}
+				>
 					{errorDetails.problemList.map((problem, index) => (
-						<Typography key={index} component={'li'}>
-							{problem}
-						</Typography>
+						<Typography key={index}>{problem}</Typography>
 					))}
-				</Stack>
+				</div>
 			)}
 		</Alert>
 	);
@@ -313,15 +318,25 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 						)}
 
 						{serverData.errorMessage && (
-							<Box sx={{ paddingBottom: 2 }}>
+							<div
+								css={css`
+									margin-bottom: ${semanticSpacing.stackMd};
+								`}
+							>
 								<FailureAlert
 									errorMessage={serverData.errorMessage}
 									errorDetails={serverData.errorDetails}
 									isPersistent={serverData.hasPersistentError}
 								/>
-							</Box>
+							</div>
 						)}
-						<Stack spacing={2} direction="row">
+						<div
+							css={css`
+								display: flex;
+								flex-direction: row;
+								gap: ${semanticSpacing.stackMd};
+							`}
+						>
 							{Object.entries(serverData.buttons ?? {}).map(([key, button]) => (
 								<StandRedesignWizardActionButton
 									key={key}
@@ -329,7 +344,7 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 									onClick={handleButtonClick}
 								/>
 							))}
-						</Stack>
+						</div>
 						{serverData.isReviewStep && formData && (
 							<div
 								css={css`

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"@emotion/styled": "^11.14.1",
 				"@guardian/image": "^1.1.0",
 				"@guardian/source": "^12.2.1",
-				"@guardian/stand": "0.0.52",
+				"@guardian/stand": "0.0.53",
 				"@internationalized/date": "^3.12.2",
 				"@mui/icons-material": "^9.0.0",
 				"@mui/material": "^9.0.0",
@@ -3913,9 +3913,9 @@
 			}
 		},
 		"node_modules/@guardian/stand": {
-			"version": "0.0.52",
-			"resolved": "https://registry.npmjs.org/@guardian/stand/-/stand-0.0.52.tgz",
-			"integrity": "sha512-SnG1zhRWvy0eRosKg5sJEhZeQOurXi5WlmqEmiYXzUnjt8TjHxlCnMBcENxOEIOYOUANLxG3F/XEJJJYmBmEPQ==",
+			"version": "0.0.53",
+			"resolved": "https://registry.npmjs.org/@guardian/stand/-/stand-0.0.53.tgz",
+			"integrity": "sha512-yHEpeDQ+o2xLUhR47H7CIqnbaAFdKd6wJHZhbySaMopwY7hEm9DGtOkEzoQ1DQC6vvKk9bygkwEDLJe2zpbPQQ==",
 			"peerDependencies": {
 				"@emotion/react": ">=11.11.4 <=11.14.0",
 				"@guardian/prosemirror-invisibles": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"@emotion/styled": "^11.14.1",
 		"@guardian/image": "^1.1.0",
 		"@guardian/source": "^12.2.1",
-		"@guardian/stand": "0.0.52",
+		"@guardian/stand": "0.0.53",
 		"@internationalized/date": "^3.12.2",
 		"@mui/icons-material": "^9.0.0",
 		"@mui/material": "^9.0.0",


### PR DESCRIPTION
## What does this change?

This PR joins together a number of small commits to add on a number of small features/refactors/fixes.

- Add permissions to nav - [`63d1e23` (this PR)](https://github.com/guardian/newsletters-nx/pull/686/commits/63d1e238442c555bd632eda565f4d531c216a83d)
  - Some pages, such as the newsletters creation flow, should only be accessible to those that have the correct permissions
  - Updated the nav to take into account these permissions and not show the create new newsletter item if they don't have the correct permission

<table>
<tr>
<th> Without permissions
<th> With permissions
<tr>
<td>
<img width="1174" height="395" alt="Screenshot 2026-06-29 at 16-04-37 Newsletters tool" src="https://github.com/user-attachments/assets/1e536cc0-24e4-409d-9db8-d6f02151a14b" />
<td>
<img width="1174" height="432" alt="Screenshot 2026-06-29 at 16-04-58 Newsletters tool" src="https://github.com/user-attachments/assets/1fdfbf35-bf6d-4f50-afbd-321a0edd15c9" />
</table>

- (Re)Add `ZodEmail` and `ZodOptional` to the `SchemaField` - [`74db9ee` (this PR)](https://github.com/guardian/newsletters-nx/pull/686/commits/74db9ee52d2bf97467d210c15fc4b4f5add2ba7c)
  - During the `SchemaField` migration these types went missing so weren't rendered correctly in the case of `ZodEmail`, and were deprecated for `ZodOptional`
  - Correctly add these back in so the fields now work correctly

<table>
<tr>
<th> Before (email input missing)
<th> After (email input visible)
<tr>
<td>
<img width="1250" height="965" alt="Screenshot 2026-06-29 at 16-07-33 Newsletters tool" src="https://github.com/user-attachments/assets/8e45c502-8ae9-4f47-8e66-66a16e87d998" />
<td>
<img width="1250" height="965" alt="Screenshot 2026-06-29 at 16-07-37 Newsletters tool" src="https://github.com/user-attachments/assets/5fc5ce2d-cb99-4c74-8549-048181f9ac45" />
</table>

- Remove as much `mui` stuff as possible from the Stand Wizard - [`0ab8f35` (this PR)](https://github.com/guardian/newsletters-nx/pull/686/commits/0ab8f35a75910e609253cc08b4aa0aeb06e06bd1)
  - Ideally we shouldnt be mixing mui and stand together, there were a few things in the Stand Redesign Wizard that were using mui still
  - We've replaced them where possible  
  - Anything else remaining has been bought up with a designer

- Fix Wizard Validation - [`4e6e3dc` (this PR)](https://github.com/guardian/newsletters-nx/pull/686/commits/4e6e3dcc9762f48e242edb5aecb69e834dce2203)
  - In https://github.com/guardian/newsletters-nx/pull/684 we updated the form to not validate until the user had interacted with the page, but if there was more than one input field on the page it would still validate the whole page
  - This commit changes this behaviour to keep track of which fields have been interacted with and only validate the whole page on save

<table>
<tr>
<th> Before (whole form validated after any input and save)
<th> After (Only interacted input validated until save)
<tr>
<td>

https://github.com/user-attachments/assets/5b7b7241-41e8-40db-999e-96a0f08697ef

<td>

https://github.com/user-attachments/assets/9fe2b3b1-f334-46e5-98cc-f131e770608f

</table>

- Add playwright tests for create newsletter flow behind switch - [`6018dc1` (this PR)](https://github.com/guardian/newsletters-nx/pull/686/commits/6018dc15afefec42d874ca8d590db9b5945f19f1)
  - Copied the existing test into a new file and updated them to work with the stand wizard

- Correct wizard margins - [`48f6e23` (this PR)](https://github.com/guardian/newsletters-nx/pull/686/commits/48f6e2315ff63f24ce3427c3311a7da7afe63560)
  - Update the stand wizard to apply correct margins to the bottom of the page and between the items

<table>
<tr>
<th> Before (no margin at bottom of page)
<th> After (Correct margin at bottom)
<tr>
<td>
<img width="1141" height="181" alt="Screenshot 2026-06-29 at 16 13 35" src="https://github.com/user-attachments/assets/90033628-0fdf-4d04-8b7d-14cbb487370a" />
<td>
<img width="1134" height="148" alt="Screenshot 2026-06-29 at 16 13 43" src="https://github.com/user-attachments/assets/1ec7cec8-1e58-4e64-b6e0-43215ef81863" />
</table>