### PR TITLE
[Stand Redesign] Apply design review changes where possible

### DIFF
--- a/apps/newsletters-e2e/src/ui/createNewsletter.spec.ts
+++ b/apps/newsletters-e2e/src/ui/createNewsletter.spec.ts
@@ -18,14 +18,16 @@ async function completeNameStep(page: Page, name: string) {
 	await expect(nameInput).toBeVisible();
 
 	await nameInput.fill(name);
-	await page.getByRole('button', { name: 'Save and Continue' }).click();
+	await page.getByRole('button', { name: 'Save and continue' }).click();
 }
 
 async function completeProductionDetailsStep(
 	page: Page,
 	category: 'article-based' | 'fronts-based' | 'manual-send' | 'other',
 ) {
-	const categoryGroup = page.getByRole('radiogroup', { name: /type of newsletter/i });
+	const categoryGroup = page.getByRole('radiogroup', {
+		name: /type of newsletter/i,
+	});
 	await expect(categoryGroup).toBeVisible();
 	await expect(
 		categoryGroup.getByRole('radio', { name: 'article-based' }),
@@ -58,8 +60,7 @@ async function completeProductionDetailsStep(
 
 	await articleLocationGroup.getByRole('radio', { name: 'Email only' }).click();
 
-	const frequencyCombobox = page
-		.getByTestId('frequency-select')
+	const frequencyCombobox = page.getByTestId('frequency-select');
 	await expect(frequencyCombobox).toBeVisible();
 
 	await categoryGroup
@@ -67,7 +68,7 @@ async function completeProductionDetailsStep(
 		.click();
 	await frequencyCombobox.click();
 	await page.getByRole('option', { name: 'Weekly', exact: true }).click();
-	await page.getByRole('button', { name: 'Save and Continue' }).click();
+	await page.getByRole('button', { name: 'Save and continue' }).click();
 }
 
 async function completeDatesStep(page: Page) {
@@ -96,7 +97,7 @@ async function completeDatesStep(page: Page) {
 	await thrasherDateInput.click();
 	await thrasherDateInput.pressSequentially(futureDate);
 
-	await page.getByRole('button', { name: 'Save and Continue' }).click();
+	await page.getByRole('button', { name: 'Save and continue' }).click();
 }
 
 async function completeTargetingStep(page: Page) {
@@ -129,18 +130,16 @@ async function completeTargetingStep(page: Page) {
 	await expect(regionFocusGroup).toBeVisible();
 	await regionFocusGroup.getByRole('radio', { name: 'UK' }).click();
 
-	await page.getByRole('button', { name: 'Save and Continue' }).click();
+	await page.getByRole('button', { name: 'Save and continue' }).click();
 }
 
 async function completeTagsStep(page: Page) {
 	await expect(page.getByLabel(/^Add the series tag$/)).toBeVisible();
 	await expect(page.getByLabel('add the series tag description')).toBeVisible();
 	await expect(page.getByLabel('Campaign tag')).toBeVisible();
-	await expect(
-		page.getByLabel('Campaign description'),
-	).toBeVisible();
+	await expect(page.getByLabel('Campaign description')).toBeVisible();
 
-	await page.getByRole('button', { name: 'Save and Continue' }).click();
+	await page.getByRole('button', { name: 'Save and continue' }).click();
 }
 
 async function completeThrasherStep(page: Page) {
@@ -177,7 +176,7 @@ async function completeThrasherStep(page: Page) {
 	await expect(multiThrashersAddButton).toBeVisible();
 	await expect(multiThrashersAddButton).toBeEnabled();
 
-	await page.getByRole('button', { name: 'Save and Continue' }).click();
+	await page.getByRole('button', { name: 'Save and continue' }).click();
 }
 
 async function completePromotionContentStep(page: Page, name: string) {
@@ -202,7 +201,7 @@ async function completePromotionContentStep(page: Page, name: string) {
 		.getByLabel('Highlight card message')
 		.fill(`Highlight card for ${name}`);
 
-	await page.getByRole('button', { name: 'Save and Continue' }).click();
+	await page.getByRole('button', { name: 'Save and continue' }).click();
 }
 
 // ─── Tests ───
@@ -292,7 +291,7 @@ test.describe('Create draft newsletter journey', () => {
 		await completeIntroStep(page);
 
 		await expect(page.getByRole('textbox', { name: 'Name' })).toBeVisible();
-		await page.getByRole('button', { name: 'Save and Continue' }).click();
+		await page.getByRole('button', { name: 'Save and continue' }).click();
 
 		await expect(page.getByRole('alert')).toBeVisible();
 		await expect(page.getByRole('textbox', { name: 'Name' })).toBeVisible();

--- a/apps/newsletters-e2e/src/ui/createNewsletterStandRedesign.spec.ts
+++ b/apps/newsletters-e2e/src/ui/createNewsletterStandRedesign.spec.ts
@@ -26,7 +26,7 @@ async function completeNameFrequencyStep(
 	await expect(frequencyRadioGroup).toBeVisible();
 	await frequencyRadioGroup.getByText(frequency).click();
 
-	await page.getByRole('button', { name: 'Save and Continue' }).click();
+	await page.getByRole('button', { name: 'Save and continue' }).click();
 }
 
 async function completeProductionDetailsStep(
@@ -58,7 +58,7 @@ async function completeProductionDetailsStep(
 
 	await articleLocationGroup.getByText('Email only').click();
 
-	await page.getByRole('button', { name: 'Save and Continue' }).click();
+	await page.getByRole('button', { name: 'Save and continue' }).click();
 }
 
 async function completeDatesStep(page: Page) {
@@ -85,7 +85,7 @@ async function completeDatesStep(page: Page) {
 	await signUpDateInput.getByRole('spinbutton').first().click();
 	await signUpDateInput.pressSequentially(futureDate);
 
-	await page.getByRole('button', { name: 'Save and Continue' }).click();
+	await page.getByRole('button', { name: 'Save and continue' }).click();
 }
 
 async function completeTargetingStep(page: Page) {
@@ -115,7 +115,7 @@ async function completeTargetingStep(page: Page) {
 	await groupSelect.click();
 	await page.getByRole('option', { name: 'News in depth' }).click();
 
-	await page.getByRole('button', { name: 'Save and Continue' }).click();
+	await page.getByRole('button', { name: 'Save and continue' }).click();
 }
 
 async function completeTagsStep(page: Page) {
@@ -130,7 +130,7 @@ async function completeTagsStep(page: Page) {
 	await expect(page.getByLabel('Campaign tag').first()).toBeVisible();
 	await expect(page.getByLabel('Campaign description').first()).toBeVisible();
 
-	await page.getByRole('button', { name: 'Save and Continue' }).click();
+	await page.getByRole('button', { name: 'Save and continue' }).click();
 }
 
 async function completePromotionContentStep(page: Page, name: string) {
@@ -159,7 +159,7 @@ async function completePromotionContentStep(page: Page, name: string) {
 		.getByLabel('Highlight card message')
 		.fill(`Highlight card for ${name}`);
 
-	await page.getByRole('button', { name: 'Save and Continue' }).click();
+	await page.getByRole('button', { name: 'Save and continue' }).click();
 }
 
 async function completeReviewPage(page: Page) {
@@ -257,7 +257,7 @@ test.describe('Create draft newsletter journey', () => {
 		await completeIntroStep(page);
 
 		await expect(page.getByRole('textbox', { name: 'Name' })).toBeVisible();
-		await page.getByRole('button', { name: 'Save and Continue' }).click();
+		await page.getByRole('button', { name: 'Save and continue' }).click();
 
 		await expect(page.getByRole('alert')).toBeVisible();
 		await expect(page.getByRole('textbox', { name: 'Name' })).toBeVisible();

--- a/apps/newsletters-ui/src/app/components/StandMainNav.tsx
+++ b/apps/newsletters-ui/src/app/components/StandMainNav.tsx
@@ -62,12 +62,12 @@ export function StandMainNav() {
 	const { pathname } = useLocation();
 
 	const navLinks: NavLink[] = [
-		{ path: '/launched', label: 'Launched Newsletters' },
-		{ path: '/drafts', label: 'Draft Newsletters' },
-		{ path: '/templates', label: 'Email Templates' },
-		{ path: '/layouts', label: 'Newsletter Layouts' },
+		{ path: '/launched', label: 'Launched newsletters' },
+		{ path: '/drafts', label: 'Draft newsletters' },
+		{ path: '/templates', label: 'Email templates' },
+		{ path: '/layouts', label: 'Newsletter layouts' },
 		permissions?.writeToDrafts
-			? { path: '/drafts/newsletter-data', label: 'Create New Newsletter' }
+			? { path: '/drafts/newsletter-data', label: 'Create new newsletter' }
 			: null,
 	].filter((link): link is NavLink => link !== null);
 

--- a/apps/newsletters-ui/src/app/components/StandRedesignMarkdownView.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignMarkdownView.tsx
@@ -1,5 +1,9 @@
 import { css } from '@emotion/react';
-import { semanticSpacing, semanticTypography } from '@guardian/stand';
+import {
+	semanticColors,
+	semanticSpacing,
+	semanticTypography,
+} from '@guardian/stand';
 import type { IconProps } from '@guardian/stand/Icon';
 import { Icon } from '@guardian/stand/Icon';
 import { Link } from '@guardian/stand/Link';
@@ -44,7 +48,12 @@ const remarkLinkDirective: Plugin = () => (tree) => {
 interface MarkdownViewProps {
 	markdown: string;
 	bottomSpacing?: keyof typeof semanticSpacing;
-	componentTypographyOverrides?: Partial<Record<'H1' | 'H2' | 'H3', TypographyProps['variant']>>;
+	componentTypographyOverrides?: Partial<
+		Record<
+			'H1' | 'H2' | 'H3' | 'P' | 'STRONG' | 'LI' | 'LI_STRONG',
+			TypographyProps['variant']
+		>
+	>;
 }
 
 const isExternal = (href?: string) => !href?.startsWith('/');
@@ -64,7 +73,10 @@ const LinkWithNewTabIfExternal = (props: {
 	);
 };
 
-const H1 = (props: {typographyVariant?: TypographyProps['variant']; children?: ReactNode}) => {
+const H1 = (props: {
+	typographyVariant?: TypographyProps['variant'];
+	children?: ReactNode;
+}) => {
 	return (
 		<Typography
 			element="h1"
@@ -80,7 +92,10 @@ const H1 = (props: {typographyVariant?: TypographyProps['variant']; children?: R
 	);
 };
 
-const H2 = (props: {typographyVariant?: TypographyProps['variant']; children?: ReactNode}) => {
+const H2 = (props: {
+	typographyVariant?: TypographyProps['variant'];
+	children?: ReactNode;
+}) => {
 	return (
 		<Typography
 			element="h2"
@@ -95,7 +110,10 @@ const H2 = (props: {typographyVariant?: TypographyProps['variant']; children?: R
 		</Typography>
 	);
 };
-const H3 = (props: {typographyVariant?: TypographyProps['variant']; children?: ReactNode }) => {
+const H3 = (props: {
+	typographyVariant?: TypographyProps['variant'];
+	children?: ReactNode;
+}) => {
 	return (
 		<Typography
 			element="h3"
@@ -110,11 +128,14 @@ const H3 = (props: {typographyVariant?: TypographyProps['variant']; children?: R
 		</Typography>
 	);
 };
-const TypographyP = (props: { children?: ReactNode }) => {
+const TypographyP = (props: {
+	typographyVariant?: TypographyProps['variant'];
+	children?: ReactNode;
+}) => {
 	return (
 		<Typography
 			element="p"
-			variant="bodySm"
+			variant={props.typographyVariant ?? 'bodyMd'}
 			cssOverrides={css`
 				margin-bottom: ${semanticSpacing.stackMd};
 			`}
@@ -128,9 +149,11 @@ const UlMarginOverride = (props: { children?: ReactNode }) => {
 	return (
 		<ul
 			css={css`
-				${convertTypographyToEmotionStringStyle(semanticTypography.bodySm)}
 				margin-bottom: ${semanticSpacing.stackXl};
 				padding-left: 1.5em;
+				:last-child {
+					margin-bottom: 0;
+				}
 				p {
 					margin-bottom: ${semanticSpacing.stackSm};
 				}
@@ -140,11 +163,39 @@ const UlMarginOverride = (props: { children?: ReactNode }) => {
 		</ul>
 	);
 };
-const TypographyStrong = (props: { children?: ReactNode }) => {
+
+const TypographyLi = (props: {
+	typographyVariant?: TypographyProps['variant'];
+	typographyStrongVariant?: TypographyProps['variant'];
+	children?: ReactNode;
+}) => {
+	return (
+		<li
+			css={css`
+				${convertTypographyToEmotionStringStyle(
+					semanticTypography[props.typographyVariant ?? 'bodyMd'],
+				)}
+
+				b {
+					${convertTypographyToEmotionStringStyle(
+						semanticTypography[props.typographyStrongVariant ?? 'bodyBoldMd'],
+					)}
+				}
+			`}
+		>
+			{props.children}
+		</li>
+	);
+};
+
+const TypographyStrong = (props: {
+	typographyVariant?: TypographyProps['variant'];
+	children?: ReactNode;
+}) => {
 	return (
 		<Typography
-			element="span"
-			variant="bodyBoldSm"
+			element="b"
+			variant={props.typographyVariant ?? 'bodyBoldMd'}
 			cssOverrides={css`
 				margin-bottom: ${semanticSpacing.stackXl};
 			`}
@@ -168,7 +219,9 @@ export const StandRedesignMarkdownView: React.FC<MarkdownViewProps> = ({
 					height: auto;
 					display: block;
 				}
-				margin-bottom: ${bottomSpacing ? semanticSpacing[bottomSpacing]: undefined };
+				margin-bottom: ${bottomSpacing
+					? semanticSpacing[bottomSpacing]
+					: undefined};
 			`}
 		>
 			<ReactMarkdown
@@ -180,12 +233,44 @@ export const StandRedesignMarkdownView: React.FC<MarkdownViewProps> = ({
 				components={
 					{
 						a: LinkWithNewTabIfExternal,
-						h1: ({ children }) => <H1 typographyVariant={componentTypographyOverrides?.H1}>{children}</H1>,
-						h2: ({ children }) => <H2 typographyVariant={componentTypographyOverrides?.H2}>{children}</H2>,
-						h3: ({ children }) => <H3 typographyVariant={componentTypographyOverrides?.H3}>{children}</H3>,
-						p: TypographyP,
+						h1: ({ children }) => (
+							<H1 typographyVariant={componentTypographyOverrides?.H1}>
+								{children}
+							</H1>
+						),
+						h2: ({ children }) => (
+							<H2 typographyVariant={componentTypographyOverrides?.H2}>
+								{children}
+							</H2>
+						),
+						h3: ({ children }) => (
+							<H3 typographyVariant={componentTypographyOverrides?.H3}>
+								{children}
+							</H3>
+						),
+						p: ({ children }) => (
+							<TypographyP typographyVariant={componentTypographyOverrides?.P}>
+								{children}
+							</TypographyP>
+						),
 						ul: UlMarginOverride,
-						strong: TypographyStrong,
+						li: ({ children }) => (
+							<TypographyLi
+								typographyVariant={componentTypographyOverrides?.LI}
+								typographyStrongVariant={
+									componentTypographyOverrides?.LI_STRONG
+								}
+							>
+								{children}
+							</TypographyLi>
+						),
+						strong: ({ children }) => (
+							<TypographyStrong
+								typographyVariant={componentTypographyOverrides?.STRONG}
+							>
+								{children}
+							</TypographyStrong>
+						),
 						icon: ({ node }: { node?: Element }) => (
 							<Icon
 								cssOverrides={css`
@@ -201,6 +286,10 @@ export const StandRedesignMarkdownView: React.FC<MarkdownViewProps> = ({
 								typography="bodySm"
 								href={node?.properties.href as string}
 								target={node?.properties.target as string | undefined}
+								cssOverrides={css`
+									/* this needs to be fixed in stand */
+									color: ${semanticColors.fill.link};
+								`}
 							>
 								{children}
 							</Link>

--- a/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/index.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignSchemaForm/index.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { baseSpacing } from '@guardian/stand';
+import { semanticSpacing } from '@guardian/stand';
 import type { z, ZodType } from 'zod';
 import type { NotedFields } from '../StandRedesignWizard';
 // eslint-disable-next-line import/no-cycle -- schemaForm renders recursively for SchemaRecordArrayInput
@@ -73,13 +73,13 @@ export function StandRedesignSchemaForm<T extends z.ZodRawShape>({
 		});
 	}
 
-	return (
+	return fields.length > 0 ? (
 		<div
 			css={css`
 				display: flex;
 				flex-direction: column;
-				gap: ${baseSpacing['32Rem']};
-				margin-bottom: ${baseSpacing['40Rem']};
+				gap: ${semanticSpacing.stackLg};
+				margin-top: ${semanticSpacing.stackXl};
 			`}
 		>
 			{fields.map((field) => (
@@ -100,5 +100,5 @@ export function StandRedesignSchemaForm<T extends z.ZodRawShape>({
 				/>
 			))}
 		</div>
-	);
+	) : null;
 }

--- a/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
+++ b/apps/newsletters-ui/src/app/components/StandRedesignWizard.tsx
@@ -306,8 +306,6 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 					>
 						<StandRedesignMarkdownView
 							markdown={serverData.markdownToDisplay ?? ''}
-							bottomSpacing={'stackXl'}
-							componentTypographyOverrides={{ H2: 'bodyMd' }}
 						/>
 
 						{formSchema && formData && (
@@ -326,7 +324,7 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 						{serverData.errorMessage && (
 							<div
 								css={css`
-									margin-bottom: ${semanticSpacing.stackMd};
+									margin-top: ${semanticSpacing.stackMd};
 								`}
 							>
 								<FailureAlert
@@ -341,6 +339,7 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 								display: flex;
 								flex-direction: row;
 								gap: ${semanticSpacing.stackMd};
+								margin-top: ${semanticSpacing.stackXl};
 							`}
 						>
 							{Object.entries(serverData.buttons ?? {}).map(([key, button]) => (
@@ -405,7 +404,15 @@ export const StandRedesignWizard: React.FC<WizardProps> = ({
 										`}
 										key={field ?? `markdown-${index}`}
 									>
-										<StandRedesignMarkdownView markdown={markdown} />
+										<StandRedesignMarkdownView
+											markdown={markdown}
+											componentTypographyOverrides={{
+												P: 'bodySm',
+												STRONG: 'bodyBoldSm',
+												LI: 'bodySm',
+												LI_STRONG: 'bodyBoldSm',
+											}}
+										/>
 									</div>
 								),
 							)}

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/brazeLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/brazeLayout.ts
@@ -8,7 +8,7 @@ import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 
 const markdownTemplate = `
-## Braze Values
+# Braze Values
 
 These are tracking fields used by Braze.
 

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/cancelLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/cancelLayout.ts
@@ -2,7 +2,7 @@ import type { LaunchService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 
 const markdownToDisplay = `
-## Cancelled
+# Cancelled
 
 Launch of the newsletter was cancelled.
 `.trim();

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/doLaunchLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/doLaunchLayout.ts
@@ -4,7 +4,7 @@ import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 
 const markdownTemplate = `
-## {{name}} is ready for a launch request
+# {{name}} is ready for a launch request
 
 All the data collection steps have now been completed. By requesting a launch for this newsletter, the teams responsible for creating tags, sign-up pages, the Braze campaign and tracking the newsletter will be notified. Once these tasks have been completed, the newsletter will be ready to send.
 

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/editBrazeLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/editBrazeLayout.ts
@@ -10,7 +10,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
 
 const markdownTemplate = `
-## Modify Braze Values
+# Modify Braze Values
 
 These are tracking fields used by Braze.
 

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/editIdentityNameLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/editIdentityNameLayout.ts
@@ -10,7 +10,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
 
 const markdownTemplate = `
-## Modify Identity Name
+# Modify Identity Name
 
 This is a unique identifier for the newsletter, used internally by the system and not displayed to newsletter readers.
 

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/emailCentralProductionLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/emailCentralProductionLayout.ts
@@ -4,7 +4,7 @@ import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 
 const markdownTemplate = `
-## Emailing Central Production
+# Emailing Central Production
 
 ***DEPENDING ON THE DATA ENTERED ON THE TAGS PAGE OF THE WIZARD, RENDER ONE OF THE FOLLOWING***
 

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/finishLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/finishLayout.ts
@@ -3,7 +3,7 @@ import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 
-const markdownTemplate = `## Finished
+const markdownTemplate = `# Finished
 
 You have requested the launch of **{{name}}**
 

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/identityNameLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/identityNameLayout.ts
@@ -5,7 +5,7 @@ import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 
 const markdownTemplate = `
-## Identity Name
+# Identity Name
 
 This is a unique identifier for the newsletter, used internally by the system and not displayed to newsletter readers.
 

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/isDataCompleteLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/isDataCompleteLayout.ts
@@ -7,7 +7,7 @@ import { appendListToMarkdown, isStringArray } from '../../markdown-util';
 import { regExPatterns } from '../../regExPatterns';
 
 const markdownTemplate = `
-## Is {{name}} ready to launch?
+# Is {{name}} ready to launch?
 
 {{answer}}
 

--- a/libs/newsletter-workflow/src/lib/steps/launchNewsletter/launchNewsletterLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/launchNewsletter/launchNewsletterLayout.ts
@@ -5,7 +5,7 @@ import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 
 const markdownTemplate = `
-## Launch {{name}}
+# Launch {{name}}
 
 This wizard will guide you through the process of putting your draft newsletter, **{{name}}** live.
 

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/createDraftNewsletterLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/createDraftNewsletterLayout.ts
@@ -18,7 +18,7 @@ The first step is to enter the name of your newsletter. For example,  **Down to 
 		},
 		next: {
 			buttonType: 'NEXT',
-			label: 'Save and Continue',
+			label: 'Save and continue',
 			stepToMoveTo: getNextStepId,
 		},
 	},

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/dateLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/dateLayout.ts
@@ -50,7 +50,7 @@ export const dateLayout: WizardStepLayout<DraftService> = {
 		},
 		finish: {
 			buttonType: 'NEXT',
-			label: 'Save and Continue',
+			label: 'Save and continue',
 			stepToMoveTo: getNextStepId,
 		},
 	},

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/editDraftNewsletterLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/editDraftNewsletterLayout.ts
@@ -19,7 +19,7 @@ You can edit the name of the newsletter.
 		},
 		next: {
 			buttonType: 'NEXT',
-			label: 'Save and Continue',
+			label: 'Save and continue',
 			stepToMoveTo: getNextStepId,
 		},
 	},

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/productionDetailsLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/productionDetailsLayout.ts
@@ -68,7 +68,7 @@ export const productionDetailsLayout: WizardStepLayout<DraftService> = {
 		},
 		finish: {
 			buttonType: 'NEXT',
-			label: 'Save and Continue',
+			label: 'Save and continue',
 			stepToMoveTo: getNextStepId,
 		},
 	},

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/promotionContentLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/promotionContentLayout.ts
@@ -58,7 +58,7 @@ export const promotionContentLayout: WizardStepLayout<DraftService> = {
 		},
 		next: {
 			buttonType: 'NEXT',
-			label: 'Save and Continue',
+			label: 'Save and continue',
 			stepToMoveTo: getNextStepId,
 		},
 	},

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/tagsLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/tagsLayout.ts
@@ -50,7 +50,7 @@ export const tagsLayout: WizardStepLayout<DraftService> = {
 		},
 		finish: {
 			buttonType: 'NEXT',
-			label: 'Save and Continue',
+			label: 'Save and continue',
 			stepToMoveTo: getNextStepId,
 			onBeforeStepChangeValidate: (stepData) => {
 				if (!stepData.formData) {

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/targetingLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/targetingLayout.ts
@@ -49,7 +49,7 @@ export const targetingLayout: WizardStepLayout<DraftService> = {
 		},
 		finish: {
 			buttonType: 'NEXT',
-			label: 'Save and Continue',
+			label: 'Save and continue',
 			stepToMoveTo: getNextStepId,
 		},
 	},

--- a/libs/newsletter-workflow/src/lib/steps/newsletterData/thrashersLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/newsletterData/thrashersLayout.ts
@@ -47,7 +47,7 @@ export const thrashersLayout: WizardStepLayout<DraftService> = {
 		},
 		next: {
 			buttonType: 'NEXT',
-			label: 'Save and Continue',
+			label: 'Save and continue',
 			stepToMoveTo: getNextStepId,
 		},
 	},

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/cancelLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/cancelLayout.ts
@@ -2,7 +2,7 @@ import type { DraftService } from '@newsletters-nx/newsletters-data-client';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 
 const markdownToDisplay = `
-## Cancelled
+# Cancelled
 
 Setting the render options was cancelled.
 `.trim();

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/darkSectionLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/darkSectionLayout.ts
@@ -9,7 +9,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
 
 const markdownTemplate = `
-## Rendering Dark sections in {{name}}
+# Rendering Dark sections in {{name}}
 
 You may want to display some elements in {{name}} as Dark sections.
 

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/finishLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/finishLayout.ts
@@ -4,7 +4,7 @@ import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 
-const markdownTemplate = `## Finished
+const markdownTemplate = `# Finished
 
 You have reached the end of the wizard.
 

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/footerLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/footerLayout.ts
@@ -9,7 +9,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
 
 const markdownTemplate = `
-## Specify the footer setup for {{name}}
+# Specify the footer setup for {{name}}
 
 What email address would you like to display in the footer of **{{name}}**?
 

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/imageLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/imageLayout.ts
@@ -9,7 +9,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
 
 const markdownTemplate = `
-## Specify the image caption setup for {{name}}
+# Specify the image caption setup for {{name}}
 
 Would you like captions to be displayed within the newsletter?
 

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/linkListLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/linkListLayout.ts
@@ -9,7 +9,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
 
 const markdownTemplate = `
-## Rendering 'Link List' sections in {{name}}
+# Rendering 'Link List' sections in {{name}}
 
 You may want to display some sections in **{{name}}** with LinkList styling.
 

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/newsletterHeaderLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/newsletterHeaderLayout.ts
@@ -9,22 +9,22 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
 
 const markdownTemplate = `
-## Specify the header setup for {{name}}
+# Specify the header setup for {{name}}
 
-### Main Banner
+## Main Banner
 
 The main banner is the image that appears at the top of the newsletter.
 To specify a specify a banner, upload the image via the [s3 Uploader service](https://s3-uploader.gutools.co.uk/).
 
 Once uploaded, copy the **vanity url** and paste it into the field below.
 
-### Date
+## Date
 
 Should the publication date display in each edition?
 
 This is typically shown for daily emails, but not for weekly ones.
 
-### Standfirst
+## Standfirst
 
 Would you like this to be displayed?
 

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/paletteOverrideLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/paletteOverrideLayout.ts
@@ -9,7 +9,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
 
 const markdownTemplate = `
-## Palette override for {{name}}
+# Palette override for {{name}}
 
 The Palette for a newsletter is usually driven by the Pillar it appears under, but that can be overridden here.
 

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/podcastLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/podcastLayout.ts
@@ -9,7 +9,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
 
 const markdownTemplate = `
-## Rendering Podcast sections in {{name}}
+# Rendering Podcast sections in {{name}}
 
 You may want to display some sections in **{{name}}** as Podcast sections.
 

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/readMoreLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/readMoreLayout.ts
@@ -9,7 +9,7 @@ import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from '../newsletterData/formSchemas';
 
 const markdownTemplate = `
-## Rendering 'Read More' sections in {{name}}
+# Rendering 'Read More' sections in {{name}}
 
 At the end of some sections in **{{name}}** you may wish to have a link encouraging the reader to 'Read more on the Guardian'.
 

--- a/libs/newsletter-workflow/src/lib/steps/renderingOptions/startLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/renderingOptions/startLayout.ts
@@ -4,7 +4,7 @@ import { getNextStepId } from '@newsletters-nx/state-machine';
 import { getDraftFromStorage } from '../../getDraftFromStorage';
 
 export const startLayout: WizardStepLayout<DraftService> = {
-	staticMarkdown: `## Set Rendering Template Options
+	staticMarkdown: `# Set Rendering Template Options
 
 This wizard is to choose the options for how an article-based newsletter will appear in Email-rendering.
 

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/dateLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/dateLayout.ts
@@ -8,7 +8,10 @@ import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from './formSchemas';
 
-type DateLayout = WizardStepLayout<DraftService,  typeof formSchemas.promotionDates.shape>
+type DateLayout = WizardStepLayout<
+	DraftService,
+	typeof formSchemas.promotionDates.shape
+>;
 
 const markdownTemplate = `
 # Launch / Promotion details
@@ -20,13 +23,18 @@ const staticMarkdown = markdownTemplate.replace(
 );
 
 const sideMarkdownTemplates: DateLayout['staticSideMarkdown'] = [
-	{field: 'launchDate', markdown: `
+	{
+		field: 'launchDate',
+		markdown: `
 ## :icon{symbol="text_snippet"} Launch
 
 When will the first send of **{{name}}** be? Please specify date. This needs to be in the UK timezone for the system.
 
 We will automatically add a testing period for the newsletter of 1 week before the first send so you can try out the template in Composer. Please also mark if the newsletter should be private if it's confidential.
-`}, { field: `signUpPageDate`,
+`,
+	},
+	{
+		field: `signUpPageDate`,
 		markdown: `
 ## :icon{symbol="text_snippet"} Promotion
 
@@ -36,15 +44,16 @@ If so:
 - What date will the sign up page go live?
 
 - What date will the thrashers go live?
-` }
-]
+`,
+	},
+];
 
-const staticSideMarkdown = sideMarkdownTemplates.map(({field, markdown}) => {
-	return {field, markdown: markdown.replace(
-	regExPatterns.name,
-	'the newsletter',
-)}})
-
+const staticSideMarkdown = sideMarkdownTemplates.map(({ field, markdown }) => {
+	return {
+		field,
+		markdown: markdown.replace(regExPatterns.name, 'the newsletter'),
+	};
+});
 
 export const dateLayout: WizardStepLayout<DraftService> = {
 	staticMarkdown,
@@ -62,12 +71,9 @@ export const dateLayout: WizardStepLayout<DraftService> = {
 			return staticSideMarkdown;
 		}
 		const [name = 'NAME'] = getStringValuesFromRecord(responseData, ['name']);
-		return sideMarkdownTemplates.map(({field, markdown}) => {
-			return {field, markdown: markdown.replace(
-					regExPatterns.name,
-					name,
-				)}
-		})
+		return sideMarkdownTemplates.map(({ field, markdown }) => {
+			return { field, markdown: markdown.replace(regExPatterns.name, name) };
+		});
 	},
 	buttons: {
 		back: {
@@ -77,7 +83,7 @@ export const dateLayout: WizardStepLayout<DraftService> = {
 		},
 		finish: {
 			buttonType: 'NEXT',
-			label: 'Save and Continue',
+			label: 'Save and continue',
 			stepToMoveTo: getNextStepId,
 		},
 	},

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/editDraftNewsletterLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/editDraftNewsletterLayout.ts
@@ -19,7 +19,7 @@ You can edit the name of the newsletter.
 		},
 		next: {
 			buttonType: 'NEXT',
-			label: 'Save and Continue',
+			label: 'Save and continue',
 			stepToMoveTo: getNextStepId,
 		},
 	},

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/nameAndFrequencyLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/nameAndFrequencyLayout.ts
@@ -3,16 +3,24 @@ import { getNextStepId } from '@newsletters-nx/state-machine';
 import type { WizardStepLayout } from '@newsletters-nx/state-machine';
 import { formSchemas } from './formSchemas';
 
-export const nameAndFrequencyLayout: WizardStepLayout<DraftService, typeof formSchemas.nameAndFrequency.shape> = {
+export const nameAndFrequencyLayout: WizardStepLayout<
+	DraftService,
+	typeof formSchemas.nameAndFrequency.shape
+> = {
 	staticMarkdown: `# Name and frequency
 `,
 
-	staticSideMarkdown: [{ markdown: `### :icon{symbol="text_snippet"}  Frequency
+	staticSideMarkdown: [
+		{
+			markdown: `## :icon{symbol="text_snippet"}  Frequency
 
 The frequency you specify will be shown on the sign up page, and on the all newsletters page.
 
 ![Frequency](https://i.guim.co.uk/img/uploads/2023/09/15/frequency.png?quality=85&dpr=2&width=300&s=e8c4bdd12b9c2f1f48d35a2d9b1ef1c7)
-`, field: 'frequency' }],
+`,
+			field: 'frequency',
+		},
+	],
 	label: 'Name & frequency',
 	buttons: {
 		cancel: {
@@ -22,7 +30,7 @@ The frequency you specify will be shown on the sign up page, and on the all news
 		},
 		next: {
 			buttonType: 'NEXT',
-			label: 'Save and Continue',
+			label: 'Save and continue',
 			stepToMoveTo: getNextStepId,
 		},
 	},

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/productionDetailsLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/productionDetailsLayout.ts
@@ -6,25 +6,34 @@ import {
 } from '@newsletters-nx/state-machine';
 import { formSchemas } from './formSchemas';
 
-type ProductionDetailsLayout = WizardStepLayout<DraftService, typeof formSchemas.productionDetails.shape>;
+type ProductionDetailsLayout = WizardStepLayout<
+	DraftService,
+	typeof formSchemas.productionDetails.shape
+>;
 
 const staticSideMarkdown: ProductionDetailsLayout['staticSideMarkdown'] = [
-	{field: 'category', markdown: `
-## Type of Newsletter
+	{
+		field: 'category',
+		markdown: `
+## :icon{symbol="text_snippet"} Type of Newsletter
 Editorial newsletters can be produced in three ways:
 - **article-based**: Each chapter of the newsletter is written as a composer article.
 - **fronts-based**: The newsletters are generated from a fronts page.
 - **manual-send**: The content of the email are generated manually or with an external tool.
-`}, {
-	field: 'onlineArticle', markdown: `
+`,
+	},
+	{
+		field: 'onlineArticle',
+		markdown: `
 ## :icon{symbol="text_snippet"} Web Article
 Tell the central production if the newsletter will appear as a web article.
 
 This is the case for most newsletters, but you may prefer to offer the newsletter exclusively as an email.
 
 Alternatively, you might want the first send on web to preview it, but subsequent sends to be email-only.
-`}
-	];
+`,
+	},
+];
 
 const staticMarkdown = `
 # Production details
@@ -41,11 +50,11 @@ export const productionDetailsLayout: ProductionDetailsLayout = {
 		},
 		finish: {
 			buttonType: 'NEXT',
-			label: 'Save and Continue',
+			label: 'Save and continue',
 			stepToMoveTo: getNextStepId,
 		},
 	},
 	schema: formSchemas.productionDetails,
 	canSkip: true,
-	staticSideMarkdown
+	staticSideMarkdown,
 };

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/promotionContentLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/promotionContentLayout.ts
@@ -8,7 +8,10 @@ import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from './formSchemas';
 
-type PromotionContentLayout = WizardStepLayout<DraftService, typeof formSchemas.promotionContent.shape>
+type PromotionContentLayout = WizardStepLayout<
+	DraftService,
+	typeof formSchemas.promotionContent.shape
+>;
 
 const markdownTemplate = `
 # Sign up page for {{name}}.
@@ -17,7 +20,9 @@ const markdownTemplate = `
 `.trim();
 
 const staticSideMarkdown: PromotionContentLayout['staticSideMarkdown'] = [
-	{field: 'signUpHeadline', markdown: `
+	{
+		field: 'signUpHeadline',
+		markdown: `
 ## :icon{symbol="text_snippet"} Sign up page text
 
 Example image with highlighted sections:
@@ -27,15 +32,20 @@ Example image with highlighted sections:
 
 ![Headline and Description](https://i.guim.co.uk/img/uploads/2023/10/06/signUpImageWithBoarderTwo.png?quality=85&dpr=2&width=300&s=002979e840129ac072654cb66367d971)
 
-`},
-	{field: 'signUpEmbedDescription', markdown: `
+`,
+	},
+	{
+		field: 'signUpEmbedDescription',
+		markdown: `
 ## :icon{symbol="text_snippet"}  Sign up embed description
 
 This text is used on the in-article embeds and on the newsletters page:
 
 ![newsletter sign up](https://uploads.guim.co.uk/2026/06/16/Newsletter-Signup-Desktop.png)
-`}, {
-	field: 'illustrationCard',
+`,
+	},
+	{
+		field: 'illustrationCard',
 		markdown: `
 ## :icon{symbol="text_snippet"} Illustration for the newsletters page
 
@@ -44,9 +54,9 @@ s3 Uploader service. Once uploaded, copy the vanity url and paste it into the fi
 - When used on the theguardian.com or other platforms, images are optimised and resized by our image service to be displayed at the most approriate file size for the usage.
 - If the orginal image is too large for the image service to process, it will fail and the original version will be used on the page. This can harm the pages performance, especially for users on mobile devices.
 - Please make sure that the image you are uploading does not exceed the limits described in this documentation from our image service.
-`
-	}
-]
+`,
+	},
+];
 
 const staticMarkdown = markdownTemplate.replace(
 	regExPatterns.name,
@@ -72,7 +82,7 @@ export const promotionContentLayout: PromotionContentLayout = {
 		},
 		next: {
 			buttonType: 'NEXT',
-			label: 'Save and Continue',
+			label: 'Save and continue',
 			stepToMoveTo: getNextStepId,
 		},
 	},

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/tagsLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/tagsLayout.ts
@@ -8,31 +8,43 @@ import { getStringValuesFromRecord } from '../../getValuesFromRecord';
 import { regExPatterns } from '../../regExPatterns';
 import { formSchemas } from './formSchemas';
 
-type TagsLayout = WizardStepLayout<DraftService, typeof formSchemas.tags.shape>
+type TagsLayout = WizardStepLayout<DraftService, typeof formSchemas.tags.shape>;
 
 const markdownTemplate = `
 # Propose the tags for the newsletter
 
-## Share ideas for tags with central production
+Share ideas for tags with central production
 `.trim();
 
-const staticSideMarkdown: TagsLayout['staticSideMarkdown'] = [{field: 'seriesTag' , markdown:`
+const staticSideMarkdown: TagsLayout['staticSideMarkdown'] = [
+	{
+		field: 'seriesTag',
+		markdown: `
 ## :icon{symbol="text_snippet"} Tag suggestions
 This section allows you to suggest the tags you think will work best to promote the newsletter.
 
 Central Production will review the tags and confirm the final recommendation. They will set up any new tags in tag manager.
 
-The request to set up these tags will not sent till you select “finish”.
-`}, {markdown: `
+The request to set up these tags will not be sent till you select “finish”.
+`,
+	},
+	{
+		markdown: `
 ## :icon{symbol="text_snippet"} Series Tag
 Please share the series tag URL & description for the newsletter.
-For example [tv-and-radio/series/what-s-on-tv](https://www.theguardian.com/tv-and-radio/series/what-s-on-tv) for the What's On newsletter.
-`}, {field: 'composerTag', markdown: `
+For example :link[tv-and-radio/series/what-s-on-tv]{href="https://www.theguardian.com/tv-and-radio/series/what-s-on-tv" target="_blank"} for the What's On newsletter.
+`,
+	},
+	{
+		field: 'composerTag',
+		markdown: `
 ## :icon{symbol="text_snippet"} Composer tag relationship for newsletter embeds
 In Composer, we now have a feature where a newsletter signup embed is proposed to the user once a tag is added to the article
 
 For example, the Games (video games only) tag recommends the user adds the Pushing Buttons (newsletter signup) campaign tag, which displays the sign up embed for Pushing Buttons.
-`}]
+`,
+	},
+];
 
 const staticMarkdown = markdownTemplate.replace(
 	regExPatterns.name,
@@ -58,7 +70,7 @@ export const tagsLayout: TagsLayout = {
 		},
 		finish: {
 			buttonType: 'NEXT',
-			label: 'Save and Continue',
+			label: 'Save and continue',
 			stepToMoveTo: getNextStepId,
 			onBeforeStepChangeValidate: (stepData) => {
 				if (!stepData.formData) {

--- a/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/targetingLayout.ts
+++ b/libs/newsletter-workflow/src/lib/steps/standRedesignNewsletterData/targetingLayout.ts
@@ -82,7 +82,7 @@ export const targetingLayout: WizardStepLayout<DraftService> = {
 		},
 		finish: {
 			buttonType: 'NEXT',
-			label: 'Save and Continue',
+			label: 'Save and continue',
 			stepToMoveTo: getNextStepId,
 		},
 	},


### PR DESCRIPTION
## What does this change?

- Top bar navigation text -> Only capitalise first letter
- Update text and spacing
- See [Figma](https://www.figma.com/design/jD7ZXQ2hmna9qQjUBu3ioH/Newsletter-pilot?node-id=3095-23655&t=Puld6MeEQsQB52ga-1) for full list of changes
  - The only change not made was making the H1 subtext into body-lg, as this didn't quite easily work in markdown, and it's not applied on every page

<table>
<tr>
<th> Page
<th> Before
<th> After
<tr>
<td> Create Newsletters - Introduction
<td>
<img width="3490" height="2092" alt="Screenshot 2026-07-02 at 08-32-29 Newsletters tool" src="https://github.com/user-attachments/assets/e1cc1a7d-0f17-4ba7-a9dc-c999683c8ae8" />
<td>
<img width="3490" height="2092" alt="Screenshot 2026-07-02 at 08-32-23 Newsletters tool" src="https://github.com/user-attachments/assets/aa890e16-7445-44f3-90ca-0e4d86bb55fe" />
<tr>
<td> Create Newsletters - Name and frequency
<td>
<img width="3490" height="2092" alt="Screenshot 2026-07-02 at 08-33-42 Newsletters tool" src="https://github.com/user-attachments/assets/bed4ef9a-fc01-44e1-ab66-30a653bc3400" />
<td>
<img width="3490" height="2092" alt="Screenshot 2026-07-02 at 08-33-38 Newsletters tool" src="https://github.com/user-attachments/assets/39589aa3-fa80-4697-8ab3-1d9c4231db82" />
<tr>
<td> Create Newsletters - Tags
<td>
<img width="3490" height="2092" alt="Screenshot 2026-07-02 at 08-36-29 Newsletters tool" src="https://github.com/user-attachments/assets/a893c0dd-c221-4604-999d-a7f4a67d5e57" />
<td>
<img width="3490" height="2092" alt="Screenshot 2026-07-02 at 08-36-33 Newsletters tool" src="https://github.com/user-attachments/assets/e74252b2-2edb-4315-b4a6-5a8e9cd3f0ee" />
<tr>
<td> Article Rendering - Headings/Text
<td>
<img width="3490" height="2092" alt="Screenshot 2026-07-02 at 08-38-43 Newsletters tool" src="https://github.com/user-attachments/assets/d3dc03de-6bbc-44e2-afed-d329c5ea504a" />
<td>
<img width="3490" height="2092" alt="Screenshot 2026-07-02 at 08-38-47 Newsletters tool" src="https://github.com/user-attachments/assets/920f799e-0184-4eef-860c-616cf2a50b1c" />
<tr>
<td> Launch Wizard - Headings/Text
<td>
<img width="3490" height="2010" alt="Screenshot 2026-07-02 at 08-39-36 Newsletters tool" src="https://github.com/user-attachments/assets/e9c25713-83a5-4f7a-8a7d-e996f988a57e" />
<td>
<img width="3490" height="2092" alt="Screenshot 2026-07-02 at 08-39-41 Newsletters tool" src="https://github.com/user-attachments/assets/3373d425-935c-44ba-b6f8-770a76be84a7" />
</table>


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216165837061490